### PR TITLE
feat: support pasting Excalidraw data

### DIFF
--- a/src/hooks/actions/useClipboardActions.ts
+++ b/src/hooks/actions/useClipboardActions.ts
@@ -3,9 +3,10 @@
  */
 
 import { useCallback } from 'react';
-import type { AnyPath, WhiteboardData, Point, Tool } from '../../types';
-import { getPathsBoundingBox, movePath } from '../../lib/drawing';
-import { importSvg } from '../../lib/import';
+import type { AnyPath, WhiteboardData, Point, Tool } from '@/types';
+import { getPathsBoundingBox, movePath } from '@/lib/drawing';
+import { importSvg } from '@/lib/import';
+import { importExcalidraw } from '@/lib/importExcalidraw';
 import type { AppActionsProps } from '../useAppActions';
 
 /**
@@ -73,17 +74,22 @@ export const useClipboardActions = ({
     } catch (err) {}
 
     if (pathsToPaste.length === 0) {
-        const trimmedText = text.trim();
-        if (trimmedText.startsWith('<svg') && trimmedText.includes('</svg')) {
-            try {
-                const svgPaths = await importSvg(trimmedText);
-                if (svgPaths.length > 0) pathsToPaste = svgPaths;
-            } catch (err) {
-                console.error("Failed to parse pasted SVG:", err);
-                alert("粘贴的内容看起来是 SVG，但无法解析。");
-                return;
-            }
+      const excalidrawPaths = importExcalidraw(text);
+      if (excalidrawPaths.length > 0) pathsToPaste = excalidrawPaths;
+    }
+
+    if (pathsToPaste.length === 0) {
+      const trimmedText = text.trim();
+      if (trimmedText.startsWith('<svg') && trimmedText.includes('</svg')) {
+        try {
+          const svgPaths = await importSvg(trimmedText);
+          if (svgPaths.length > 0) pathsToPaste = svgPaths;
+        } catch (err) {
+          console.error('Failed to parse pasted SVG:', err);
+          alert('粘贴的内容看起来是 SVG，但无法解析。');
+          return;
         }
+      }
     }
     
     if (pathsToPaste.length === 0) return;

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -324,12 +324,35 @@ const useGlobalEventHandlers = () => {
                     };
                     reader.readAsDataURL(blob);
                     // Image found and handled, so we can exit.
-                    return; 
+                    return;
+                }
+            }
+
+            // Priority 2: Check for Excalidraw JSON in clipboard items.
+            for (const item of items) {
+                if (item.type === 'application/vnd.excalidraw+json') {
+                    event.preventDefault();
+                    item.getAsString((str) => {
+                        let pasteAt: Point | undefined;
+                        if (lastPointerPosition) {
+                            pasteAt = lastPointerPosition;
+                        } else {
+                            const svg = document.querySelector('svg');
+                            if (svg) {
+                                pasteAt = getPointerPosition(
+                                    { clientX: window.innerWidth / 2, clientY: window.innerHeight / 2 },
+                                    svg
+                                );
+                            }
+                        }
+                        void handlePaste({ pasteAt, clipboardText: str });
+                    });
+                    return;
                 }
             }
         }
-        
-        // Priority 2: If no image was found, check for our shape data.
+
+        // Priority 3: If no image or Excalidraw data was found, check for our shape data.
         const target = event.target as HTMLElement;
         const isInput = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
 

--- a/src/lib/importExcalidraw.ts
+++ b/src/lib/importExcalidraw.ts
@@ -1,0 +1,109 @@
+/**
+ * Imports Excalidraw JSON and converts it into internal AnyPath objects.
+ */
+
+import type { AnyPath, RectangleData, EllipseData, VectorPathData, Anchor, TextData } from '@/types';
+import {
+  DEFAULT_ROUGHNESS,
+  DEFAULT_BOWING,
+  DEFAULT_FILL_WEIGHT,
+  DEFAULT_HACHURE_ANGLE,
+  DEFAULT_HACHURE_GAP,
+  DEFAULT_CURVE_TIGHTNESS,
+  DEFAULT_CURVE_STEP_COUNT,
+} from '@/constants';
+
+interface ExcalidrawElement {
+  type: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  angle?: number;
+  strokeColor?: string;
+  backgroundColor?: string;
+  strokeWidth?: number;
+  roughness?: number;
+  opacity?: number;
+  points?: [number, number][];
+  text?: string;
+  fontSize?: number;
+  fontFamily?: string | number;
+  textAlign?: 'left' | 'center' | 'right';
+}
+
+const sharedProps = (el: ExcalidrawElement) => ({
+  id: `${Date.now()}-${Math.random()}`,
+  color: el.strokeColor ?? '#000000',
+  fill: el.backgroundColor ?? 'transparent',
+  strokeWidth: el.strokeWidth ?? 1,
+  fillStyle: 'solid',
+  roughness: el.roughness ?? DEFAULT_ROUGHNESS,
+  bowing: DEFAULT_BOWING,
+  fillWeight: DEFAULT_FILL_WEIGHT,
+  hachureAngle: DEFAULT_HACHURE_ANGLE,
+  hachureGap: DEFAULT_HACHURE_GAP,
+  curveTightness: DEFAULT_CURVE_TIGHTNESS,
+  curveStepCount: DEFAULT_CURVE_STEP_COUNT,
+  opacity: el.opacity ?? 1,
+  rotation: el.angle ?? 0,
+});
+
+export function importExcalidraw(json: string): AnyPath[] {
+  let data: any;
+  try { data = JSON.parse(json); } catch { return []; }
+  const elements: ExcalidrawElement[] = data?.elements;
+  if (!Array.isArray(elements)) return [];
+
+  const paths: AnyPath[] = [];
+
+  for (const el of elements) {
+    if (el.type === 'rectangle') {
+      paths.push({
+        ...sharedProps(el),
+        tool: 'rectangle',
+        x: el.x,
+        y: el.y,
+        width: el.width,
+        height: el.height,
+      } as RectangleData);
+    } else if (el.type === 'ellipse') {
+      paths.push({
+        ...sharedProps(el),
+        tool: 'ellipse',
+        x: el.x,
+        y: el.y,
+        width: el.width,
+        height: el.height,
+      } as EllipseData);
+    } else if (el.type === 'text' && el.text) {
+      paths.push({
+        ...sharedProps(el),
+        tool: 'text',
+        text: el.text,
+        fontSize: el.fontSize ?? 16,
+        fontFamily: typeof el.fontFamily === 'string' ? el.fontFamily : 'Virgil',
+        textAlign: el.textAlign ?? 'left',
+        x: el.x,
+        y: el.y,
+        width: el.width ?? 0,
+        height: el.height ?? el.fontSize ?? 16,
+      } as TextData);
+    } else if (['line', 'arrow', 'draw', 'freedraw'].includes(el.type) && Array.isArray(el.points)) {
+      const anchors: Anchor[] = el.points.map((p) => {
+        const x = el.x + p[0];
+        const y = el.y + p[1];
+        return { point: { x, y }, handleIn: { x, y }, handleOut: { x, y } };
+      });
+      paths.push({
+        ...sharedProps(el),
+        tool: 'pen',
+        anchors,
+        isClosed: false,
+      } as VectorPathData);
+    }
+  }
+
+  return paths;
+}
+


### PR DESCRIPTION
## Summary
- parse Excalidraw JSON into internal shapes
- use Excalidraw importer on clipboard paste
- detect Excalidraw MIME type during global paste

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2bfd2c9a88323ba1936864e1363fc