### PR TITLE
fix(panel-button): shrink size to 85%

### DIFF
--- a/src/components/PanelButton.tsx
+++ b/src/components/PanelButton.tsx
@@ -10,7 +10,7 @@ export const PanelButton = React.forwardRef<HTMLButtonElement, PanelButtonProps>
       ref={ref}
       className={
         variant === 'panel'
-          ? `flex items-center justify-center h-10 w-10 rounded-lg bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-lg border-0 text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none ${className}`
+          ? `flex items-center justify-center h-[34px] w-[34px] rounded-lg bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-lg border-0 text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] transition-colors focus:outline-none ${className}`
           : `focus:outline-none ${className}`
       }
       {...props}


### PR DESCRIPTION
## Summary
- reduce panel button dimensions to 34px (~85% of previous 40px)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c66502ec188323a030d4bd12c35e75