### PR TITLE
refactor: remove obsolete fix comments

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -7,7 +7,6 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
-// FIX: Import ImageData type for the croppingState prop.
 import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '../types';
 import { getPointerPosition } from '../lib/utils';
 import { useViewTransformStore } from '@/context/viewTransformStore';
@@ -19,13 +18,11 @@ import { LivePreviewRenderer } from './whiteboard/LivePreviewRenderer';
 import { ControlsRenderer } from './whiteboard/ControlsRenderer';
 import { Marquee } from './whiteboard/Marquee';
 import { Lasso } from './whiteboard/Lasso';
-// FIX: Import CropOverlay component to render the crop mask.
 import { CropOverlay } from './whiteboard/CropOverlay';
 
 
 interface WhiteboardProps {
   paths: AnyPath[];
-  // FIX: Add onionSkinPaths prop to fix type error in MainLayout.tsx.
   onionSkinPaths: AnyPath[];
   backgroundPaths: AnyPath[];
   tool: Tool;
@@ -52,7 +49,6 @@ interface WhiteboardProps {
   gridOpacity: number;
   dragState: DragState | null;
   editingTextPathId: string | null;
-  // FIX: Add croppingState prop to fix type error in MainLayout.tsx.
   croppingState: { pathId: string; originalPath: ImageData; } | null;
   currentCropRect: BBox | null;
 }
@@ -65,7 +61,6 @@ interface WhiteboardProps {
  */
 export const Whiteboard: React.FC<WhiteboardProps> = ({
   paths,
-  // FIX: Destructure the new onionSkinPaths prop.
   onionSkinPaths,
   backgroundPaths,
   tool,
@@ -92,7 +87,6 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   gridOpacity,
   dragState,
   editingTextPathId,
-  // FIX: Destructure the new croppingState prop.
   croppingState,
   currentCropRect,
 }) => {
@@ -194,7 +188,6 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
         <g style={{ transform: `translate(${viewTransform.translateX}px, ${viewTransform.translateY}px) scale(${viewTransform.scale})` }}>
           
           <PathsRenderer paths={backgroundPaths} rc={rc} isBackground />
-          {/* FIX: Render the onion skin paths. */}
           <PathsRenderer paths={onionSkinPaths} rc={rc} />
           <PathsRenderer paths={visiblePaths} rc={rc} />
 
@@ -208,7 +201,6 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
             viewTransform={viewTransform}
           />
           
-          {/* FIX: Render the crop overlay when in cropping mode. */}
           {croppingState && currentCropRect && <CropOverlay croppingState={croppingState} currentCropRect={currentCropRect} />}
 
           <ControlsRenderer

--- a/src/components/whiteboard/PathsRenderer.tsx
+++ b/src/components/whiteboard/PathsRenderer.tsx
@@ -55,7 +55,6 @@ const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.m
     return <g className="pointer-events-none" dangerouslySetInnerHTML={{ __html: nodeString }} />;
 });
 
-// FIX: Export a `RoughPath` component to be used for live previews in other components.
 /**
  * Renders a single non-group path using RoughJS.
  * This is optimized for live previews where we don't need group recursion or frame logic.

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -7,7 +7,6 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
-// FIX: Import ImageData type for the croppingState prop.
 import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '../../types';
 import { getPointerPosition } from '../../lib/utils';
 import { useViewTransformStore } from '@/context/viewTransformStore';
@@ -19,7 +18,6 @@ import { LivePreviewRenderer } from './LivePreviewRenderer';
 import { ControlsRenderer } from './ControlsRenderer';
 import { Marquee } from './Marquee';
 import { Lasso } from './Lasso';
-// FIX: Import CropOverlay component to render the crop mask.
 import { CropOverlay } from './CropOverlay';
 
 
@@ -51,7 +49,6 @@ interface WhiteboardProps {
   gridOpacity: number;
   dragState: DragState | null;
   editingTextPathId: string | null;
-  // FIX: Add croppingState prop to fix type error in MainLayout.tsx.
   croppingState: { pathId: string; originalPath: ImageData; } | null;
   currentCropRect: BBox | null;
 }
@@ -90,7 +87,6 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   gridOpacity,
   dragState,
   editingTextPathId,
-  // FIX: Destructure the new croppingState prop.
   croppingState,
   currentCropRect,
 }) => {
@@ -187,7 +183,6 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
             viewTransform={viewTransform}
           />
           
-          {/* FIX: Render the crop overlay when in cropping mode. */}
           {croppingState && currentCropRect && <CropOverlay croppingState={croppingState} currentCropRect={currentCropRect} />}
 
           <ControlsRenderer

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -23,7 +23,6 @@ import {
   Sparkles, Languages, GripVertical,
   Blend,Slash,MoveRight,
   Play, Pause, Rewind, ChevronUp, Wand2,SquaresExclude,SquaresIntersect,SquaresSubtract,SquaresUnite,
-  // FIX: `RectangleDashed` is not a valid icon in `lucide-react`. Replaced with `SquareDashed`.
   SquareDashed,
   RotateCcw,
 } from 'lucide-react';

