### PR TITLE
fix(touch): disable mac gestures

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -176,7 +176,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   return (
     <div
       ref={containerRef}
-      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-contain"
+      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-none"
       onWheel={onWheel}
       style={{ cursor }}
       onContextMenu={onContextMenu}

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -156,7 +156,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
 
   return (
     <div
-      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-contain"
+      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-none"
       onWheel={onWheel}
       style={{ cursor }}
       onContextMenu={onContextMenu}

--- a/src/index.css
+++ b/src/index.css
@@ -82,6 +82,8 @@ html, body, #root {
   height: 100%;
   width: 100%;
   overflow-x: hidden;
+  touch-action: none; /* 禁用默认手势，防止回退或缩放 */
+  overscroll-behavior: none; /* 阻止浏览器回退手势 */
 }
 
 body {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,11 +9,11 @@ import App from './App';
 import './index.css';
 import { registerSW } from 'virtual:pwa-register';
 
-// 屏蔽全局浏览器捏合手势，避免页面缩放
+// 屏蔽全局浏览器捏合及双指滑动手势，避免页面缩放或回退
 const blockGesture = (e: Event) => e.preventDefault();
-document.addEventListener('gesturestart', blockGesture);
-document.addEventListener('gesturechange', blockGesture);
-document.addEventListener('gestureend', blockGesture);
+['gesturestart', 'gesturechange', 'gestureend', 'touchstart', 'touchmove'].forEach(evt => {
+  document.addEventListener(evt, blockGesture, { passive: false });
+});
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {


### PR DESCRIPTION
## Summary
- prevent two-finger navigation and pinch zoom using global CSS and event listeners
- tighten overscroll behavior on whiteboard containers to block back-swipe

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c628b6dad08323a218835e136e8cb0