### PR TITLE
feat(ui): shrink toolbar buttons and unify menu spacing

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -188,19 +188,19 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, onInt
         </div>
         
         <div className="flex items-center justify-between gap-2 pt-1">
-           <div className="flex items-center bg-black/20 rounded-md h-9 px-2 w-[100px]">
+           <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-[100px]">
              <input
                type="text"
                value={hexInput}
                onChange={handleHexInputChange}
                onBlur={handleHexInputCommit}
                onKeyDown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur() }}
-               className="w-full text-sm font-mono bg-transparent text-[var(--text-primary)] focus:outline-none"
+               className="w-full text-xs font-mono bg-transparent text-[var(--text-primary)] focus:outline-none"
                aria-label="Hex color value"
              />
            </div>
            
-           <div className="flex items-center bg-black/20 rounded-md h-9 px-2 w-[70px]">
+           <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-[70px]">
                <input
                  type="number"
                  min="0"
@@ -208,10 +208,10 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, onInt
                  value={Math.round(hsla.a * 100)}
                  onChange={handleAlphaInputChange}
                  onBlur={(e) => { if (e.target.value === '') handleHslaChange({a: 1})}}
-                 className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                 className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                  aria-label="Alpha percentage"
                />
-               <span className="text-sm text-[var(--text-secondary)]">%</span>
+               <span className="text-xs text-[var(--text-secondary)]">%</span>
            </div>
            
             {'EyeDropper' in window && (

--- a/src/components/FloatingAnimationExporter.tsx
+++ b/src/components/FloatingAnimationExporter.tsx
@@ -176,8 +176,8 @@ export const FloatingAnimationExporter: React.FC<FloatingAnimationExporterProps>
 
                     <div className={`grid grid-cols-2 items-center gap-2 transition-opacity ${format !== 'spritesheet' ? 'opacity-50 pointer-events-none' : ''}`}>
                         <label htmlFor="spritesheet-cols" className="text-sm font-medium text-[var(--text-primary)]">列数</label>
-                        <div className="flex items-center bg-black/20 rounded-md h-8 px-2">
-                            <input id="spritesheet-cols" type="number" min="1" step="1" value={columns} onChange={e => setColumns(Math.max(1, parseInt(e.target.value) || 1))} className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners" />
+                        <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px]">
+                            <input id="spritesheet-cols" type="number" min="1" step="1" value={columns} onChange={e => setColumns(Math.max(1, parseInt(e.target.value) || 1))} className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners" />
                         </div>
                     </div>
                     

--- a/src/components/FloatingPngExporter.tsx
+++ b/src/components/FloatingPngExporter.tsx
@@ -132,7 +132,7 @@ export const FloatingPngExporter: React.FC<FloatingPngExporterProps> = ({
                     <h3 className="text-sm font-bold text-center text-[var(--text-primary)]">PNG 导出选项</h3>
                     <div className="grid grid-cols-2 items-center gap-2">
                         <label htmlFor="png-scale" className="text-sm font-medium text-[var(--text-primary)]">比例</label>
-                        <div className="flex items-center bg-black/20 rounded-md h-8 px-2">
+                        <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px]">
                             <input
                                 id="png-scale"
                                 type="number"
@@ -141,9 +141,9 @@ export const FloatingPngExporter: React.FC<FloatingPngExporterProps> = ({
                                 step="0.1"
                                 value={pngExportOptions.scale}
                                 onChange={e => setPngExportOptions(prev => ({ ...prev, scale: Math.max(0.1, parseFloat(e.target.value)) || 1 }))}
-                                className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                             />
-                            <span className="text-sm text-[var(--text-secondary)]">x</span>
+                            <span className="text-xs text-[var(--text-secondary)]">x</span>
                         </div>
                     </div>
                     <SwitchControl label="透明背景" enabled={pngExportOptions.transparentBg} setEnabled={val => setPngExportOptions(prev => ({ ...prev, transparentBg: val }))} />

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -160,7 +160,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                         variant="unstyled"
                         ref={ref as any}
                         onClick={onClick}
-                        className="w-full flex items-center gap-3 p-2 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
+                        className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
                       >
                         <div className="w-4 h-4 flex flex-shrink-0 items-center justify-center text-[var(--text-secondary)]">{ICONS.BACKGROUND_COLOR}</div>
                         <span className="flex-grow">画布背景...</span>
@@ -193,7 +193,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                         ref={ref as any}
                         onClick={onClick}
                         disabled={!canExport}
-                        className="w-full flex items-center gap-3 p-2 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 ring-[var(--accent-primary)]"
+                        className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 ring-[var(--accent-primary)]"
                       >
                         <div className="w-4 h-4 flex flex-shrink-0 items-center justify-center text-[var(--text-secondary)]">{ICONS.COPY_PNG}</div>
                         <span className="flex-grow">{action.label}</span>
@@ -217,7 +217,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                           ref={ref}
                           onClick={onClick}
                           disabled={frameCount <= 1}
-                          className="w-full flex items-center gap-3 p-2 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 ring-[var(--accent-primary)]"
+                          className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 ring-[var(--accent-primary)]"
                         >
                           <div className="w-4 h-4 flex flex-shrink-0 items-center justify-center text-[var(--text-secondary)]">{ICONS.PLAY}</div>
                           <span className="flex-grow">{action.label}</span>
@@ -229,7 +229,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
 
                 if ((action as any).isLanguageSelector) {
                   return (
-                    <div key="language-selector" className="p-2">
+                    <div key="language-selector" className="px-2 py-1">
                       <LanguageSelector />
                     </div>
                   );
@@ -241,7 +241,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                   key={action.label}
                   onClick={() => !(action as any).disabled && (action as any).handler()}
                   disabled={(action as any).disabled}
-                  className={`w-full flex items-center gap-3 p-2 rounded-md text-left text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                  className={`w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                     (action as any).isDanger
                       ? 'text-[var(--danger-text)] hover:bg-[var(--danger-bg)] focus:bg-[var(--danger-bg)]'
                       : 'text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)]'

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -230,16 +230,16 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
                          </div>
                          <div>
                             <label htmlFor="dist-spacing" className="text-sm font-semibold text-[var(--text-primary)] mb-1 block">固定间距</label>
-                             <div className="flex items-center bg-[var(--ui-element-bg)] rounded-md h-[34px] px-2">
+                             <div className="flex items-center bg-[var(--ui-element-bg)] rounded-md h-[30px] px-[7px]">
                               <input
                                 id="dist-spacing"
                                 type="number"
                                 placeholder="自动"
                                 value={distributeSpacing}
                                 onChange={(e) => setDistributeSpacing(e.target.value)}
-                                className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                               />
-                              <span className="text-sm text-[var(--text-secondary)]">px</span>
+                              <span className="text-xs text-[var(--text-secondary)]">px</span>
                             </div>
                          </div>
                       </div>

--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -232,6 +232,7 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
                 setColor={setFill}
                 beginCoalescing={beginCoalescing}
                 endCoalescing={endCoalescing}
+                className="mt-2"
               />
               <FillStyleControl
                 fillStyle={fillStyle}

--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -268,7 +268,7 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
         <PanelButton
           variant="unstyled"
           onClick={onToggleStyleLibrary}
-          className={`flex items-center justify-center h-10 w-10 rounded-lg transition-colors ${
+          className={`flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors ${
             isStyleLibraryOpen
               ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
               : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'

--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -159,11 +159,11 @@ export const TimelinePanel: React.FC = () => {
                       </div>
                     <div className="flex items-center gap-2">
                          <label htmlFor="fps-input" className="text-sm font-medium text-[var(--text-secondary)]">FPS</label>
-                         <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-20">
+                         <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20">
                            <input
                              id="fps-input" type="number" min="1" max="60" step="1"
                              value={fps} onChange={(e) => setFps(Math.max(1, parseInt(e.target.value) || 1))}
-                             className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                             className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                            />
                          </div>
                     </div>
@@ -178,33 +178,33 @@ export const TimelinePanel: React.FC = () => {
                           <div className={`flex items-center gap-4 transition-opacity ${isOnionSkinEnabled ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
                             <div className="flex items-center gap-2">
                                 <label htmlFor="onion-opacity-input" className="text-sm font-medium text-[var(--text-secondary)]">透明度</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-20">
+                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20">
                                 <input
                                     id="onion-opacity-input" type="number" min="0" max="100" step="1"
                                     value={Math.round(onionSkinOpacity * 100)}
                                     onChange={(e) => setOnionSkinOpacity(Math.max(0, Math.min(100, parseInt(e.target.value) || 0)) / 100)}
-                                    className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                    className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                                 />
-                                 <span className="text-sm text-[var(--text-secondary)]">%</span>
+                                 <span className="text-xs text-[var(--text-secondary)]">%</span>
                                 </div>
                             </div>
                             <div className="flex items-center gap-2">
                                 <label htmlFor="prev-frames-input" className="text-sm font-medium text-[var(--text-secondary)]">之前</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-16">
+                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
                                 <input
                                     id="prev-frames-input" type="number" min="0" max="10" step="1"
                                     value={onionSkinPrevFrames} onChange={(e) => setOnionSkinPrevFrames(Math.max(0, parseInt(e.target.value) || 0))}
-                                    className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                    className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                                 />
                                 </div>
                             </div>
                             <div className="flex items-center gap-2">
                                 <label htmlFor="next-frames-input" className="text-sm font-medium text-[var(--text-secondary)]">之后</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-16">
+                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
                                 <input
                                     id="next-frames-input" type="number" min="0" max="10" step="1"
                                     value={onionSkinNextFrames} onChange={(e) => setOnionSkinNextFrames(Math.max(0, parseInt(e.target.value) || 0))}
-                                    className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                    className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                                 />
                                 </div>
                             </div>

--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -159,7 +159,7 @@ export const TimelinePanel: React.FC = () => {
                       </div>
                     <div className="flex items-center gap-2">
                          <label htmlFor="fps-input" className="text-sm font-medium text-[var(--text-secondary)]">FPS</label>
-                         <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20">
+                         <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
                            <input
                              id="fps-input" type="number" min="1" max="60" step="1"
                              value={fps} onChange={(e) => setFps(Math.max(1, parseInt(e.target.value) || 1))}
@@ -178,7 +178,7 @@ export const TimelinePanel: React.FC = () => {
                           <div className={`flex items-center gap-4 transition-opacity ${isOnionSkinEnabled ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
                             <div className="flex items-center gap-2">
                                 <label htmlFor="onion-opacity-input" className="text-sm font-medium text-[var(--text-secondary)]">透明度</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20">
+                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
                                 <input
                                     id="onion-opacity-input" type="number" min="0" max="100" step="1"
                                     value={Math.round(onionSkinOpacity * 100)}
@@ -190,7 +190,7 @@ export const TimelinePanel: React.FC = () => {
                             </div>
                             <div className="flex items-center gap-2">
                                 <label htmlFor="prev-frames-input" className="text-sm font-medium text-[var(--text-secondary)]">之前</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
+                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-14">
                                 <input
                                     id="prev-frames-input" type="number" min="0" max="10" step="1"
                                     value={onionSkinPrevFrames} onChange={(e) => setOnionSkinPrevFrames(Math.max(0, parseInt(e.target.value) || 0))}
@@ -200,7 +200,7 @@ export const TimelinePanel: React.FC = () => {
                             </div>
                             <div className="flex items-center gap-2">
                                 <label htmlFor="next-frames-input" className="text-sm font-medium text-[var(--text-secondary)]">之后</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
+                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-14">
                                 <input
                                     id="next-frames-input" type="number" min="0" max="10" step="1"
                                     value={onionSkinNextFrames} onChange={(e) => setOnionSkinNextFrames(Math.max(0, parseInt(e.target.value) || 0))}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -106,7 +106,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               </div>
 
               <label htmlFor="grid-size" className="text-sm font-medium justify-self-start">网格大小</label>
-              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-24 justify-self-end">
+              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20 justify-self-end">
                 <input
                   id="grid-size"
                   type="number"
@@ -122,7 +122,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               </div>
 
               <label htmlFor="grid-subdivisions" className="text-sm font-medium justify-self-start">细分</label>
-              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-24 justify-self-end">
+              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20 justify-self-end">
                 <input
                   id="grid-subdivisions"
                   type="number"
@@ -137,7 +137,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               </div>
 
               <label htmlFor="grid-opacity" className="text-sm font-medium justify-self-start">透明度</label>
-              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-24 justify-self-end">
+              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20 justify-self-end">
                 <input
                   id="grid-opacity"
                   type="number"

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -61,7 +61,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           title={t.title}
           onClick={() => setTool(t.name)}
           variant="unstyled"
-          className={`flex items-center justify-center h-10 w-10 rounded-lg transition-colors ${
+          className={`flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors ${
             tool === t.name
               ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
               : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
@@ -78,7 +78,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
           as={PanelButton}
           variant="unstyled"
           title="网格设置"
-          className="flex items-center justify-center h-10 w-10 rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+          className="flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
         >
           {ICONS.GRID}
         </Popover.Button>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -106,7 +106,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
               </div>
 
               <label htmlFor="grid-size" className="text-sm font-medium justify-self-start">网格大小</label>
-              <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-24 justify-self-end">
+              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-24 justify-self-end">
                 <input
                   id="grid-size"
                   type="number"
@@ -115,14 +115,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                   step="5"
                   value={gridSize}
                   onChange={(e) => setGridSize(Math.max(5, Number(e.target.value)))}
-                  className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                  className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                   disabled={!isGridVisible}
                 />
-                <span className="text-sm text-[var(--text-secondary)]">px</span>
+                <span className="text-xs text-[var(--text-secondary)]">px</span>
               </div>
 
               <label htmlFor="grid-subdivisions" className="text-sm font-medium justify-self-start">细分</label>
-              <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-24 justify-self-end">
+              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-24 justify-self-end">
                 <input
                   id="grid-subdivisions"
                   type="number"
@@ -131,13 +131,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                   step="1"
                   value={gridSubdivisions}
                   onChange={(e) => setGridSubdivisions(Math.max(2, Number(e.target.value)))}
-                  className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                  className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                   disabled={!isGridVisible}
                 />
               </div>
 
               <label htmlFor="grid-opacity" className="text-sm font-medium justify-self-start">透明度</label>
-              <div className="flex items-center bg-black/20 rounded-md h-8 px-2 w-24 justify-self-end">
+              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-24 justify-self-end">
                 <input
                   id="grid-opacity"
                   type="number"
@@ -146,10 +146,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                   step="1"
                   value={Math.round(gridOpacity * 100)}
                   onChange={(e) => setGridOpacity(Math.max(0, Math.min(100, Number(e.target.value))) / 100)}
-                  className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)] hide-spinners"
+                  className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
                   disabled={!isGridVisible}
                 />
-                <span className="text-sm text-[var(--text-secondary)]">%</span>
+                <span className="text-xs text-[var(--text-secondary)]">%</span>
               </div>
             </div>
           </Popover.Panel>

--- a/src/components/layers-panel/LayerItem.tsx
+++ b/src/components/layers-panel/LayerItem.tsx
@@ -143,7 +143,7 @@ export const LayerItem: React.FC<LayerItemProps> = ({
               onChange={e => setNameInput(e.target.value)}
               onBlur={handleNameCommit}
               onKeyDown={e => { if (e.key === 'Enter') handleNameCommit(); if (e.key === 'Escape') setIsEditing(false); }}
-              className="flex-grow text-sm truncate bg-transparent ring-1 ring-[var(--accent-primary)] rounded-sm px-1 min-w-0"
+              className="flex-grow text-xs truncate bg-transparent ring-1 ring-[var(--accent-primary)] rounded-sm px-1 min-w-0"
               onClick={e => e.stopPropagation()}
             />
           ) : (

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -17,7 +17,7 @@ export const SideToolbarPanel: React.FC = () => {
             <PanelButton
                 variant="unstyled"
                 onClick={() => setIsSideToolbarCollapsed(prev => !prev)}
-                className="absolute top-4 right-4 z-30 flex items-center justify-center h-10 w-10 rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
+                className="absolute top-4 right-4 z-30 flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
                 title={isSideToolbarCollapsed ? '展开工具栏' : '折叠工具栏'}
             >
                 <div className={`transition-transform duration-300 ${isSideToolbarCollapsed ? '' : 'rotate-180'}`}>{ICONS.CHEVRON_LEFT}</div>

--- a/src/components/side-toolbar/ColorControl.tsx
+++ b/src/components/side-toolbar/ColorControl.tsx
@@ -10,6 +10,7 @@ interface ColorControlProps {
     beginCoalescing: () => void;
     endCoalescing: () => void;
     disabled?: boolean;
+    className?: string;
 }
 
 export const ColorControl: React.FC<ColorControlProps> = React.memo(({
@@ -18,7 +19,8 @@ export const ColorControl: React.FC<ColorControlProps> = React.memo(({
     setColor,
     beginCoalescing,
     endCoalescing,
-    disabled = false
+    disabled = false,
+    className = ''
 }) => {
     const isTransparent = color === 'transparent' || (color.includes('rgba') && color.endsWith('0)')) || (color.includes('hsla') && color.endsWith('0)'));
     const checkerboardStyle = {
@@ -28,7 +30,7 @@ export const ColorControl: React.FC<ColorControlProps> = React.memo(({
     };
 
     return (
-        <div className={`flex flex-col items-center w-14 transition-opacity ${disabled ? 'opacity-50' : ''}`} title={label}>
+        <div className={`flex flex-col items-center w-14 transition-opacity ${disabled ? 'opacity-50' : ''} ${className}`} title={label}>
             <FloatingColorPicker
                 color={color}
                 onChange={setColor}

--- a/src/components/side-toolbar/ColorControl.tsx
+++ b/src/components/side-toolbar/ColorControl.tsx
@@ -42,7 +42,7 @@ export const ColorControl: React.FC<ColorControlProps> = React.memo(({
                         ref={ref as any}
                         onClick={onClick}
                         disabled={disabled}
-                        className="h-8 w-8 rounded-full ring-1 ring-inset ring-white/10 transition-transform transform hover:scale-110 disabled:cursor-not-allowed disabled:hover:scale-100"
+                        className="h-7 w-7 rounded-full ring-1 ring-inset ring-white/10 transition-transform transform hover:scale-110 disabled:cursor-not-allowed disabled:hover:scale-100"
                         style={{
                             backgroundColor: color,
                             ...(isTransparent && checkerboardStyle)

--- a/src/components/side-toolbar/DashControl.tsx
+++ b/src/components/side-toolbar/DashControl.tsx
@@ -42,38 +42,38 @@ export const DashControl: React.FC<DashControlProps> = React.memo((props) => {
                             <div className={`space-y-3 transition-opacity ${!dashGap.isDashed ? 'opacity-50 pointer-events-none' : ''}`}>
                                 <div className="grid grid-cols-2 items-center gap-2">
                                     <label htmlFor="dash-length-input" className="text-sm font-medium text-[var(--text-primary)]">虚线长度</label>
-                                    <div className="flex items-center bg-black/20 rounded-md h-8 px-2 cursor-ns-resize" onWheel={dashGap.handleDashWheel} title="使用滚轮调节">
-                                        <input 
+                                    <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] cursor-ns-resize" onWheel={dashGap.handleDashWheel} title="使用滚轮调节">
+                                        <input
                                             id="dash-length-input"
-                                            type="text" 
-                                            inputMode="numeric" 
-                                            pattern="[0-9]*" 
-                                            value={dashGap.localDash} 
-                                            onChange={(e) => dashGap.setLocalDash(e.target.value.replace(/[^0-9]/g, ''))} 
-                                            onBlur={dashGap.handleCommit} 
-                                            onKeyDown={(e) => { if (e.key === 'Enter') { dashGap.handleCommit(); (e.currentTarget as HTMLInputElement).blur(); }}} 
-                                            className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)]" 
-                                            aria-label="虚线长度" 
+                                            type="text"
+                                            inputMode="numeric"
+                                            pattern="[0-9]*"
+                                            value={dashGap.localDash}
+                                            onChange={(e) => dashGap.setLocalDash(e.target.value.replace(/[^0-9]/g, ''))}
+                                            onBlur={dashGap.handleCommit}
+                                            onKeyDown={(e) => { if (e.key === 'Enter') { dashGap.handleCommit(); (e.currentTarget as HTMLInputElement).blur(); }}}
+                                            className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)]"
+                                            aria-label="虚线长度"
                                         />
-                                        <span className="text-sm text-[var(--text-secondary)]">px</span>
+                                        <span className="text-xs text-[var(--text-secondary)]">px</span>
                                     </div>
                                 </div>
                                 <div className="grid grid-cols-2 items-center gap-2">
                                     <label htmlFor="dash-gap-input" className="text-sm font-medium text-[var(--text-primary)]">虚线间隔</label>
-                                    <div className="flex items-center bg-black/20 rounded-md h-8 px-2 cursor-ns-resize" onWheel={dashGap.handleGapWheel} title="使用滚轮调节">
-                                        <input 
+                                    <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] cursor-ns-resize" onWheel={dashGap.handleGapWheel} title="使用滚轮调节">
+                                        <input
                                             id="dash-gap-input"
-                                            type="text" 
-                                            inputMode="numeric" 
-                                            pattern="[0-9]*" 
-                                            value={dashGap.localGap} 
-                                            onChange={(e) => dashGap.setLocalGap(e.target.value.replace(/[^0-9]/g, ''))} 
-                                            onBlur={dashGap.handleCommit} 
-                                            onKeyDown={(e) => { if (e.key === 'Enter') { dashGap.handleCommit(); (e.currentTarget as HTMLInputElement).blur(); }}} 
-                                            className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)]" 
-                                            aria-label="虚线间隔" 
+                                            type="text"
+                                            inputMode="numeric"
+                                            pattern="[0-9]*"
+                                            value={dashGap.localGap}
+                                            onChange={(e) => dashGap.setLocalGap(e.target.value.replace(/[^0-9]/g, ''))}
+                                            onBlur={dashGap.handleCommit}
+                                            onKeyDown={(e) => { if (e.key === 'Enter') { dashGap.handleCommit(); (e.currentTarget as HTMLInputElement).blur(); }}}
+                                            className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)]"
+                                            aria-label="虚线间隔"
                                         />
-                                        <span className="text-sm text-[var(--text-secondary)]">px</span>
+                                        <span className="text-xs text-[var(--text-secondary)]">px</span>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -71,7 +71,7 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
   return (
     <div className="flex flex-col items-center w-16" title={label}>
       <div
-        className="flex items-center bg-black/20 rounded-md h-9 px-2 w-full cursor-ns-resize"
+        className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-full cursor-ns-resize"
         onWheel={(e) => handleWheel(e, handleWheelUpdate)}
       >
         <input
@@ -94,10 +94,10 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
               e.currentTarget.blur();
             }
           }}
-          className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)]"
+          className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)]"
           aria-label={label}
         />
-        <span className="input-unit text-sm text-[var(--text-secondary)]">{unit}</span>
+        <span className="text-xs text-[var(--text-secondary)]">{unit}</span>
       </div>
     </div>
   );

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -69,7 +69,7 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
   const handleWheel = useWheelCoalescer(beginCoalescing, endCoalescing);
 
   return (
-    <div className="flex flex-col items-center w-16" title={label}>
+    <div className="flex flex-col items-center w-14" title={label}>
       <div
         className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-full cursor-ns-resize"
         onWheel={(e) => handleWheel(e, handleWheelUpdate)}

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -97,7 +97,7 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
           className="w-full bg-transparent text-sm text-center outline-none text-[var(--text-primary)]"
           aria-label={label}
         />
-        <span className="text-sm text-[var(--text-secondary)]">{unit}</span>
+        <span className="input-unit text-sm text-[var(--text-secondary)]">{unit}</span>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -112,16 +112,8 @@ textarea {
   -ms-user-select: auto;
   user-select: auto;
   font-size: 85%;
-  transform: scale(0.85);
-  transform-origin: top left;
 }
 
-/* Scale unit labels to match compact inputs */
-.input-unit {
-  font-size: 85%;
-  transform: scale(0.85);
-  transform-origin: top left;
-}
 
 body.light-bg-canvas {
   --grid-line: rgba(0, 0, 0, 0.15);

--- a/src/index.css
+++ b/src/index.css
@@ -111,6 +111,9 @@ textarea {
   -moz-user-select: auto;
   -ms-user-select: auto;
   user-select: auto;
+  font-size: 85%;
+  transform: scale(0.85);
+  transform-origin: top left;
 }
 
 body.light-bg-canvas {

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,13 @@ textarea {
   transform-origin: top left;
 }
 
+/* Scale unit labels to match compact inputs */
+.input-unit {
+  font-size: 85%;
+  transform: scale(0.85);
+  transform-origin: top left;
+}
+
 body.light-bg-canvas {
   --grid-line: rgba(0, 0, 0, 0.15);
   --subgrid-line: rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- Reduce top toolbar and right sidebar button size by 15%
- Align main menu button spacing and height with layers panel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c695cadb5c832386d593ce932ee56f