--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -1,7 +1,6 @@
 /**
  * 本文件包含了 useSelection hook 中处理 pointerDown 事件的复杂逻辑。
  */
-// FIX: Removed 'React' from type import as it's not used and can cause errors.
 import type { MutableRefObject } from 'react';
 import type { Point, DragState, AnyPath, VectorPathData, ResizeHandlePosition, ImageData, BBox, GroupData, ArcData } from '../../types';
 import { updatePathAnchors, insertAnchorOnCurve, getSqDistToSegment, getPathsBoundingBox, dist, sampleCubicBezier, rotateResizeHandle } from '../../lib/drawing';
@@ -213,7 +212,6 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
                  } else setDragState({ type: (e.shiftKey && type === 'anchor' ? 'handleOut' : type), pathId, anchorIndex });
             } else if (handle === 'border-radius' && (path.tool === 'rectangle' || path.tool === 'image' || path.tool === 'polygon')) setDragState({ type: 'border-radius', pathId, originalPath: path, initialPointerPos: point });
             else if (handle === 'arc' && path.tool === 'arc' && target.dataset.pointIndex) setDragState({ type: 'arc', pathId, pointIndex: parseInt(target.dataset.pointIndex, 10) as 0 | 1 | 2 });
-            // FIX: Ensure `handle` is of type `ResizeHandlePosition` before creating a resize state.
             else if (handle && handle !== 'rotate' && handle !== 'border-radius' && handle !== 'arc') {
                 if (path.tool === 'rectangle' || path.tool === 'ellipse' || path.tool === 'image' || path.tool === 'polygon' || path.tool === 'text' || path.tool === 'frame') setDragState({ type: 'resize', pathId, handle, originalPath: path as any, initialPointerPos: point });
             }

--- a/src/hooks/selection-logic/pointerMove.ts
+++ b/src/hooks/selection-logic/pointerMove.ts
@@ -1,15 +1,13 @@
 /**
  * 本文件包含了 useSelection hook 中处理 pointerMove 事件的复杂逻辑。
  */
-// FIX: Removed 'React' from type import as it's not used and can cause errors.
 import type { MutableRefObject } from 'react';
 import type { Point, DragState, AnyPath, RectangleData } from '../../types';
 import { updatePathAnchors, movePath, rotatePath, getPathsBoundingBox, resizePath, scalePath, transformCropRect, dist } from '../../lib/drawing';
 import { isPointHittingPath } from '../../lib/hit-testing';
 import { recursivelyUpdatePaths } from './utils';
 
-// FIX: Define HIT_RADIUS as it was missing in this file.
-const HIT_RADIUS = 10;
+const HIT_RADIUS = 10; // 点击命中控制点的半径
 
 // Coalesce frequent move-updates into a single render per frame to improve
 // responsiveness when dragging, especially for large groups or rough shapes.
