### PR TITLE
fix(language): unify dropdown style with animation exporter

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -36,14 +36,7 @@ const LanguageSelector: React.FC = () => {
           variant="unstyled"
           className="min-w-[72px] flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
         >
-          <span className="flex items-center gap-2 truncate">
-            {currentInfo && (
-              <span className="w-4 h-4 flex items-center justify-center flex-shrink-0">
-                {currentInfo.icon}
-              </span>
-            )}
-            <span className="truncate">{currentInfo?.abbr}</span>
-          </span>
+          <span className="truncate">{currentInfo?.abbr}</span>
           <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>
         </Popover.Button>
         <Transition
@@ -69,10 +62,7 @@ const LanguageSelector: React.FC = () => {
                         : 'hover:bg-[var(--ui-element-bg-hover)] text-[var(--text-primary)]'
                     }`}
                   >
-                    <span className="flex items-center gap-2 truncate">
-                      <span className="w-4 h-4 flex items-center justify-center flex-shrink-0">{l.icon}</span>
-                      <span className="truncate">{`${l.abbr} ${t(l.labelKey)}`}</span>
-                    </span>
+                    <span className="truncate">{`${l.abbr} ${t(l.labelKey)}`}</span>
                     {currentLang === l.code && (
                       <div className="w-4 h-4 flex-shrink-0">{ICONS.CHECK}</div>
                     )}

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -25,16 +25,16 @@ const LanguageSelector: React.FC = () => {
 
   const currentLang = i18n.language as Lang;
   const currentInfo = supportedLangs.find((l) => l.code === currentLang);
-  const currentLabel = t(currentInfo?.labelKey ?? '');
 
   return (
-    <label className="flex items-center gap-2 text-sm text-[var(--text-primary)]">
+    <label className="flex items-center gap-2 w-full text-sm text-[var(--text-primary)]">
+      <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.LANGUAGE}</div>
       <span className="whitespace-nowrap">{t('language')}</span>
-      <Popover className="relative">
+      <Popover className="relative ml-auto">
         <Popover.Button
           as={PanelButton}
           variant="unstyled"
-          className="min-w-[120px] flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
+          className="min-w-[72px] flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
         >
           <span className="flex items-center gap-2 truncate">
             {currentInfo && (
@@ -42,7 +42,7 @@ const LanguageSelector: React.FC = () => {
                 {currentInfo.icon}
               </span>
             )}
-            <span className="truncate">{currentLabel}</span>
+            <span className="truncate">{currentInfo?.abbr}</span>
           </span>
           <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>
         </Popover.Button>
@@ -71,7 +71,7 @@ const LanguageSelector: React.FC = () => {
                   >
                     <span className="flex items-center gap-2 truncate">
                       <span className="w-4 h-4 flex items-center justify-center flex-shrink-0">{l.icon}</span>
-                      <span className="truncate">{t(l.labelKey)}</span>
+                      <span className="truncate">{`${l.abbr} ${t(l.labelKey)}`}</span>
                     </span>
                     {currentLang === l.code && (
                       <div className="w-4 h-4 flex-shrink-0">{ICONS.CHECK}</div>

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -24,20 +24,26 @@ const LanguageSelector: React.FC = () => {
   };
 
   const currentLang = i18n.language as Lang;
-  const currentLabel = t(
-    supportedLangs.find((l) => l.code === currentLang)?.labelKey ?? ''
-  );
+  const currentInfo = supportedLangs.find((l) => l.code === currentLang);
+  const currentLabel = t(currentInfo?.labelKey ?? '');
 
   return (
-    <label className="flex flex-col gap-1 text-sm text-[var(--text-primary)]">
-      {t('language')}
+    <label className="flex items-center gap-2 text-sm text-[var(--text-primary)]">
+      <span className="whitespace-nowrap">{t('language')}</span>
       <Popover className="relative">
         <Popover.Button
           as={PanelButton}
           variant="unstyled"
-          className="w-full flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
+          className="min-w-[120px] flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
         >
-          <span className="truncate">{currentLabel}</span>
+          <span className="flex items-center gap-2 truncate">
+            {currentInfo && (
+              <span className="w-4 h-4 flex items-center justify-center flex-shrink-0">
+                {currentInfo.icon}
+              </span>
+            )}
+            <span className="truncate">{currentLabel}</span>
+          </span>
           <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>
         </Popover.Button>
         <Transition
@@ -57,13 +63,19 @@ const LanguageSelector: React.FC = () => {
                     key={l.code}
                     variant="unstyled"
                     onClick={() => handleSelect(l.code as Lang, close)}
-                    className={`w-full text-left p-2 rounded-md text-sm ${
+                    className={`flex items-center justify-between p-2 rounded-md text-sm ${
                       currentLang === l.code
                         ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
                         : 'hover:bg-[var(--ui-element-bg-hover)] text-[var(--text-primary)]'
                     }`}
                   >
-                    {t(l.labelKey)}
+                    <span className="flex items-center gap-2 truncate">
+                      <span className="w-4 h-4 flex items-center justify-center flex-shrink-0">{l.icon}</span>
+                      <span className="truncate">{t(l.labelKey)}</span>
+                    </span>
+                    {currentLang === l.code && (
+                      <div className="w-4 h-4 flex-shrink-0">{ICONS.CHECK}</div>
+                    )}
                   </PanelButton>
                 ))}
               </div>

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,8 +1,11 @@
 /**
  * 语言选择器组件
  */
