### PR TITLE
fix(language): align selector with menu style

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,8 +1,11 @@
 /**
  * 语言选择器组件
  */
-import React from 'react';
+import React, { Fragment } from 'react';
+import { Popover, Transition } from '@headlessui/react';
 import { useTranslation } from 'react-i18next';
+import { ICONS } from '@/constants';
+import PanelButton from '@/components/PanelButton';
 import i18n, { supportedLangs, type Lang } from '@/lib/i18n';
 
 /**
@@ -14,27 +17,65 @@ const LanguageSelector: React.FC = () => {
   /**
    * 处理语言切换
    */
-  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const newLang = e.target.value as Lang;
+  const handleSelect = (newLang: Lang, close: () => void) => {
     void i18n.changeLanguage(newLang);
     localStorage.setItem('whiteboard_lang', newLang);
+    close();
   };
 
+  const currentLang = i18n.language as Lang;
+  const currentInfo = supportedLangs.find((l) => l.code === currentLang);
+
   return (
-    <label className="flex items-center gap-2 text-sm text-[var(--text-primary)]">
-      {t('language')}
-      <select
-        className="border rounded p-1 bg-[var(--ui-element-bg)]"
-        value={i18n.language as Lang}
-        onChange={handleChange}
+    <Popover className="relative w-full">
+      <Popover.Button
+        as={PanelButton}
+        variant="unstyled"
+        className="w-full flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
       >
-        {supportedLangs.map((l) => (
-          <option key={l.code} value={l.code}>
-            {t(l.labelKey)}
-          </option>
-        ))}
-      </select>
-    </label>
+        <div className="flex items-center gap-2">
+          <div className="w-4 h-4 flex items-center justify-center text-[var(--text-secondary)]">{ICONS.LANGUAGE}</div>
+          <span>{t('language')}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span>{currentInfo?.abbr}</span>
+          <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>
+        </div>
+      </Popover.Button>
+      <Transition
+        as={Fragment}
+        enter="transition ease-out duration-100"
+        enterFrom="transform opacity-0 scale-95"
+        enterTo="transform opacity-100 scale-100"
+        leave="transition ease-in duration-75"
+        leaveFrom="transform opacity-100 scale-100"
+        leaveTo="transform opacity-0 scale-95"
+      >
+        <Popover.Panel className="absolute right-0 mt-2 w-full max-h-48 overflow-y-auto bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] z-30 p-1">
+          {({ close }) => (
+            <div className="flex flex-col gap-1">
+              {supportedLangs.map((l) => (
+                <PanelButton
+                  key={l.code}
+                  variant="unstyled"
+                  onClick={() => handleSelect(l.code as Lang, close)}
+                  className={`flex items-center justify-between p-2 rounded-md text-sm ${
+                    currentLang === l.code
+                      ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
+                      : 'hover:bg-[var(--ui-element-bg-hover)] text-[var(--text-primary)]'
+                  }`}
+                >
+                  <span>{l.abbr}</span>
+                  {currentLang === l.code && (
+                    <div className="w-4 h-4 flex-shrink-0">{ICONS.CHECK}</div>
+                  )}
+                </PanelButton>
+              ))}
+            </div>
+          )}
+        </Popover.Panel>
+      </Transition>
+    </Popover>
   );
 };
 

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -31,7 +31,7 @@ const LanguageSelector: React.FC = () => {
       <Popover.Button
         as={PanelButton}
         variant="unstyled"
-        className="w-full flex items-center gap-3 p-2 h-9 rounded-md bg-black/20 text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
+        className="w-full flex items-center gap-3 p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
       >
         <div className="w-4 h-4 flex items-center justify-center text-[var(--text-secondary)]">{ICONS.LANGUAGE}</div>
         <span className="flex-grow">{t('language')}</span>
@@ -57,7 +57,7 @@ const LanguageSelector: React.FC = () => {
                   key={l.code}
                   variant="unstyled"
                   onClick={() => handleSelect(l.code as Lang, close)}
-                  className={`flex items-center justify-between p-2 rounded-md text-sm ${
+                  className={`w-full flex items-center justify-between p-2 rounded-md text-left text-sm ${
                     currentLang === l.code
                       ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
                       : 'hover:bg-[var(--ui-element-bg-hover)] text-[var(--text-primary)]'

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -31,12 +31,10 @@ const LanguageSelector: React.FC = () => {
       <Popover.Button
         as={PanelButton}
         variant="unstyled"
-        className="w-full flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
+        className="w-full flex items-center gap-3 p-2 h-9 rounded-md bg-black/20 text-sm text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
       >
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 flex items-center justify-center text-[var(--text-secondary)]">{ICONS.LANGUAGE}</div>
-          <span>{t('language')}</span>
-        </div>
+        <div className="w-4 h-4 flex items-center justify-center text-[var(--text-secondary)]">{ICONS.LANGUAGE}</div>
+        <span className="flex-grow">{t('language')}</span>
         <div className="flex items-center gap-1">
           <span>{currentInfo?.abbr}</span>
           <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -227,13 +227,9 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                   );
                 }
 
-                if ((action as any).isLanguageSelector) {
-                  return (
-                    <div key="language-selector" className="p-2">
-                      <LanguageSelector />
-                    </div>
-                  );
-                }
+                  if ((action as any).isLanguageSelector) {
+                    return <LanguageSelector key="language-selector" />;
+                  }
 
               return (
                 <PanelButton

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -20,7 +20,7 @@ import {
   Pencil, Type,
   MousePointer2, Paintbrush2, AlignHorizontalSpaceAround,
   AlignLeft, AlignJustify, AlignRight,
-  Sparkles, GripVertical,
+  Sparkles, Languages, GripVertical,
   Blend,Slash,MoveRight,
   Play, Pause, Rewind, ChevronUp, Wand2,SquaresExclude,SquaresIntersect,SquaresSubtract,SquaresUnite,
   // FIX: `RectangleDashed` is not a valid icon in `lucide-react`. Replaced with `SquareDashed`.
@@ -186,6 +186,7 @@ export const ICONS = {
   LOGO: <Pencil />,
   EYEDROPPER: <Pipette className="h-5 w-5" />,
   EFFECTS: <Sparkles className="h-5 w-5" />,
+  LANGUAGE: <Languages className="h-5 w-5" />,
   X: <X className="h-4 w-4" />,
   GRIP: <GripVertical className="h-4 w-4" />,
   MASK: <Blend className="h-5 w-5" />,

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -30,8 +30,6 @@ const resources = {
   },
 } as const;
 
-export type TranslationKey = keyof typeof resources.en.translation;
-
 const storedLang = localStorage.getItem('whiteboard_lang') as Lang | null;
 
 void i18n.use(initReactI18next).init({
@@ -44,9 +42,12 @@ void i18n.use(initReactI18next).init({
 /**
  * 支持的语言列表
  */
-export const supportedLangs: { code: Lang; labelKey: TranslationKey }[] = [
-  { code: 'en', labelKey: 'en' },
-  { code: 'zh', labelKey: 'zh' },
+export const supportedLangs: {
+  code: Lang;
+  abbr: string;
+}[] = [
+  { code: 'en', abbr: 'EN' },
+  { code: 'zh', abbr: 'CN' },
 ];
 
 export default i18n;


### PR DESCRIPTION
## Summary
- style language selector like other menu actions with popover trigger
- keep dropdown options to language abbreviations only
- remove unused language name keys
- shrink selector button and right-align popover panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c65b9d44b08323b512f5402406fec4