### PR TITLE
refactor(toolbars): reuse PanelButton for icon buttons

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -3,36 +3,40 @@
  * 当用户进入裁剪模式时，此工具栏会显示，提供确认或取消裁剪的选项。
  */
 import React from 'react';
-import { ICONS } from '../constants';
-import { useAppContext } from '../context/AppContext';
+import PanelButton from '@/components/PanelButton';
+import { ICONS } from '@/constants';
+import { useAppContext } from '@/context/AppContext';
 
+/**
+ * 裁剪模式下显示的工具栏组件，提供确认与取消裁剪操作。
+ */
 export const CropToolbar: React.FC = () => {
   const { confirmCrop, cancelCrop, isTimelineCollapsed } = useAppContext();
 
   return (
-    <div 
+    <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)] transition-all duration-300 ease-in-out"
       style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
     >
-      <button
+      <PanelButton
         type="button"
         title="取消裁剪"
         onClick={cancelCrop}
-        className="p-2 rounded-lg flex items-center justify-center w-20 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--danger-text)] hover:bg-[var(--danger-bg)]"
+        className="!w-auto px-3 gap-1 text-[var(--danger-text)] hover:bg-[var(--danger-bg)]"
       >
-        {React.cloneElement(ICONS.X, { className: "h-5 w-5 mr-1" })}
-        取消
-      </button>
+        {React.cloneElement(ICONS.X, { className: 'h-5 w-5' })}
+        <span>取消</span>
+      </PanelButton>
       <div className="h-6 w-px bg-[var(--ui-separator)] mx-1" />
-      <button
+      <PanelButton
         type="button"
         title="确认裁剪"
         onClick={confirmCrop}
-        className="p-2 rounded-lg flex items-center justify-center w-20 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 bg-[var(--accent-bg)] text-[var(--accent-primary)]"
+        className="!w-auto px-3 gap-1 bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:bg-[var(--accent-bg)] hover:opacity-90"
       >
-        {React.cloneElement(ICONS.CHECK, { className: "h-5 w-5 mr-1" })}
-        确认
-      </button>
+        {React.cloneElement(ICONS.CHECK, { className: 'h-5 w-5' })}
+        <span>确认</span>
+      </PanelButton>
     </div>
   );
 };

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -5,6 +5,7 @@
 
 import React, { Fragment, useState } from 'react';
 import { Popover, Transition, RadioGroup } from '@headlessui/react';
+import PanelButton from '@/components/PanelButton';
 import { ICONS } from '../constants';
 import type { SelectionMode, Alignment, DistributeMode } from '../types';
 import { Slider } from './side-toolbar';
