### PR TITLE
fix(layers): unify layers panel icon sizes with menu

### DIFF
--- a/src/components/layers-panel/LayerItem.tsx
+++ b/src/components/layers-panel/LayerItem.tsx
@@ -6,7 +6,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import type { AnyPath, GroupData } from '../../types';
 import { ICONS } from '../../constants';
 import { useLayers } from '../../lib/layers-context';
-import { getToolIcon, capitalize } from './constants';
+import { getToolIcon, capitalize, withLayerIconSize } from './constants';
 import PanelButton from '@/components/PanelButton';
 
 interface LayerItemProps {
@@ -128,11 +128,11 @@ export const LayerItem: React.FC<LayerItemProps> = ({
                 disabled={isEditing}
               >
                 <div className={`transition-transform duration-300 ease-in-out ${(path as GroupData).isCollapsed ? '-rotate-90' : ''}`}>
-                  {ICONS.CHEVRON_DOWN}
+                  {withLayerIconSize(ICONS.CHEVRON_DOWN)}
                 </div>
               </PanelButton>
             )}
-            <div className="w-5 h-5 text-[var(--text-secondary)]">{getToolIcon(path.tool, path)}</div>
+            <div className="w-4 h-4 text-[var(--text-secondary)]">{getToolIcon(path.tool, path)}</div>
           </div>
           
           {isEditing ? (
@@ -160,7 +160,7 @@ export const LayerItem: React.FC<LayerItemProps> = ({
             className="p-1 rounded-md text-[var(--text-secondary)] hover:bg-white/10 transition-colors"
             title={isLocked ? '解锁' : '锁定'}
           >
-            {isLocked ? ICONS.LOCK_CLOSED : ICONS.LOCK_OPEN}
+            {isLocked ? withLayerIconSize(ICONS.LOCK_CLOSED) : withLayerIconSize(ICONS.LOCK_OPEN)}
           </PanelButton>
           <PanelButton
             variant="unstyled"
@@ -168,7 +168,7 @@ export const LayerItem: React.FC<LayerItemProps> = ({
             className="p-1 rounded-md text-[var(--text-secondary)] hover:bg-white/10 transition-colors"
             title={isVisible ? '隐藏' : '显示'}
           >
-            {isVisible ? ICONS.EYE_OPEN : ICONS.EYE_OFF}
+            {isVisible ? withLayerIconSize(ICONS.EYE_OPEN) : withLayerIconSize(ICONS.EYE_OFF)}
           </PanelButton>
           <PanelButton
             variant="unstyled"
@@ -176,7 +176,7 @@ export const LayerItem: React.FC<LayerItemProps> = ({
             className="p-1 rounded-md text-[var(--danger-text)] hover:bg-[var(--danger-bg)] transition-colors"
             title="删除"
           >
-            {ICONS.TRASH}
+            {withLayerIconSize(ICONS.TRASH)}
           </PanelButton>
         </div>
       </div>

--- a/src/components/layers-panel/LayersPanel.tsx
+++ b/src/components/layers-panel/LayersPanel.tsx
@@ -10,6 +10,7 @@ import { useLayers } from '../../lib/layers-context';
 import { useAppContext } from '@/context/AppContext';
 import { LayerItem } from './LayerItem';
 import PanelButton from '@/components/PanelButton';
+import { withLayerIconSize } from './constants';
 
 export const LayersPanel: React.FC = () => {
   const { paths, selectedPathIds, reorderPaths, handleDeletePaths, setPaths, setSelectedPathIds } = useLayers();
@@ -187,7 +188,7 @@ export const LayersPanel: React.FC = () => {
               }
               className="flex-1 flex items-center justify-center gap-2 p-2 rounded-md text-sm text-[var(--danger-text)] hover:bg-[var(--danger-bg)]"
             >
-              <div className="w-5 h-5 flex-shrink-0 text-[var(--text-secondary)]">{ICONS.CLEAR}</div>
+              <div className="w-4 h-4 flex-shrink-0 text-[var(--text-secondary)]">{withLayerIconSize(ICONS.CLEAR)}</div>
               清空画布
             </PanelButton>
           )}
@@ -197,7 +198,7 @@ export const LayersPanel: React.FC = () => {
               onClick={() => handleDeletePaths(selectedPathIds)}
               className="flex-1 flex items-center justify-center gap-2 p-2 rounded-md text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)]"
             >
-              <div className="w-5 h-5 flex-shrink-0 text-[var(--text-secondary)]">{ICONS.TRASH}</div>
+              <div className="w-4 h-4 flex-shrink-0 text-[var(--text-secondary)]">{withLayerIconSize(ICONS.TRASH)}</div>
               删除选中
             </PanelButton>
           )}

--- a/src/components/layers-panel/constants.ts
+++ b/src/components/layers-panel/constants.ts
@@ -1,8 +1,17 @@
 /**
  * 本文件存放图层面板相关的常量和辅助函数。
  */
+import React from 'react';
 import { ICONS } from '../../constants';
 import type { AnyPath, GroupData } from '../../types';
+
+/**
+ * 将图标尺寸调整为与菜单统一
+ * @param icon - 原始图标元素
+ * @returns 调整尺寸后的图标元素
+ */
+export const withLayerIconSize = (icon: JSX.Element) =>
+  React.cloneElement(icon, { className: 'h-4 w-4' });
 
 /**
  * 根据路径的工具类型返回对应的图标。
@@ -12,20 +21,20 @@ import type { AnyPath, GroupData } from '../../types';
  */
 export const getToolIcon = (tool: AnyPath['tool'], path?: AnyPath) => {
   if (path && path.tool === 'group' && (path as GroupData).mask === 'clip') {
-    return ICONS.MASK;
+    return withLayerIconSize(ICONS.MASK);
   }
   switch (tool) {
-    case 'rectangle': return ICONS.RECTANGLE;
-    case 'ellipse': return ICONS.ELLIPSE;
-    case 'pen': return ICONS.PEN;
-    case 'line': return ICONS.LINE;
-    case 'brush': return ICONS.BRUSH;
-    case 'polygon': return ICONS.POLYGON;
-    case 'arc': return ICONS.ARC;
-    case 'image': return ICONS.IMAGE;
-    case 'group': return ICONS.GROUP;
-    case 'text': return ICONS.TEXT;
-    case 'frame': return ICONS.FRAME;
+    case 'rectangle': return withLayerIconSize(ICONS.RECTANGLE);
+    case 'ellipse': return withLayerIconSize(ICONS.ELLIPSE);
+    case 'pen': return withLayerIconSize(ICONS.PEN);
+    case 'line': return withLayerIconSize(ICONS.LINE);
+    case 'brush': return withLayerIconSize(ICONS.BRUSH);
+    case 'polygon': return withLayerIconSize(ICONS.POLYGON);
+    case 'arc': return withLayerIconSize(ICONS.ARC);
+    case 'image': return withLayerIconSize(ICONS.IMAGE);
+    case 'group': return withLayerIconSize(ICONS.GROUP);
+    case 'text': return withLayerIconSize(ICONS.TEXT);
+    case 'frame': return withLayerIconSize(ICONS.FRAME);
     default: return null;
   }
 };


### PR DESCRIPTION
## Summary
- ensure layer panel icons match menu bar size
- add helper to resize icons consistently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c660e674a083239e4c9972c30bc94e