### PR TITLE
fix(view): disable passive wheel listener

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -42,7 +42,7 @@ interface WhiteboardProps {
   onPointerMove: (e: React.PointerEvent<SVGSVGElement>) => void;
   onPointerUp: (e: React.PointerEvent<SVGSVGElement>) => void;
   onPointerLeave: (e: React.PointerEvent<SVGSVGElement>) => void;
-  onWheel: (e: React.WheelEvent<HTMLDivElement>) => void;
+  onWheel: (e: WheelEvent) => void;
   onContextMenu: (e: React.MouseEvent<HTMLDivElement>) => void;
   viewTransform: { scale: number, translateX: number, translateY: number };
   cursor: string;
@@ -109,6 +109,16 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
       setRc(rough.svg(svgRef.current));
     }
   }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const handle = (e: WheelEvent) => onWheel(e);
+    el.addEventListener('wheel', handle, { passive: false });
+    return () => {
+      el.removeEventListener('wheel', handle);
+    };
+  }, [onWheel]);
 
   /**
    * 处理指针在 SVG 画布上移动的事件。
@@ -177,7 +187,6 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
     <div
       ref={containerRef}
       className="w-full h-full bg-transparent overflow-hidden touch-none overscroll-none"
-      onWheel={onWheel}
       style={{ cursor }}
       onContextMenu={onContextMenu}
     >

--- a/src/context/viewTransformStore.ts
+++ b/src/context/viewTransformStore.ts
@@ -26,7 +26,7 @@ export interface ViewTransformState {
   setViewTransform: (updater: (prev: ViewTransform) => ViewTransform) => void;
   setLastPointerPosition: (p: Point | null) => void;
 
-  handleWheel: (e: React.WheelEvent<HTMLDivElement>) => void;
+  handleWheel: (e: WheelEvent) => void;
   handlePanMove: (e: React.PointerEvent<SVGSVGElement>) => void;
   handleTouchStart: (e: React.PointerEvent<SVGSVGElement>) => void;
   handleTouchMove: (e: React.PointerEvent<SVGSVGElement>) => void;


### PR DESCRIPTION
## Summary
- attach wheel handler with `{ passive: false }` so preventDefault works
- type view transform wheel handler for native `WheelEvent`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c7128ef48323b1739a4fa935d560