### PR TITLE
fix(toolbar): remove focus outline from buttons

### DIFF
--- a/src/components/PanelButton.tsx
+++ b/src/components/PanelButton.tsx
@@ -10,7 +10,7 @@ export const PanelButton = React.forwardRef<HTMLButtonElement, PanelButtonProps>
       ref={ref}
       className={
         variant === 'panel'
-          ? `flex items-center justify-center h-10 w-10 rounded-lg bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-lg border border-[var(--ui-panel-border)] text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] ${className}`
+          ? `flex items-center justify-center h-10 w-10 rounded-lg bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-lg border border-[var(--ui-panel-border)] text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none ${className}`
           : `focus:outline-none ${className}`
       }
       {...props}

--- a/src/components/PanelButton.tsx
+++ b/src/components/PanelButton.tsx
@@ -10,7 +10,7 @@ export const PanelButton = React.forwardRef<HTMLButtonElement, PanelButtonProps>
       ref={ref}
       className={
         variant === 'panel'
-          ? `flex items-center justify-center h-10 w-10 rounded-lg bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-lg border border-[var(--ui-panel-border)] text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none ${className}`
+          ? `flex items-center justify-center h-10 w-10 rounded-lg bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-lg border-0 text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none ${className}`
           : `focus:outline-none ${className}`
       }
       {...props}

--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -266,8 +266,13 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
       
       <div className="flex flex-col items-center w-14" title="样式库">
         <PanelButton
+          variant="unstyled"
           onClick={onToggleStyleLibrary}
-          className={`${isStyleLibraryOpen ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)]'}`}
+          className={`flex items-center justify-center h-10 w-10 rounded-lg transition-colors ${
+            isStyleLibraryOpen
+              ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
+              : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
+          }`}
           title="样式库"
         >
           {ICONS.STYLE_LIBRARY}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -60,11 +60,12 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           type="button"
           title={t.title}
           onClick={() => setTool(t.name)}
