### PR TITLE
fix(layers-panel): match button style with menu

### DIFF
--- a/src/components/layers-panel/LayersPanel.tsx
+++ b/src/components/layers-panel/LayersPanel.tsx
@@ -169,13 +169,13 @@ export const LayersPanel: React.FC = () => {
       </div>
       {selectedPathIds.length > 0 && (
         <div className="flex-shrink-0 pt-2 mt-2 border-t border-[var(--ui-separator)]">
-           <button 
-             onClick={() => handleDeletePaths(selectedPathIds)} 
-             className="w-full flex items-center justify-center gap-2 p-2 rounded-md text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)]"
-           >
-             <div className="w-5 h-5 flex-shrink-0 text-[var(--text-secondary)]">{ICONS.TRASH}</div>
-             删除选中
-           </button>
+          <button
+            onClick={() => handleDeletePaths(selectedPathIds)}
+            className="w-full flex items-center gap-3 p-2 rounded-md text-left text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none focus-visible:ring-2 ring-[var(--accent-primary)]"
+          >
+            <div className="w-4 h-4 flex-shrink-0 text-[var(--text-secondary)]">{ICONS.TRASH}</div>
+            删除选中
+          </button>
         </div>
       )}
       {paths.length > 0 && (
@@ -187,9 +187,9 @@ export const LayersPanel: React.FC = () => {
               () => { setPaths([]); setSelectedPathIds([]); },
               '清空'
             )}
-            className="w-full flex items-center justify-center gap-2 p-2 rounded-md text-sm text-[var(--danger-text)] hover:bg-[var(--danger-bg)]"
+            className="w-full flex items-center gap-3 p-2 rounded-md text-left text-sm text-[var(--danger-text)] hover:bg-[var(--danger-bg)] focus:bg-[var(--danger-bg)] transition-colors focus:outline-none focus-visible:ring-2 ring-[var(--accent-primary)]"
           >
-            <div className="w-5 h-5 flex-shrink-0 text-[var(--text-secondary)]">{ICONS.CLEAR}</div>
+            <div className="w-4 h-4 flex-shrink-0 text-[var(--text-secondary)]">{ICONS.CLEAR}</div>
             清空画布
           </button>
         </div>


### PR DESCRIPTION
## Summary
- make layer panel action buttons match menu styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf8418e48323b559e63483fda70a