@@ -45,7 +43,6 @@ export const handlePointerMoveLogic = (props: HandlePointerMoveProps) => {
     const { selectionMode } = toolbarState;
     const { viewTransform: vt } = viewTransform;
 
-    // FIX: Pass a value instead of a function to setLassoPath, as its type signature expects a value.
     if (lassoPath) { setLassoPath([...(lassoPath ?? []), movePoint]); return; }
     if (dragState) {
         if (dragState.type === 'crop') {
@@ -102,7 +99,6 @@ export const handlePointerMoveLogic = (props: HandlePointerMoveProps) => {
                 setPaths(recursivelyUpdatePaths(paths, (p: AnyPath) => {
                     if (p.id === pathId && p.tool === 'arc') {
                         const newPoints = [...(p as any).points]; newPoints[pointIndex] = snappedMovePoint; 
-                        // FIX: Cast `newPoints` to the correct tuple type to satisfy ArcData.
                         return { ...p, points: newPoints as [Point, Point, Point] };
                     } return null;
                 })); return;

--- a/src/hooks/selection-logic/pointerUp.ts
+++ b/src/hooks/selection-logic/pointerUp.ts
@@ -1,7 +1,6 @@
 /**
  * 本文件包含了 useSelection hook 中处理 pointerUp 事件的复杂逻辑。
  */
-// FIX: Removed 'React' from type import as it's not used and can cause errors.
 import type { MutableRefObject } from 'react';
 import type { Point, DragState, AnyPath, BBox } from '../../types';
 import { getMarqueeRect } from '../../lib/drawing';

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -11,13 +11,10 @@ import { useAppContext } from '../context/AppContext';
 
 
 const useGlobalEventHandlers = () => {
-  // FIX: Destructure all properties directly from the store returned by useAppContext.
-  // The original code had incorrect destructuring assumptions causing multiple errors.
   const {
     selectedPathIds, setSelectedPathIds,
     currentPenPath, handleCancelPenPath, handleFinishPenPath,
     currentLinePath, handleCancelLinePath, handleFinishLinePath,
-    // FIX: Replaced `handleUndo` and `handleRedo` with aliased `undo: handleUndo` and `redo: handleRedo` to match properties from the context.
     undo: handleUndo, redo: handleRedo, handleDeleteSelected, setPaths,
     beginCoalescing, endCoalescing,
     tool, selectionMode, handleSetTool: setTool, setSelectionMode,
@@ -32,7 +29,6 @@ const useGlobalEventHandlers = () => {
     cancelCrop,
   } = useAppContext();
 
-  // FIX: Destructure drawingShape and cancelDrawingShape from the drawingInteraction object.
   const { drawingShape, cancelDrawingShape } = drawingInteraction;
 
   const nudgeTimeoutRef = useRef<number | null>(null);

--- a/src/hooks/useGroupIsolation.ts
+++ b/src/hooks/useGroupIsolation.ts
@@ -14,7 +14,6 @@ type PathState = {
  * @param pathState - 包含根路径及其设置器的对象。
  * @returns 返回隔离模式的状态和操作函数。
  */
-// FIX: Remove the restrictive `PathState` type annotation to allow the full type from `usePaths` to be inferred.
 export const useGroupIsolation = (pathState: any) => {
   const [groupIsolationPath, setGroupIsolationPath] = useState<AnyPath[]>([]);
 

--- a/src/hooks/usePointerInteraction.ts
+++ b/src/hooks/usePointerInteraction.ts
@@ -109,7 +109,6 @@ export const usePointerInteraction = ({
     }
     if (isPanning) {
       if (e.currentTarget && e.currentTarget.hasPointerCapture(e.pointerId)) {
-        // FIX: Corrected method name to releasePointerCapture and completed the function.
         e.currentTarget.releasePointerCapture(e.pointerId);
       }
       setIsPanning(false);

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -5,7 +5,6 @@
  */
 import React, { useState, useRef, useCallback, useEffect } from 'react';
 import type { Point, DragState, AnyPath, ImageData, BBox } from '../types';
-// FIX: Correct the import path to point to the index file within the directory, avoiding the empty 'selection-logic.ts' file.
 import { handlePointerDownLogic, handlePointerMoveLogic, handlePointerUpLogic } from './selection-logic/index';
 
 // 定义 Hook 将接收的 props

--- a/src/hooks/useToolbarState.ts
+++ b/src/hooks/useToolbarState.ts
@@ -94,8 +94,6 @@ export const useToolbarState = (
           return { ...path, ...finalProps, tool: 'group', children: updatedChildren };
       }
       
-      // FIX: Cast the return type to AnyPath to resolve a complex TypeScript inference issue
-      // where the spread operator on a union type results in a type that's too wide.
       return { ...path, ...finalProps } as AnyPath;
     };
 

--- a/src/lib/drawing/transform.ts
+++ b/src/lib/drawing/transform.ts
@@ -438,10 +438,7 @@ export async function flipPath(path: AnyPath, center: Point, axis: 'horizontal' 
             } else if (path.tool === 'polygon') {
                 vectorPath = polygonToVectorPath(path as PolygonData);
             } else {
-                 // FIX: This `else` block is unreachable because the `case` statement covers all possible tool types.
-                 // The original code `...path` caused a "Spread types may only be created from object types" error
-                 // because TypeScript correctly inferred `path` as `never` here.
-                 // Replacing it with a `throw` makes the logic explicit and safe, resolving the type error.
+                 // Unreachable: all tool types are handled above; throw for safety.
                  throw new Error(`Unreachable code: unexpected tool '${(path as AnyPath).tool}' in flipPath`);
             }
             

--- a/src/lib/export/png/export.ts
+++ b/src/lib/export/png/export.ts
@@ -6,8 +6,6 @@ import type { AnyPath, PngExportOptions, BBox, FrameData } from '../../types';
 import { getPathsBoundingBox } from '../../drawing';
 import { pathsToSvgString } from '../svg/export';
 
-// FIX: Explicitly define all properties instead of extending PngExportOptions
-// to avoid TypeScript resolution issues in some environments.
 interface PngExportCoreOptions {
   backgroundColor: string;
   scale: number;
@@ -15,7 +13,6 @@ interface PngExportCoreOptions {
   transparentBg: boolean;
   overrideBbox?: BBox;
   clipFrame?: FrameData;
-  // FIX: Add the missing 'padding' property to fix a TypeScript error.
   padding?: number;
 }
 


### PR DESCRIPTION
## Summary
- remove resolved `FIX:` annotations across hooks, components, and utilities
- clarify unreachable branch in `flipPath` by throwing explicit error
- document pointer hit radius constant for selection logic

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c736b4f083238c7e7402780d8645