-          className={
+          variant="unstyled"
+          className={`flex items-center justify-center h-10 w-10 rounded-lg transition-colors ${
             tool === t.name
               ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
               : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
-          }
+          }`}
         >
           {t.icon}
         </PanelButton>
@@ -75,8 +76,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       <Popover className="relative">
         <Popover.Button
           as={PanelButton}
+          variant="unstyled"
           title="网格设置"
-          className="text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+          className="flex items-center justify-center h-10 w-10 rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
         >
           {ICONS.GRID}
         </Popover.Button>

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -15,8 +15,9 @@ export const SideToolbarPanel: React.FC = () => {
     return (
         <>
             <PanelButton
+                variant="unstyled"
                 onClick={() => setIsSideToolbarCollapsed(prev => !prev)}
-                className="absolute top-4 right-4 z-30"
+                className="absolute top-4 right-4 z-30 flex items-center justify-center h-10 w-10 rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
                 title={isSideToolbarCollapsed ? '展开工具栏' : '折叠工具栏'}
             >
                 <div className={`transition-transform duration-300 ${isSideToolbarCollapsed ? '' : 'rotate-180'}`}>{ICONS.CHEVRON_LEFT}</div>

--- a/src/components/side-toolbar/ColorControl.tsx
+++ b/src/components/side-toolbar/ColorControl.tsx
@@ -42,7 +42,7 @@ export const ColorControl: React.FC<ColorControlProps> = React.memo(({
                         ref={ref as any}
                         onClick={onClick}
                         disabled={disabled}
-                        className="h-8 w-8 rounded-full ring-1 ring-inset ring-white/10 transition-transform transform hover:scale-110 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-offset-[var(--ui-panel-bg)] disabled:cursor-not-allowed disabled:hover:scale-100"
+                        className="h-8 w-8 rounded-full ring-1 ring-inset ring-white/10 transition-transform transform hover:scale-110 disabled:cursor-not-allowed disabled:hover:scale-100"
                         style={{
                             backgroundColor: color,
                             ...(isTransparent && checkerboardStyle)

--- a/src/components/side-toolbar/DashControl.tsx
+++ b/src/components/side-toolbar/DashControl.tsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
 import { ICONS } from '../../constants';
 import type { EndpointStyle } from '../../types';
+import PanelButton from '@/components/PanelButton';
 import { useDashGapInput } from '../../hooks/side-toolbar/useDashGapInput';
 import { SwitchControl } from './shared';
 
@@ -26,8 +27,10 @@ export const DashControl: React.FC<DashControlProps> = React.memo((props) => {
         <div className={`flex flex-col items-center w-14 transition-opacity ${strokeWidth === 0 ? 'opacity-50' : ''}`} title="虚线样式">
             <Popover className="relative">
                 <Popover.Button
+                    as={PanelButton}
+                    variant="unstyled"
                     disabled={strokeWidth === 0}
-                    className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-hover-bg)] ring-1 ring-inset ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed"
+                    className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] disabled:cursor-not-allowed"
                     title="虚线样式"
                 >
                     {ICONS.DASH_SETTINGS}

--- a/src/components/side-toolbar/EffectsPopover.tsx
+++ b/src/components/side-toolbar/EffectsPopover.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
 import { ICONS } from '../../constants';
+import PanelButton from '@/components/PanelButton';
 import { SwitchControl, Slider, PopoverColorControl } from './shared';
 
 // Define props interface
@@ -31,7 +32,12 @@ export const EffectsPopover: React.FC<EffectsPopoverProps> = React.memo((props) 
     return (
         <div className="flex flex-col items-center w-14" title="效果">
             <Popover className="relative">
-                <Popover.Button className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-hover-bg)] ring-1 ring-inset ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]" title="效果">
+                <Popover.Button
+                    as={PanelButton}
+                    variant="unstyled"
+                    className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+                    title="效果"
+                >
                     {ICONS.EFFECTS}
                 </Popover.Button>
                 <Transition as={Fragment} enter="transition ease-out duration-200" enterFrom="opacity-0 translate-y-1" enterTo="opacity-100 translate-y-0" leave="transition ease-in duration-150" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-1">

--- a/src/components/side-toolbar/FillStyleControl.tsx
+++ b/src/components/side-toolbar/FillStyleControl.tsx
@@ -15,7 +15,7 @@ export const FillStyleControl: React.FC<FillStyleControlProps> = React.memo(({ f
             <Popover.Button
               as={PanelButton}
               variant="unstyled"
-              className="h-9 w-9 p-1.5 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] ring-1 ring-inset ring-white/10 focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed"
+              className="h-9 w-9 p-1.5 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] disabled:cursor-not-allowed"
               title={`填充样式: ${FILL_STYLES.find(s => s.name === fillStyle)?.title}`}
               aria-label="选择填充样式"
             >

--- a/src/components/side-toolbar/ImageHsvPopover.tsx
+++ b/src/components/side-toolbar/ImageHsvPopover.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment, useState } from 'react';
 import { Popover, Transition } from '@headlessui/react';
 import { ICONS } from '@/constants';
+import PanelButton from '@/components/PanelButton';
 import type { HsvAdjustment } from '@/lib/image';
 
 interface ImageHsvPopoverProps {
@@ -56,7 +57,12 @@ export const ImageHsvPopover: React.FC<ImageHsvPopoverProps> = ({ onAdjust, begi
   return (
     <div className="flex flex-col items-center w-14" title="HSV 调整">
       <Popover className="relative">
-        <Popover.Button className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-hover-bg)] ring-1 ring-inset ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]" title="HSV 调整">
+        <Popover.Button
+          as={PanelButton}
+          variant="unstyled"
+          className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+          title="HSV 调整"
+        >
           {ICONS.HSV}
         </Popover.Button>
         <Transition as={Fragment} enter="transition ease-out duration-200" enterFrom="opacity-0 translate-y-1" enterTo="opacity-100 translate-y-0" leave="transition ease-in duration-150" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-1">

--- a/src/components/side-toolbar/StrokeStylePopover.tsx
+++ b/src/components/side-toolbar/StrokeStylePopover.tsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
 import { ICONS, ENDPOINT_STYLES } from '../../constants';
 import type { EndpointStyle } from '../../types';
+import PanelButton from '@/components/PanelButton';
 import { SwitchControl, Slider, EndpointGrid } from './shared';
 
 // Define props for the component
@@ -50,8 +51,10 @@ export const EndpointPopover: React.FC<EndpointPopoverProps> = React.memo((props
         <div className={`flex flex-col items-center w-14 transition-opacity ${strokeWidth === 0 ? 'opacity-50' : ''}`} title="端点样式">
             <Popover className="relative">
                 <Popover.Button
+                    as={PanelButton}
+                    variant="unstyled"
                     disabled={strokeWidth === 0}
-                    className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-hover-bg)] ring-1 ring-inset ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed"
+                    className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] disabled:cursor-not-allowed"
                     title="端点样式"
                 >
                     {ICONS.ENDPOINT_SETTINGS}

--- a/src/components/side-toolbar/StyleLibraryPopover.tsx
+++ b/src/components/side-toolbar/StyleLibraryPopover.tsx
@@ -281,7 +281,7 @@ export const StyleLibraryPopover: React.FC<StyleLibraryPanelProps> = ({
                         variant="unstyled"
                         onClick={onAddStyle}
                         disabled={!canAddStyle}
-                        className="w-full aspect-square rounded-md focus-visible:ring-2 ring-inset focus-visible:ring-[var(--accent-primary)] flex items-center justify-center bg-[var(--ui-element-bg)] hover:bg-[var(--ui-element-bg-active)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        className="w-full aspect-square rounded-md flex items-center justify-center bg-[var(--ui-element-bg)] hover:bg-[var(--ui-element-bg-active)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         title="从选区添加样式"
                     >
                         {ICONS.PLUS}
@@ -292,7 +292,7 @@ export const StyleLibraryPopover: React.FC<StyleLibraryPanelProps> = ({
                                 variant="unstyled"
                                 onClick={() => onApplyStyle(style)}
                                 title="应用样式"
-                                className="w-full aspect-square rounded-md focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] flex items-center justify-center"
+                                className="w-full aspect-square rounded-md flex items-center justify-center"
                               >
                                 <div className="w-full h-full transition-transform transform group-hover:scale-110">
                                     <StyleSwatch style={style} />
@@ -318,7 +318,7 @@ export const StyleLibraryPopover: React.FC<StyleLibraryPanelProps> = ({
                         variant="unstyled"
                         onClick={onAddMaterial}
                         disabled={!canAddMaterial}
-                        className="w-full aspect-square rounded-md focus-visible:ring-2 ring-inset focus-visible:ring-[var(--accent-primary)] flex items-center justify-center bg-[var(--ui-element-bg)] hover:bg-[var(--ui-element-bg-active)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        className="w-full aspect-square rounded-md flex items-center justify-center bg-[var(--ui-element-bg)] hover:bg-[var(--ui-element-bg-active)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         title="从选区添加素材"
                     >
                         {ICONS.PLUS}
@@ -330,7 +330,7 @@ export const StyleLibraryPopover: React.FC<StyleLibraryPanelProps> = ({
                                 draggable
                                 onDragStart={(e) => handleDragStartMaterial(e, material)}
                                 title="拖拽素材"
-                                className="w-full aspect-square rounded-md focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] flex items-center justify-center"
+                                className="w-full aspect-square rounded-md flex items-center justify-center"
                               >
                                 <div className="w-full h-full transition-transform transform group-hover:scale-110">
                                     <MaterialSwatch material={material} />

--- a/src/components/side-toolbar/StylePropertiesPopover.tsx
+++ b/src/components/side-toolbar/StylePropertiesPopover.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
 import { ICONS } from '../../constants';
+import PanelButton from '@/components/PanelButton';
 import { SwitchControl, Slider } from './shared';
 
 // Define props interface
@@ -44,7 +45,12 @@ export const StylePropertiesPopover: React.FC<StylePropertiesPopoverProps> = Rea
     return (
         <div className="flex flex-col items-center w-14" title="样式属性">
             <Popover className="relative">
-                <Popover.Button className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-hover-bg)] ring-1 ring-inset ring-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]" title="样式属性">
+                <Popover.Button
+                    as={PanelButton}
+                    variant="unstyled"
+                    className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+                    title="样式属性"
+                >
                     {ICONS.PROPERTIES}
                 </Popover.Button>
                 <Transition as={Fragment} enter="transition ease-out duration-200" enterFrom="opacity-0 translate-y-1" enterTo="opacity-100 translate-y-0" leave="transition ease-in duration-150" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-1">


### PR DESCRIPTION
## Summary
- remove focus-visible ring styling so toolbar buttons no longer show an outline

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c65af4047c8323b225569b1285afdf