-import React from 'react';
+import React, { Fragment } from 'react';
+import { Popover, Transition } from '@headlessui/react';
 import { useTranslation } from 'react-i18next';
+import { ICONS } from '@/constants';
+import PanelButton from '@/components/PanelButton';
 import i18n, { supportedLangs, type Lang } from '@/lib/i18n';
 
 /**
@@ -14,26 +17,60 @@ const LanguageSelector: React.FC = () => {
   /**
    * 处理语言切换
    */
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newLang = e.target.value as Lang;
+  const handleSelect = (newLang: Lang, close: () => void) => {
     void i18n.changeLanguage(newLang);
     localStorage.setItem('whiteboard_lang', newLang);
+    close();
   };
 
+  const currentLang = i18n.language as Lang;
+  const currentLabel = t(
+    supportedLangs.find((l) => l.code === currentLang)?.labelKey ?? ''
+  );
+
   return (
-    <label className="flex items-center gap-2 text-sm text-[var(--text-primary)]">
+    <label className="flex flex-col gap-1 text-sm text-[var(--text-primary)]">
       {t('language')}
-      <select
-        className="border rounded p-1 bg-[var(--ui-element-bg)]"
-        value={i18n.language as Lang}
-        onChange={handleChange}
-      >
-        {supportedLangs.map((l) => (
-          <option key={l.code} value={l.code}>
-            {t(l.labelKey)}
-          </option>
-        ))}
-      </select>
+      <Popover className="relative">
+        <Popover.Button
+          as={PanelButton}
+          variant="unstyled"
+          className="w-full flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
+        >
+          <span className="truncate">{currentLabel}</span>
+          <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>
+        </Popover.Button>
+        <Transition
+          as={Fragment}
+          enter="transition ease-out duration-100"
+          enterFrom="transform opacity-0 scale-95"
+          enterTo="transform opacity-100 scale-100"
+          leave="transition ease-in duration-75"
+          leaveFrom="transform opacity-100 scale-100"
+          leaveTo="transform opacity-0 scale-95"
+        >
+          <Popover.Panel className="absolute bottom-full mb-2 w-full max-h-48 overflow-y-auto bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] z-30 p-1">
+            {({ close }) => (
+              <div className="flex flex-col gap-1">
+                {supportedLangs.map((l) => (
+                  <PanelButton
+                    key={l.code}
+                    variant="unstyled"
+                    onClick={() => handleSelect(l.code as Lang, close)}
+                    className={`w-full text-left p-2 rounded-md text-sm ${
+                      currentLang === l.code
+                        ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
+                        : 'hover:bg-[var(--ui-element-bg-hover)] text-[var(--text-primary)]'
+                    }`}
+                  >
+                    {t(l.labelKey)}
+                  </PanelButton>
+                ))}
+              </div>
+            )}
+          </Popover.Panel>
+        </Transition>
+      </Popover>
     </label>
   );
 };

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -20,7 +20,7 @@ import {
   Pencil, Type,
   MousePointer2, Paintbrush2, AlignHorizontalSpaceAround,
   AlignLeft, AlignJustify, AlignRight,
-  Sparkles, GripVertical,
+  Sparkles, Languages, GripVertical,
   Blend,Slash,MoveRight,
   Play, Pause, Rewind, ChevronUp, Wand2,SquaresExclude,SquaresIntersect,SquaresSubtract,SquaresUnite,
   // FIX: `RectangleDashed` is not a valid icon in `lucide-react`. Replaced with `SquareDashed`.
@@ -186,6 +186,7 @@ export const ICONS = {
   LOGO: <Pencil />,
   EYEDROPPER: <Pipette className="h-5 w-5" />,
   EFFECTS: <Sparkles className="h-5 w-5" />,
+  LANGUAGE: <Languages className="h-5 w-5" />,
   X: <X className="h-4 w-4" />,
   GRIP: <GripVertical className="h-4 w-4" />,
   MASK: <Blend className="h-5 w-5" />,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -44,9 +44,14 @@ void i18n.use(initReactI18next).init({
 /**
  * 支持的语言列表
  */
-export const supportedLangs: { code: Lang; labelKey: TranslationKey; icon: string }[] = [
-  { code: 'en', labelKey: 'en', icon: '🇺🇸' },
-  { code: 'zh', labelKey: 'zh', icon: '🇨🇳' },
+export const supportedLangs: {
+  code: Lang;
+  labelKey: TranslationKey;
+  icon: string;
+  abbr: string;
+}[] = [
+  { code: 'en', labelKey: 'en', icon: '🇺🇸', abbr: 'EN' },
+  { code: 'zh', labelKey: 'zh', icon: '🇨🇳', abbr: 'CN' },
 ];
 
 export default i18n;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -47,11 +47,10 @@ void i18n.use(initReactI18next).init({
 export const supportedLangs: {
   code: Lang;
   labelKey: TranslationKey;
-  icon: string;
   abbr: string;
 }[] = [
-  { code: 'en', labelKey: 'en', icon: '🇺🇸', abbr: 'EN' },
-  { code: 'zh', labelKey: 'zh', icon: '🇨🇳', abbr: 'CN' },
+  { code: 'en', labelKey: 'en', abbr: 'EN' },
+  { code: 'zh', labelKey: 'zh', abbr: 'CN' },
 ];
 
 export default i18n;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -44,9 +44,9 @@ void i18n.use(initReactI18next).init({
 /**
  * 支持的语言列表
  */
-export const supportedLangs: { code: Lang; labelKey: TranslationKey }[] = [
-  { code: 'en', labelKey: 'en' },
-  { code: 'zh', labelKey: 'zh' },
+export const supportedLangs: { code: Lang; labelKey: TranslationKey; icon: string }[] = [
+  { code: 'en', labelKey: 'en', icon: '🇺🇸' },
+  { code: 'zh', labelKey: 'zh', icon: '🇨🇳' },
 ];
 
 export default i18n;


### PR DESCRIPTION
## Summary
- style language settings dropdown to match animation export panel

## Testing
- `npm test` *(fails: Failed to resolve import "magic-wand-tool" from "src/lib/image.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68c65b9d44b08323b512f5402406fec4