### PR TITLE
fix: keep pasted PNG size

### DIFF
--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -291,14 +291,8 @@ const useGlobalEventHandlers = () => {
                                 );
                             }
 
-                            const MAX_DIM = 400;
                             let width = img.width;
                             let height = img.height;
-                            if (width > MAX_DIM || height > MAX_DIM) {
-                                const ratio = Math.min(MAX_DIM / width, MAX_DIM / height);
-                                width *= ratio;
-                                height *= ratio;
-                            }
 
                             const newImage: ImageData = {
                                 id: Date.now().toString(),


### PR DESCRIPTION
## Summary
- prevent image paste handler from scaling large PNGs down to 400px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2dafb3ba483239adaf62907315dc8