### PR TITLE
fix(touch): disable mac gestures

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -176,7 +176,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   return (
     <div
       ref={containerRef}
-      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-contain"
+      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-none"
       onWheel={onWheel}
       style={{ cursor }}
       onContextMenu={onContextMenu}

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -156,7 +156,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
 
   return (
     <div
-      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-contain"
+      className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-none"
       onWheel={onWheel}
       style={{ cursor }}
       onContextMenu={onContextMenu}

--- a/src/context/viewTransformStore.ts
+++ b/src/context/viewTransformStore.ts
@@ -56,9 +56,10 @@ export const useViewTransformStore = create<ViewTransformState>((set, get) => ({
     const { deltaX, deltaY, ctrlKey, clientX, clientY } = e as any;
     const { viewTransform } = get();
 
-    if (ctrlKey || Math.abs(deltaX) < Math.abs(deltaY)) {
+    if (ctrlKey) {
       const { scale, translateX, translateY } = viewTransform;
-      const zoomStep = 0.001;
+      // 调整滚轮缩放步长以提高灵敏度
+      const zoomStep = 0.01;
       const newScale = Math.max(0.1, Math.min(10, scale - deltaY * zoomStep));
       if (Math.abs(scale - newScale) < 1e-9) return;
 
@@ -148,7 +149,9 @@ export const useViewTransformStore = create<ViewTransformState>((set, get) => ({
           x: (values[0].x + values[1].x) / 2,
           y: (values[0].y + values[1].y) / 2,
         };
-        const scaleFactor = dist / s.initialPinch.distance;
+        const rawFactor = dist / s.initialPinch.distance;
+        // 提高捏合缩放灵敏度，放大缩放因子
+        const scaleFactor = 1 + (rawFactor - 1) * 3;
         let newScale = s.initialPinch.scale * scaleFactor;
         newScale = Math.max(0.1, Math.min(10, newScale));
         const newTranslateX = midScreen.x - s.initialPinch.midpoint.x * newScale;

--- a/src/index.css
+++ b/src/index.css
@@ -81,7 +81,9 @@
 html, body, #root {
   height: 100%;
   width: 100%;
-  overflow-x: hidden;
+  overflow: hidden; /* 禁用滚动以防止系统手势 */
+  touch-action: none; /* 禁用默认手势，防止回退或缩放 */
+  overscroll-behavior: none; /* 阻止浏览器回退手势 */
 }
 
 body {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,11 +9,22 @@ import App from './App';
 import './index.css';
 import { registerSW } from 'virtual:pwa-register';
 
-// 屏蔽全局浏览器捏合手势，避免页面缩放
-const blockGesture = (e: Event) => e.preventDefault();
-document.addEventListener('gesturestart', blockGesture);
-document.addEventListener('gesturechange', blockGesture);
-document.addEventListener('gestureend', blockGesture);
+// 阻止浏览器默认手势（捏合缩放、双指滑动回退等）
+const preventDefault = (e: Event) => e.preventDefault();
+['gesturestart', 'gesturechange', 'gestureend', 'touchstart', 'touchmove'].forEach(evt => {
+  window.addEventListener(evt, preventDefault, { passive: false });
+});
+
+// 禁用 Ctrl+滚轮及页面层级的滚轮默认行为，避免触发页面缩放或回退
+window.addEventListener(
+  'wheel',
+  e => {
+    if ((e as WheelEvent).ctrlKey || e.target === document.body) {
+      e.preventDefault();
+    }
+  },
+  { passive: false }
+);
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/tests/context/viewTransformStore.test.ts
+++ b/tests/context/viewTransformStore.test.ts
@@ -41,8 +41,8 @@ describe('useViewTransformStore pinch gestures', () => {
     store.handleTouchStart({ pointerId: 2, clientX: 10, clientY: 0, currentTarget: svg } as any);
     store.handleTouchMove({ pointerId: 2, clientX: 20, clientY: 0 } as any);
     const vt = useViewTransformStore.getState().viewTransform;
-    expect(vt.scale).toBeCloseTo(2);
-    expect(vt.translateX).toBeCloseTo(0);
+    expect(vt.scale).toBeCloseTo(4);
+    expect(vt.translateX).toBeCloseTo(-10);
     expect(vt.translateY).toBeCloseTo(0);
   });
 


### PR DESCRIPTION
## Summary
- block pinch zoom and two-finger back-swipe via global gesture and touch listeners
- hide page scroll to remove overscroll navigation on mac trackpads
- boost zoom gesture sensitivity for wheel and pinch interactions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c628b6dad08323a218835e136e8cb0