### PR TITLE
fix(side-toolbar): align button spacing with top toolbar

### DIFF
--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -144,7 +144,7 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
   const isFrameSelected = firstSelectedPath?.tool === 'frame';
 
   return (
-    <div className="sidebar-container bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-3 flex flex-col items-center gap-4 text-[var(--text-primary)]">
+    <div className="sidebar-container bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-3 flex flex-col items-center gap-2 text-[var(--text-primary)]">
       {isFrameSelected ? (
         <div className="text-center text-sm text-[var(--text-secondary)]">画框属性</div>
       ) : isTextMode ? (


### PR DESCRIPTION
## Summary
- Match right sidebar button spacing to top toolbar by reducing container gap

## Testing
- `npm test` *(fails: Failed to resolve import "magic-wand-tool" from "src/lib/image.ts")*


------
https://chatgpt.com/codex/tasks/task_e_68c65b3cb9e48323bb0911d4f1b6fe44