### PR TITLE
fix: finalize image crop handling

### DIFF
--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -5,7 +5,7 @@
 
 import React from 'react';
 import type { AnyPath, VectorPathData, RectangleData, EllipseData, Point, DragState, Tool, SelectionMode, ResizeHandlePosition, ImageData, PolygonData, GroupData, ArcData, TextData, FrameData, BBox } from '../../types';
-import { getPathBoundingBox, getPathsBoundingBox, dist, getPathD, rotatePoint, calculateArcPathD } from '../../lib/drawing';
+import { getPathBoundingBox, getPathsBoundingBox, dist, getPathD, rotatePoint, calculateArcPathD, rotateResizeHandle } from '../../lib/drawing';
 
 
 const VectorPathControls: React.FC<{ data: VectorPathData; scale: number; dragState: DragState | null; hoveredPoint: Point | null; }> = React.memo(({ data, scale, dragState, hoveredPoint }) => {
@@ -197,24 +197,41 @@ const CropControls: React.FC<{
     const o = croppingState.originalPath;
     const c = currentCropRect;
 
+    const rotation = o.rotation ?? 0;
     const rotationCenter = { x: o.x + o.width / 2, y: o.y + o.height / 2 };
-    const rotationAngle = (o.rotation ?? 0) * (180 / Math.PI);
+    const rotationAngle = rotation * (180 / Math.PI);
     const transform = `rotate(${rotationAngle} ${rotationCenter.x} ${rotationCenter.y})`;
 
     const handleSize = 10 / scale;
     const halfHandleSize = handleSize / 2;
     const accent = 'var(--accent-primary)';
-    
-    const handles: { pos: Point, name: ResizeHandlePosition, cursor: string }[] = [
-        { pos: { x: c.x, y: c.y }, name: 'top-left', cursor: 'nwse-resize' },
-        { pos: { x: c.x + c.width, y: c.y }, name: 'top-right', cursor: 'nesw-resize' },
-        { pos: { x: c.x, y: c.y + c.height }, name: 'bottom-left', cursor: 'nesw-resize' },
-        { pos: { x: c.x + c.width, y: c.y + c.height }, name: 'bottom-right', cursor: 'nwse-resize' },
-        { pos: { x: c.x + c.width / 2, y: c.y }, name: 'top', cursor: 'ns-resize' },
-        { pos: { x: c.x + c.width, y: c.y + c.height / 2 }, name: 'right', cursor: 'ew-resize' },
-        { pos: { x: c.x + c.width / 2, y: c.y + c.height }, name: 'bottom', cursor: 'ns-resize' },
-        { pos: { x: c.x, y: c.y + c.height / 2 }, name: 'left', cursor: 'ew-resize' },
+
+    const baseHandles: { pos: Point; name: ResizeHandlePosition }[] = [
+        { pos: { x: c.x, y: c.y }, name: 'top-left' },
+        { pos: { x: c.x + c.width, y: c.y }, name: 'top-right' },
+        { pos: { x: c.x, y: c.y + c.height }, name: 'bottom-left' },
+        { pos: { x: c.x + c.width, y: c.y + c.height }, name: 'bottom-right' },
+        { pos: { x: c.x + c.width / 2, y: c.y }, name: 'top' },
+        { pos: { x: c.x + c.width, y: c.y + c.height / 2 }, name: 'right' },
+        { pos: { x: c.x + c.width / 2, y: c.y + c.height }, name: 'bottom' },
+        { pos: { x: c.x, y: c.y + c.height / 2 }, name: 'left' },
     ];
+
+    const cursorMap: Record<ResizeHandlePosition, string> = {
+        'top-left': 'nwse-resize',
+        'top-right': 'nesw-resize',
+        'bottom-left': 'nesw-resize',
+        'bottom-right': 'nwse-resize',
+        'top': 'ns-resize',
+        'bottom': 'ns-resize',
+        'left': 'ew-resize',
+        'right': 'ew-resize',
+    };
+
+    const handles = baseHandles.map(h => {
+        const screenName = rotateResizeHandle(h.name, rotation);
+        return { pos: h.pos, handle: h.name, cursor: cursorMap[screenName] };
+    });
 
     const strokeWidth = 1 / scale;
     const cornerStrokeWidth = 3 / scale;
@@ -233,8 +250,8 @@ const CropControls: React.FC<{
             <path d={`M ${c.x + cornerLineLength} ${c.y + c.height} L ${c.x} ${c.y + c.height} L ${c.x} ${c.y + c.height - cornerLineLength}`} fill="none" stroke={accent} strokeWidth={cornerStrokeWidth} strokeLinecap="round" strokeLinejoin="round" />
             <path d={`M ${c.x + c.width - cornerLineLength} ${c.y + c.height} L ${c.x + c.width} ${c.y + c.height} L ${c.x + c.width} ${c.y + c.height - cornerLineLength}`} fill="none" stroke={accent} strokeWidth={cornerStrokeWidth} strokeLinecap="round" strokeLinejoin="round" />
             
-            {handles.map(({ pos, name, cursor }) => (
-                <rect key={name} x={pos.x - halfHandleSize} y={pos.y - halfHandleSize} width={handleSize} height={handleSize} fill="transparent" data-handle={name} data-path-id={o.id} style={{ cursor }} className="pointer-events-all" />
+            {handles.map(({ pos, handle, cursor }) => (
+                <rect key={handle} x={pos.x - halfHandleSize} y={pos.y - halfHandleSize} width={handleSize} height={handleSize} fill="transparent" data-handle={handle} data-path-id={o.id} style={{ cursor }} className="pointer-events-all" />
             ))}
         </g>
     );

--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -4,7 +4,7 @@
 // FIX: Removed 'React' from type import as it's not used and can cause errors.
 import type { MutableRefObject } from 'react';
 import type { Point, DragState, AnyPath, VectorPathData, ResizeHandlePosition, ImageData, BBox, GroupData, ArcData } from '../../types';
-import { updatePathAnchors, insertAnchorOnCurve, getSqDistToSegment, getPathsBoundingBox, dist, sampleCubicBezier } from '../../lib/drawing';
+import { updatePathAnchors, insertAnchorOnCurve, getSqDistToSegment, getPathsBoundingBox, dist, sampleCubicBezier, rotateResizeHandle } from '../../lib/drawing';
 import { isPointHittingPath, findDeepestHitPath } from '../../lib/hit-testing';
 import { recursivelyUpdatePaths } from './utils';
 
@@ -158,7 +158,7 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
             setDragState({
                 type: 'crop',
                 pathId,
-                handle,
+                handle: handle as ResizeHandlePosition,
                 initialCropRect: currentCropRect,
                 originalImage: croppingState.originalPath,
                 initialPointerPos: point,

--- a/src/hooks/selection-logic/pointerUp.ts
+++ b/src/hooks/selection-logic/pointerUp.ts
@@ -3,7 +3,7 @@
  */
 // FIX: Removed 'React' from type import as it's not used and can cause errors.
 import type { MutableRefObject } from 'react';
-import type { Point, DragState, AnyPath } from '../../types';
+import type { Point, DragState, AnyPath, BBox } from '../../types';
 import { getMarqueeRect } from '../../lib/drawing';
 import { isPathIntersectingMarquee, isPathIntersectingLasso } from '../../lib/hit-testing';
 
@@ -17,6 +17,7 @@ interface HandlePointerUpProps {
   setLassoPath: (path: Point[] | null) => void;
   pathState: any;
   isClosingPath: MutableRefObject<{ pathId: string; anchorIndex: number } | null>;
+  pushCropHistory?: (rect: BBox) => void;
 }
 
 /**
@@ -24,7 +25,7 @@ interface HandlePointerUpProps {
  * @param props - 包含事件对象、状态和设置器的对象。
  */
 export const handlePointerUpLogic = (props: HandlePointerUpProps) => {
-    const { e, dragState, setDragState, marquee, setMarquee, lassoPath, setLassoPath, pathState, isClosingPath } = props;
+    const { e, dragState, setDragState, marquee, setMarquee, lassoPath, setLassoPath, pathState, isClosingPath, pushCropHistory } = props;
     const { paths, setPaths, setSelectedPathIds, endCoalescing } = pathState;
 
     if (dragState) {
@@ -38,6 +39,9 @@ export const handlePointerUpLogic = (props: HandlePointerUpProps) => {
                 } return p;
             }));
             isClosingPath.current = null;
+        }
+        if (dragState.type === 'crop' && pushCropHistory) {
+            pushCropHistory(dragState.initialCropRect);
         }
         endCoalescing();
         setDragState(null);

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -17,7 +17,7 @@ import { getLocalStorageItem } from '../lib/utils';
 import * as idb from '../lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, TextData, PngExportOptions, ImageData, BBox, Frame } from '../types';
-import { measureText } from '../lib/drawing';
+import { measureText, rotatePoint } from '@/lib/drawing';
 
 type ConfirmationDialogState = {
   isOpen: boolean;
@@ -248,8 +248,78 @@ export const useAppStore = () => {
   }, [activePathState]);
   const handleTextEditCommit = useCallback(() => { pathState.endCoalescing(); setEditingTextPathId(null); }, [pathState, setEditingTextPathId]);
   
-  const confirmCrop = useCallback(() => { /* ... crop logic ... */ }, [appState.croppingState, appState.currentCropRect, pathState, setCroppingState, setCurrentCropRect]);
-  const cancelCrop = useCallback(() => { setCroppingState(null); setCurrentCropRect(null); }, [setCroppingState, setCurrentCropRect]);
+  const confirmCrop = useCallback(() => {
+    if (!appState.croppingState || !appState.currentCropRect) return;
+    const { pathId, originalPath } = appState.croppingState;
+    const cropRect = appState.currentCropRect;
+
+    const performCrop = async () => {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.src = originalPath.src;
+      await new Promise<void>((resolve, reject) => {
+        img.onload = () => resolve();
+        img.onerror = err => reject(err);
+      });
+
+      const rotation = originalPath.rotation ?? 0;
+      const rotationCenter = {
+        x: originalPath.x + originalPath.width / 2,
+        y: originalPath.y + originalPath.height / 2,
+      };
+      const corners = [
+        { x: cropRect.x, y: cropRect.y },
+        { x: cropRect.x + cropRect.width, y: cropRect.y },
+        { x: cropRect.x + cropRect.width, y: cropRect.y + cropRect.height },
+        { x: cropRect.x, y: cropRect.y + cropRect.height },
+      ].map(p => rotatePoint(p, rotationCenter, -rotation));
+      const minX = Math.min(...corners.map(p => p.x));
+      const maxX = Math.max(...corners.map(p => p.x));
+      const minY = Math.min(...corners.map(p => p.y));
+      const maxY = Math.max(...corners.map(p => p.y));
+
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(maxX - minX);
+      canvas.height = Math.round(maxY - minY);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const sourceX = minX - originalPath.x;
+      const sourceY = minY - originalPath.y;
+
+      ctx.drawImage(
+        img,
+        sourceX,
+        sourceY,
+        canvas.width,
+        canvas.height,
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      );
+
+      const newSrc = canvas.toDataURL();
+
+      pathState.setPaths(prev => prev.map(p =>
+        p.id === pathId
+          ? { ...(p as ImageData), src: newSrc, x: cropRect.x, y: cropRect.y, width: cropRect.width, height: cropRect.height, rotation }
+          : p
+      ));
+
+      setCroppingState(null);
+      setCurrentCropRect(null);
+      pathState.endCoalescing();
+    };
+
+    void performCrop();
+  }, [appState.croppingState, appState.currentCropRect, pathState, setCroppingState, setCurrentCropRect]);
+
+  const cancelCrop = useCallback(() => {
+    setCroppingState(null);
+    setCurrentCropRect(null);
+    pathState.endCoalescing();
+  }, [setCroppingState, setCurrentCropRect, pathState]);
 
   const onDoubleClick = useCallback((path: AnyPath) => {
       if (toolbarState.selectionMode !== 'move') return;

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -17,7 +17,7 @@ import { getLocalStorageItem } from '../lib/utils';
 import * as idb from '../lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, TextData, PngExportOptions, ImageData, BBox, Frame } from '../types';
-import { measureText, rotatePoint } from '@/lib/drawing';
+import { measureText } from '@/lib/drawing';
 
 type ConfirmationDialogState = {
   isOpen: boolean;
@@ -262,30 +262,14 @@ export const useAppStore = () => {
         img.onerror = err => reject(err);
       });
 
-      const rotation = originalPath.rotation ?? 0;
-      const rotationCenter = {
-        x: originalPath.x + originalPath.width / 2,
-        y: originalPath.y + originalPath.height / 2,
-      };
-      const corners = [
-        { x: cropRect.x, y: cropRect.y },
-        { x: cropRect.x + cropRect.width, y: cropRect.y },
-        { x: cropRect.x + cropRect.width, y: cropRect.y + cropRect.height },
-        { x: cropRect.x, y: cropRect.y + cropRect.height },
-      ].map(p => rotatePoint(p, rotationCenter, -rotation));
-      const minX = Math.min(...corners.map(p => p.x));
-      const maxX = Math.max(...corners.map(p => p.x));
-      const minY = Math.min(...corners.map(p => p.y));
-      const maxY = Math.max(...corners.map(p => p.y));
-
       const canvas = document.createElement('canvas');
-      canvas.width = Math.round(maxX - minX);
-      canvas.height = Math.round(maxY - minY);
+      canvas.width = Math.round(cropRect.width);
+      canvas.height = Math.round(cropRect.height);
       const ctx = canvas.getContext('2d');
       if (!ctx) return;
 
-      const sourceX = minX - originalPath.x;
-      const sourceY = minY - originalPath.y;
+      const sourceX = cropRect.x - originalPath.x;
+      const sourceY = cropRect.y - originalPath.y;
 
       ctx.drawImage(
         img,
@@ -300,6 +284,7 @@ export const useAppStore = () => {
       );
 
       const newSrc = canvas.toDataURL();
+      const rotation = originalPath.rotation ?? 0;
 
       pathState.setPaths(prev => prev.map(p =>
         p.id === pathId

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -20,6 +20,7 @@ interface SelectionInteractionProps {
   croppingState: { pathId: string, originalPath: ImageData } | null;
   currentCropRect: BBox | null;
   setCurrentCropRect: React.Dispatch<React.SetStateAction<BBox | null>>;
+  pushCropHistory: (rect: BBox) => void;
 }
 
 /**
@@ -37,6 +38,7 @@ export const useSelection = ({
   croppingState,
   currentCropRect,
   setCurrentCropRect,
+  pushCropHistory,
 }: SelectionInteractionProps) => {
   const [dragState, setDragState] = useState<DragState>(null);
   const [marquee, setMarquee] = useState<{ start: Point; end: Point } | null>(null);
@@ -119,7 +121,7 @@ export const useSelection = ({
     
     handlePointerUpLogic({
       e, dragState, setDragState, marquee, setMarquee, lassoPath, setLassoPath,
-      pathState, isClosingPath,
+      pathState, isClosingPath, pushCropHistory,
     });
     
     setIsHoveringMovable(false);

--- a/src/lib/drawing/transform.ts
+++ b/src/lib/drawing/transform.ts
@@ -121,6 +121,43 @@ export function resizePath(
     return result;
 }
 
+/**
+ * 根据旋转角度转换尺寸调整手柄的位置。
+ * @param handle 原始手柄位置（未旋转）。
+ * @param angle 旋转角度（弧度，顺时针为正）。
+ * @returns 旋转后对应的手柄位置。
+ */
+export function rotateResizeHandle(handle: ResizeHandlePosition, angle: number): ResizeHandlePosition {
+    const vectors: Record<ResizeHandlePosition, Point> = {
+        'top-left': { x: -1, y: -1 },
+        'top': { x: 0, y: -1 },
+        'top-right': { x: 1, y: -1 },
+        'right': { x: 1, y: 0 },
+        'bottom-right': { x: 1, y: 1 },
+        'bottom': { x: 0, y: 1 },
+        'bottom-left': { x: -1, y: 1 },
+        'left': { x: -1, y: 0 },
+    };
+
+    const v = vectors[handle];
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const rx = v.x * cos - v.y * sin;
+    const ry = v.x * sin + v.y * cos;
+    const sx = Math.abs(rx) < 1e-8 ? 0 : Math.sign(rx);
+    const sy = Math.abs(ry) < 1e-8 ? 0 : Math.sign(ry);
+
+    if (sx === 0 && sy === -1) return 'top';
+    if (sx === 1 && sy === -1) return 'top-right';
+    if (sx === 1 && sy === 0) return 'right';
+    if (sx === 1 && sy === 1) return 'bottom-right';
+    if (sx === 0 && sy === 1) return 'bottom';
+    if (sx === -1 && sy === 1) return 'bottom-left';
+    if (sx === -1 && sy === 0) return 'left';
+    return 'top-left';
+}
+
+
 
 /**
  * 变换裁剪矩形。


### PR DESCRIPTION
## Summary
- rotate crop handles for display while keeping underlying handle anchors stable
- preserve original rotation when confirming crop
- stop rotating crop handle names during drag setup to keep anchors diagonal
- offset crop source coordinates by the image's original position so cropped images remain aligned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3dce0eed48323836f5da71d23dcfe