### PR TITLE
refactor(selection): type selection state interfaces

### DIFF
--- a/src/hooks/selection-logic/pointerMove.ts
+++ b/src/hooks/selection-logic/pointerMove.ts
@@ -2,8 +2,17 @@
  * 本文件包含了 useSelection hook 中处理 pointerMove 事件的复杂逻辑。
  */
 // FIX: Removed 'React' from type import as it's not used and can cause errors.
-import type { MutableRefObject } from 'react';
-import type { Point, DragState, AnyPath, RectangleData } from '../../types';
+import type { MutableRefObject, Dispatch, SetStateAction } from 'react';
+import type {
+  Point,
+  DragState,
+  AnyPath,
+  RectangleData,
+  BBox,
+  SelectionPathState,
+  SelectionToolbarState,
+  SelectionViewTransform,
+} from '../../types';
 import { updatePathAnchors, movePath, rotatePath, getPathsBoundingBox, resizePath, scalePath, transformCropRect, dist } from '../../lib/drawing';
 import { isPointHittingPath } from '../../lib/hit-testing';
 import { recursivelyUpdatePaths } from './utils';
@@ -22,17 +31,17 @@ interface HandlePointerMoveProps {
   movePoint: Point;
   dragState: DragState;
   marquee: { start: Point; end: Point } | null;
-  setMarquee: (marquee: { start: Point; end: Point } | null) => void;
+  setMarquee: Dispatch<SetStateAction<{ start: Point; end: Point } | null>>;
   lassoPath: Point[] | null;
-  setLassoPath: (path: Point[] | null) => void;
-  pathState: any;
-  toolbarState: any;
-  viewTransform: any;
+  setLassoPath: Dispatch<SetStateAction<Point[] | null>>;
+  pathState: SelectionPathState;
+  toolbarState: SelectionToolbarState;
+  viewTransform: SelectionViewTransform;
   setIsHoveringMovable: (hovering: boolean) => void;
   setIsHoveringEditable: (hovering: boolean) => void;
   isClosingPath: MutableRefObject<{ pathId: string; anchorIndex: number } | null>;
   snapToGrid: (point: Point) => Point;
-  setCurrentCropRect: (rect: any) => void;
+  setCurrentCropRect: Dispatch<SetStateAction<BBox | null>>;
 }
 
 /**

--- a/src/hooks/selection-logic/pointerUp.ts
+++ b/src/hooks/selection-logic/pointerUp.ts
@@ -2,20 +2,26 @@
  * 本文件包含了 useSelection hook 中处理 pointerUp 事件的复杂逻辑。
  */
 // FIX: Removed 'React' from type import as it's not used and can cause errors.
-import type { MutableRefObject } from 'react';
-import type { Point, DragState, AnyPath, BBox } from '../../types';
+import type { MutableRefObject, Dispatch, SetStateAction } from 'react';
+import type {
+  Point,
+  DragState,
+  AnyPath,
+  BBox,
+  SelectionPathState,
+} from '../../types';
 import { getMarqueeRect } from '../../lib/drawing';
 import { isPathIntersectingMarquee, isPathIntersectingLasso } from '../../lib/hit-testing';
 
 interface HandlePointerUpProps {
   e: React.PointerEvent<SVGSVGElement>;
   dragState: DragState;
-  setDragState: (state: DragState) => void;
+  setDragState: Dispatch<SetStateAction<DragState>>;
   marquee: { start: Point; end: Point } | null;
-  setMarquee: (marquee: { start: Point; end: Point } | null) => void;
+  setMarquee: Dispatch<SetStateAction<{ start: Point; end: Point } | null>>;
   lassoPath: Point[] | null;
-  setLassoPath: (path: Point[] | null) => void;
-  pathState: any;
+  setLassoPath: Dispatch<SetStateAction<Point[] | null>>;
+  pathState: SelectionPathState;
   isClosingPath: MutableRefObject<{ pathId: string; anchorIndex: number } | null>;
   pushCropHistory?: (rect: BBox) => void;
 }

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -4,15 +4,24 @@
  * 该 Hook 协调状态管理，并将复杂的事件处理逻辑委托给 `selection-logic.ts`。
  */
 import React, { useState, useRef, useCallback, useEffect } from 'react';
-import type { Point, DragState, AnyPath, ImageData, BBox } from '../types';
+import type {
+  Point,
+  DragState,
+  AnyPath,
+  ImageData,
+  BBox,
+  SelectionPathState,
+  SelectionToolbarState,
+  SelectionViewTransform,
+} from '../types';
 // FIX: Correct the import path to point to the index file within the directory, avoiding the empty 'selection-logic.ts' file.
 import { handlePointerDownLogic, handlePointerMoveLogic, handlePointerUpLogic } from './selection-logic/index';
 
 // 定义 Hook 将接收的 props
 interface SelectionInteractionProps {
-  pathState: any; // from usePaths
-  toolbarState: any; // from useToolbarState
-  viewTransform: any; // from useViewTransform
+  pathState: SelectionPathState; // from usePaths
+  toolbarState: SelectionToolbarState; // from useToolbarState
+  viewTransform: SelectionViewTransform; // from useViewTransform
   isGridVisible: boolean;
   gridSize: number;
   gridSubdivisions: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
  * 本文件定义了整个应用中使用的所有 TypeScript 类型和接口。
  * 这有助于确保代码的类型安全和可读性，定义了如点、路径、工具等核心数据结构。
  */
+import type { Dispatch, SetStateAction } from 'react';
 
 export interface Point {
   x: number;
@@ -328,3 +329,27 @@ type CropDragState = {
 
 // Union of all possible drag states
 export type DragState = VectorDragState | MoveDragState | ResizeDragState | ScaleDragState | RotateDragState | BorderRadiusDragState | ArcDragState | CropDragState | null;
+
+export interface SelectionPathState {
+  paths: AnyPath[];
+  setPaths: Dispatch<SetStateAction<AnyPath[]>>;
+  selectedPathIds: string[];
+  setSelectedPathIds: Dispatch<SetStateAction<string[]>>;
+  beginCoalescing: () => void;
+  endCoalescing: () => void;
+}
+
+export interface SelectionToolbarState {
+  selectionMode: SelectionMode;
+}
+
+export interface CanvasViewTransform {
+  scale: number;
+  translateX: number;
+  translateY: number;
+}
+
+export interface SelectionViewTransform {
+  viewTransform: CanvasViewTransform;
+  getPointerPosition: (e: { clientX: number; clientY: number }, svg: SVGSVGElement) => Point;
+}


### PR DESCRIPTION
## Summary
- define `SelectionPathState`, `SelectionToolbarState`, and `SelectionViewTransform`
- update selection hook and pointer handlers to use typed interfaces instead of `any`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c73dcd508323a7d8c7c6eaa98d93