### PR TITLE
fix(touch): disable default svg gestures

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -192,7 +192,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
     >
       <svg
         ref={svgRef}
-        className="w-full h-full"
+        className="w-full h-full touch-none"
         onPointerDown={onPointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={onPointerUp}

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -163,7 +163,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
     >
       <svg
         ref={svgRef}
-        className="w-full h-full"
+        className="w-full h-full touch-none"
         onPointerDown={onPointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={onPointerUp}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,7 +12,7 @@ import { registerSW } from 'virtual:pwa-register';
 
 // 阻止浏览器默认手势（捏合缩放、双指滑动回退等）
 const preventDefault = (e: Event) => e.preventDefault();
-['gesturestart', 'gesturechange', 'gestureend', 'touchstart', 'touchmove'].forEach(evt => {
+['gesturestart', 'gesturechange', 'gestureend'].forEach(evt => {
   window.addEventListener(evt, preventDefault, { passive: false });
 });
 


### PR DESCRIPTION
## Summary
- prevent default browser gestures on the whiteboard SVG so touch interactions work correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7ca106b94832398143bf98fa7dbf1