@@ -93,26 +94,27 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
   return (
     <div className="flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)]">
       {MODES.map((mode) => (
-        <button
+        <PanelButton
           key={mode.name}
           type="button"
           title={mode.title}
           onClick={() => setSelectionMode(mode.name as SelectionMode)}
-          className={`p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 ${
+          className={
             selectionMode === mode.name
               ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
               : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
-          }`}
+          }
         >
           {mode.icon}
-        </button>
+        </PanelButton>
       ))}
 
       {isSimplifiable && (
           <Popover className="relative">
             <Popover.Button
+              as={PanelButton}
               title="简化路径"
-              className="p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+              className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
             >
               {ICONS.SIMPLIFY_PATH}
             </Popover.Button>
@@ -136,8 +138,9 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
       {canAlignOrDistribute && (
           <Popover className="relative">
              <Popover.Button
+                  as={PanelButton}
                   title="对齐与分布"
-                  className="p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+                  className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
                 >
                   {ICONS.ALIGN_DISTRIBUTE}
             </Popover.Button>
@@ -148,7 +151,15 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
                       <label className="text-sm font-semibold text-[var(--text-primary)]">对齐</label>
                       <div className="grid grid-cols-6 gap-1 mt-2">
                         {ALIGN_BUTTONS.map(btn => (
-                           <button key={btn.name} onClick={() => onAlign(btn.name as Alignment)} title={btn.title} disabled={!canAlignOrDistribute} className="p-2 rounded-lg flex items-center justify-center text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed">{btn.icon}</button>
+                           <PanelButton
+                             key={btn.name}
+                             onClick={() => onAlign(btn.name as Alignment)}
+                             title={btn.title}
+                             disabled={!canAlignOrDistribute}
+                             className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] disabled:opacity-50 disabled:cursor-not-allowed"
+                           >
+                             {btn.icon}
+                           </PanelButton>
                         ))}
                       </div>
                     </div>
@@ -196,8 +207,9 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
       {canPerformBooleanOrMask && (
         <Popover className="relative">
             <Popover.Button
+                as={PanelButton}
                 title="布尔运算"
-                className="p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+                className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
             >
                 {ICONS.BOOLEAN_UNION}
             </Popover.Button>
@@ -206,14 +218,14 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
                     {({ close }) => (
                         <div className="flex items-center gap-1">
                             {BOOLEAN_BUTTONS.map(btn => (
-                                <button
+                                <PanelButton
                                     key={btn.name}
                                     onClick={() => { onBooleanOperation(btn.name); close(); }}
                                     title={btn.title}
-                                    className="p-2 rounded-lg flex items-center justify-center text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+                                    className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
                                 >
                                     {btn.icon}
-                                </button>
+                                </PanelButton>
                             ))}
                         </div>
                     )}
@@ -223,13 +235,13 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
       )}
 
       {canPerformBooleanOrMask && (
-        <button
+        <PanelButton
           onClick={onMask}
           title="使用顶层对象作为蒙版"
-          className="p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+          className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
         >
           {ICONS.MASK}
-        </button>
+        </PanelButton>
       )}
 
     </div>

--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -7,6 +7,7 @@
 import React, { useMemo } from 'react';
 import type { Tool, AnyPath, VectorPathData, TextData } from '../types';
 import { ICONS } from '../constants';
+import PanelButton from '@/components/PanelButton';
 
 import { NumericInput, ColorControl, FillStyleControl, EndpointPopover, DashControl, StylePropertiesPopover, TextProperties, EffectsPopover } from './side-toolbar';
 
@@ -252,17 +253,13 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
       <div className="h-px w-full bg-[var(--ui-separator)] my-1"></div>
       
       <div className="flex flex-col items-center w-14" title="样式库">
-        <button 
-          onClick={e => onToggleStyleLibrary(e)}
-          className={`p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors ring-1 ring-inset ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] ${
-            isStyleLibraryOpen
-              ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
-              : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
-          }`}
+        <PanelButton
+          onClick={onToggleStyleLibrary}
+          className={`${isStyleLibraryOpen ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)]'}`}
           title="样式库"
         >
           {ICONS.STYLE_LIBRARY}
-        </button>
+        </PanelButton>
       </div>
     </div>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -5,6 +5,7 @@
 
 import React, { Fragment } from 'react';
 import { Popover, Transition, Switch } from '@headlessui/react';
+import PanelButton from '@/components/PanelButton';
 import { ICONS } from '../constants';
 import type { Tool } from '../types';
 
@@ -54,27 +55,28 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   return (
     <div className="flex flex-wrap items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)]">
       {TOOLS.map((t) => (
-        <button
+        <PanelButton
           key={t.name}
           type="button"
           title={t.title}
           onClick={() => setTool(t.name)}
-          className={`p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 ${
+          className={
             tool === t.name
               ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
               : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
-          }`}
+          }
         >
           {t.icon}
-        </button>
+        </PanelButton>
       ))}
 
       <div className="h-6 w-px bg-[var(--ui-separator)] mx-1" />
 
       <Popover className="relative">
         <Popover.Button
+          as={PanelButton}
           title="网格设置"
-          className="p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+          className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
         >
           {ICONS.GRID}
         </Popover.Button>

--- a/src/components/TraceImagePopover.tsx
+++ b/src/components/TraceImagePopover.tsx
@@ -3,6 +3,7 @@
  */
 import React, { Fragment, useState } from 'react';
 import { Popover, Transition } from '@headlessui/react';
+import PanelButton from '@/components/PanelButton';
 import { ICONS } from '../constants';
 import { Slider } from './side-toolbar';
 import type { TraceOptions } from '../types';
@@ -31,8 +32,9 @@ export const TraceImagePopover: React.FC<TraceImagePopoverProps> = ({ onTrace })
       {({ close }) => (
         <>
           <Popover.Button
+            as={PanelButton}
             title="将图片转换为矢量图"
-            className="p-2 rounded-lg flex items-center justify-center w-10 h-10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+            className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
           >
             {ICONS.TRACE_IMAGE}
           </Popover.Button>
@@ -55,13 +57,13 @@ export const TraceImagePopover: React.FC<TraceImagePopoverProps> = ({ onTrace })
                 />
                 <Slider label="路径忽略" value={pathomit} setValue={setPathomit} min={0} max={50} step={1} onInteractionStart={() => {}} onInteractionEnd={() => {}}
                 />
-                <button
+                <PanelButton
                   type="button"
                   onClick={() => handleTrace(close)}
-                  className="w-full mt-2 h-9 rounded-md bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90"
+                  className="w-full mt-2 h-9 rounded-md bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90 border-0 shadow-none"
                 >
                   矢量化
-                </button>
+                </PanelButton>
               </div>
             </Popover.Panel>
           </Transition>


### PR DESCRIPTION
## Summary
- componentize toolbar buttons with PanelButton
- unify selection toolbar, trace popover, and crop toolbar buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c521d6defc8323b01edf13fa142c3d