### PR TITLE
refactor: replace relative imports with alias

### DIFF
--- a/src/components/layers-panel/LayerItem.tsx
+++ b/src/components/layers-panel/LayerItem.tsx
@@ -3,9 +3,9 @@
  * 它负责渲染图层名称、图标和操作按钮，并处理用户交互。
  */
 import React, { useState, useRef, useEffect } from 'react';
-import type { AnyPath, GroupData } from '../../types';
-import { ICONS } from '../../constants';
-import { useLayers } from '../../lib/layers-context';
+import type { AnyPath, GroupData } from '@/types';
+import { ICONS } from '@/constants';
+import { useLayers } from '@/lib/layers-context';
 import { getToolIcon, capitalize, withLayerIconSize } from './constants';
 import PanelButton from '@/components/PanelButton';
 

--- a/src/components/layers-panel/LayersPanel.tsx
+++ b/src/components/layers-panel/LayersPanel.tsx
@@ -4,9 +4,9 @@
  * 并使用 Context 获取和操作图层数据。
  */
 import React, { useState, useRef } from 'react';
-import type { AnyPath, GroupData } from '../../types';
-import { ICONS } from '../../constants';
-import { useLayers } from '../../lib/layers-context';
+import type { AnyPath, GroupData } from '@/types';
+import { ICONS } from '@/constants';
+import { useLayers } from '@/lib/layers-context';
 import { useAppContext } from '@/context/AppContext';
 import { LayerItem } from './LayerItem';
 import PanelButton from '@/components/PanelButton';

--- a/src/components/layers-panel/constants.ts
+++ b/src/components/layers-panel/constants.ts
@@ -2,8 +2,8 @@
  * 本文件存放图层面板相关的常量和辅助函数。
  */
 import React from 'react';
-import { ICONS } from '../../constants';
-import type { AnyPath, GroupData } from '../../types';
+import { ICONS } from '@/constants';
+import type { AnyPath, GroupData } from '@/types';
 
 /**
  * 将图标尺寸调整为与菜单统一

--- a/src/components/layout/AboutButton.tsx
+++ b/src/components/layout/AboutButton.tsx
@@ -4,9 +4,9 @@
  */
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { useAppContext } from '../../context/AppContext';
+import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS } from '../../constants';
+import { CONTROL_BUTTON_CLASS } from '@/constants';
 
 const links = [
   { name: 'vtracer - PNG转矢量工具', href: 'https://www.visioncortex.org/vtracer/' },

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -4,9 +4,9 @@
  */
 import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppContext } from '../../context/AppContext';
+import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS } from '../../constants';
+import { CONTROL_BUTTON_CLASS } from '@/constants';
 import { Toolbar } from '../Toolbar';
 import { SelectionToolbar } from '../SelectionToolbar';
 import { ContextMenu } from '../ContextMenu';
@@ -16,9 +16,9 @@ import { ConfirmationDialog } from '../ConfirmationDialog';
 import { Breadcrumbs } from '../Breadcrumbs';
 import { AboutButton } from './AboutButton';
 import { CropToolbar } from '../CropToolbar';
-import type { AnyPath, TextData, MaterialData } from '../../types';
-import { ICONS } from '../../constants';
-import { getPathsBoundingBox, getPathBoundingBox } from '../../lib/drawing';
+import type { AnyPath, TextData, MaterialData } from '@/types';
+import { ICONS } from '@/constants';
+import { getPathsBoundingBox, getPathBoundingBox } from '@/lib/drawing';
 
 // Helper to define context menu actions
 const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);

--- a/src/components/layout/MainMenuPanel.tsx
+++ b/src/components/layout/MainMenuPanel.tsx
@@ -3,10 +3,10 @@
  * 它包含了主菜单，并管理其宽度调整逻辑。
  */
 import React, { useState, useMemo } from 'react';
-import { useAppContext } from '../../context/AppContext';
+import { useAppContext } from '@/context/AppContext';
 import { MainMenu } from '../MainMenu';
-import type { AnyPath } from '../../types';
-import { getPathsBoundingBox, getPathBoundingBox } from '../../lib/drawing';
+import type { AnyPath } from '@/types';
+import { getPathsBoundingBox, getPathBoundingBox } from '@/lib/drawing';
 
 export const MainMenuPanel: React.FC = () => {
     const {

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -3,9 +3,9 @@
  * 它包含侧边工具栏及其折叠/展开按钮。
  */
 import React from 'react';
-import { useAppContext } from '../../context/AppContext';
+import { useAppContext } from '@/context/AppContext';
 import { SideToolbar } from '../SideToolbar';
-import { ICONS, CONTROL_BUTTON_CLASS } from '../../constants';
+import { ICONS, CONTROL_BUTTON_CLASS } from '@/constants';
 import PanelButton from '@/components/PanelButton';
 
 /**

--- a/src/components/side-toolbar/DashControl.tsx
+++ b/src/components/side-toolbar/DashControl.tsx
@@ -1,9 +1,9 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { ICONS } from '../../constants';
-import type { EndpointStyle } from '../../types';
+import { ICONS } from '@/constants';
+import type { EndpointStyle } from '@/types';
 import PanelButton from '@/components/PanelButton';
-import { useDashGapInput } from '../../hooks/side-toolbar/useDashGapInput';
+import { useDashGapInput } from '@/hooks/side-toolbar/useDashGapInput';
 import { SwitchControl } from './shared';
 
 interface DashControlProps {

--- a/src/components/side-toolbar/EffectsPopover.tsx
+++ b/src/components/side-toolbar/EffectsPopover.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { ICONS } from '../../constants';
+import { ICONS } from '@/constants';
 import PanelButton from '@/components/PanelButton';
 import { SwitchControl, Slider, PopoverColorControl } from './shared';
 

--- a/src/components/side-toolbar/FillStyleControl.tsx
+++ b/src/components/side-toolbar/FillStyleControl.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { ICONS } from '../../constants';
+import { ICONS } from '@/constants';
 import { FILL_STYLES, FILL_STYLE_ICONS } from './constants';
 import PanelButton from '@/components/PanelButton';
 

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useWheelCoalescer } from '../../hooks/side-toolbar/useWheelCoalescer';
+import { useWheelCoalescer } from '@/hooks/side-toolbar/useWheelCoalescer';
 
 interface NumericInputProps {
   label: string;

--- a/src/components/side-toolbar/StrokeStylePopover.tsx
+++ b/src/components/side-toolbar/StrokeStylePopover.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { ICONS, ENDPOINT_STYLES } from '../../constants';
-import type { EndpointStyle } from '../../types';
+import { ICONS, ENDPOINT_STYLES } from '@/constants';
+import type { EndpointStyle } from '@/types';
 import PanelButton from '@/components/PanelButton';
 import { SwitchControl, Slider, EndpointGrid } from './shared';
 

--- a/src/components/side-toolbar/StyleLibraryPopover.tsx
+++ b/src/components/side-toolbar/StyleLibraryPopover.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useEffect, useState, useMemo, Fragment } from 'react';
 import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
-import { ICONS, DEFAULT_ROUGHNESS, DEFAULT_BOWING, DEFAULT_FILL_WEIGHT, DEFAULT_HACHURE_ANGLE, DEFAULT_HACHURE_GAP, DEFAULT_CURVE_TIGHTNESS, DEFAULT_CURVE_STEP_COUNT } from '../../constants';
-import type { AnyPath, StyleClipboardData, RectangleData, MaterialData } from '../../types';
-import { renderPathNode, pathsToSvgString } from '../../lib/export';
+import { ICONS, DEFAULT_ROUGHNESS, DEFAULT_BOWING, DEFAULT_FILL_WEIGHT, DEFAULT_HACHURE_ANGLE, DEFAULT_HACHURE_GAP, DEFAULT_CURVE_TIGHTNESS, DEFAULT_CURVE_STEP_COUNT } from '@/constants';
+import type { AnyPath, StyleClipboardData, RectangleData, MaterialData } from '@/types';
+import { renderPathNode, pathsToSvgString } from '@/lib/export';
 import { Tab, Popover, Transition } from '@headlessui/react';
 import PanelButton from '@/components/PanelButton';
 

--- a/src/components/side-toolbar/StylePropertiesPopover.tsx
+++ b/src/components/side-toolbar/StylePropertiesPopover.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { ICONS } from '../../constants';
+import { ICONS } from '@/constants';
 import PanelButton from '@/components/PanelButton';
 import { SwitchControl, Slider } from './shared';
 

--- a/src/components/side-toolbar/TextProperties.tsx
+++ b/src/components/side-toolbar/TextProperties.tsx
@@ -4,7 +4,7 @@
  */
 import React, { useLayoutEffect, useRef, Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { ICONS } from '../../constants';
+import { ICONS } from '@/constants';
 import { NumericInput } from './NumericInput';
 import PanelButton from '@/components/PanelButton';
 

--- a/src/components/side-toolbar/constants.ts
+++ b/src/components/side-toolbar/constants.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ICONS } from '../../constants';
-import type { EndpointStyle } from '../../types';
+import { ICONS } from '@/constants';
+import type { EndpointStyle } from '@/types';
 
 export const FILL_STYLE_ICONS = {
   solid: React.createElement("svg", { width: "20", height: "20", viewBox: "0 0 20 20", className: "w-5 h-5", fill: "currentColor" },

--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -4,8 +4,8 @@
  */
 
 import React from 'react';
-import type { AnyPath, VectorPathData, RectangleData, EllipseData, Point, DragState, Tool, SelectionMode, ResizeHandlePosition, ImageData, PolygonData, GroupData, ArcData, TextData, FrameData, BBox } from '../../types';
-import { getPathBoundingBox, getPathsBoundingBox, dist, getPathD, rotatePoint, calculateArcPathD, rotateResizeHandle } from '../../lib/drawing';
+import type { AnyPath, VectorPathData, RectangleData, EllipseData, Point, DragState, Tool, SelectionMode, ResizeHandlePosition, ImageData, PolygonData, GroupData, ArcData, TextData, FrameData, BBox } from '@/types';
+import { getPathBoundingBox, getPathsBoundingBox, dist, getPathD, rotatePoint, calculateArcPathD, rotateResizeHandle } from '@/lib/drawing';
 
 
 const VectorPathControls: React.FC<{ data: VectorPathData; scale: number; dragState: DragState | null; hoveredPoint: Point | null; }> = React.memo(({ data, scale, dragState, hoveredPoint }) => {

--- a/src/components/whiteboard/CropOverlay.tsx
+++ b/src/components/whiteboard/CropOverlay.tsx
@@ -3,7 +3,7 @@
  * 它会使裁剪区域外的图像变暗，以清晰地显示裁剪结果。
  */
 import React from 'react';
-import type { ImageData, BBox } from '../../types';
+import type { ImageData, BBox } from '@/types';
 
 interface CropOverlayProps {
   croppingState: { pathId: string; originalPath: ImageData };

--- a/src/components/whiteboard/Lasso.tsx
+++ b/src/components/whiteboard/Lasso.tsx
@@ -2,7 +2,7 @@
  * 本文件是 Whiteboard 的子组件，负责渲染拖拽套索选择时出现的虚线选择路径（Lasso）。
  */
 import React from 'react';
-import type { Point } from '../../types';
+import type { Point } from '@/types';
 
 interface LassoProps {
   lassoPath: Point[] | null;

--- a/src/components/whiteboard/LivePreviewRenderer.tsx
+++ b/src/components/whiteboard/LivePreviewRenderer.tsx
@@ -5,9 +5,9 @@
 
 import React from 'react';
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { LivePath, DrawingShape, VectorPathData } from '../../types';
-import { pointsToSimplePathD, anchorsToPathD } from '../../lib/path-fitting';
-import { getPolygonPathD } from '../../lib/drawing';
+import type { LivePath, DrawingShape, VectorPathData } from '@/types';
+import { pointsToSimplePathD, anchorsToPathD } from '@/lib/path-fitting';
+import { getPolygonPathD } from '@/lib/drawing';
 import { RoughPath } from './PathsRenderer';
 
 // For live brush previews, we use a simple, performant path.

--- a/src/components/whiteboard/Marquee.tsx
+++ b/src/components/whiteboard/Marquee.tsx
@@ -3,8 +3,8 @@
  */
 
 import React from 'react';
-import type { Point } from '../../types';
-import { getMarqueeRect } from '../../lib/drawing';
+import type { Point } from '@/types';
+import { getMarqueeRect } from '@/lib/drawing';
 
 interface MarqueeProps {
   marquee: { start: Point; end: Point } | null;

--- a/src/components/whiteboard/PathsRenderer.tsx
+++ b/src/components/whiteboard/PathsRenderer.tsx
@@ -5,8 +5,8 @@
 
 import React, { useMemo } from 'react';
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { AnyPath, FrameData, GroupData } from '../../types';
-import { renderPathNode } from '../../lib/export';
+import type { AnyPath, FrameData, GroupData } from '@/types';
+import { renderPathNode } from '@/lib/export';
 
 /**
  * 递归地查找并返回路径树中所有的画框对象。

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -7,8 +7,8 @@
 import React, { useRef, useEffect, useState, useMemo } from 'react';
 import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '../../types';
-import { getPointerPosition } from '../../lib/utils';
+import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '@/types';
+import { getPointerPosition } from '@/lib/utils';
 import { useViewTransformStore } from '@/context/viewTransformStore';
 
 // Import new sub-components

--- a/src/hooks/actions/useAppActions.ts
+++ b/src/hooks/actions/useAppActions.ts
@@ -8,7 +8,7 @@ import { useExportActions } from './useExportActions';
 import { useFileActions } from './useFileActions';
 import { useLibraryActions } from './useLibraryActions';
 import { useObjectActions } from './useObjectActions';
-import type { AnyPath, Point, Tool, WhiteboardData, StyleClipboardData, MaterialData, LibraryData, Alignment, DistributeMode, PngExportOptions, Frame, AnimationExportOptions } from '../../types';
+import type { AnyPath, Point, Tool, WhiteboardData, StyleClipboardData, MaterialData, LibraryData, Alignment, DistributeMode, PngExportOptions, Frame, AnimationExportOptions } from '@/types';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 
 // The props type is a combination of all props needed by the sub-hooks.

--- a/src/hooks/actions/useExportActions.ts
+++ b/src/hooks/actions/useExportActions.ts
@@ -2,11 +2,11 @@
  * 本文件定义了一个自定义 Hook，用于封装导出操作（如导出为 SVG、PNG）。
  */
 import { useCallback } from 'react';
-import { pathsToSvgString, pathsToPngBlob } from '../../lib/export';
+import { pathsToSvgString, pathsToPngBlob } from '@/lib/export';
 import { fileSave } from 'browser-fs-access';
 import type { AppActionsProps } from './useAppActions';
-import type { FrameData, AnimationExportOptions, ImageData } from '../../types';
-import { getPathBoundingBox, getPathsBoundingBox, doBboxesIntersect } from '../../lib/drawing';
+import type { FrameData, AnimationExportOptions, ImageData } from '@/types';
+import { getPathBoundingBox, getPathsBoundingBox, doBboxesIntersect } from '@/lib/drawing';
 import JSZip from 'jszip';
 
 /**

--- a/src/hooks/actions/useFileActions.ts
+++ b/src/hooks/actions/useFileActions.ts
@@ -2,11 +2,11 @@
  * 本文件定义了一个自定义 Hook，用于封装文件操作（打开、保存、导入）。
  */
 import React, { useCallback, useRef } from 'react';
-import type { AnyPath, WhiteboardData, Frame } from '../../types';
-import * as idb from '../../lib/indexedDB';
+import type { AnyPath, WhiteboardData, Frame } from '@/types';
+import * as idb from '@/lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 import { fileOpen, fileSave } from 'browser-fs-access';
-import { importSvg } from '../../lib/import';
+import { importSvg } from '@/lib/import';
 import type { AppActionsProps } from './useAppActions';
 
 type FileWithHandle = File & { handle: FileSystemFileHandle };

--- a/src/hooks/actions/useLibraryActions.ts
+++ b/src/hooks/actions/useLibraryActions.ts
@@ -3,8 +3,8 @@
  */
 import { useCallback } from 'react';
 import { fileOpen, fileSave } from 'browser-fs-access';
-import type { AnyPath, StyleClipboardData, MaterialData, LibraryData, RectangleData, ImageData, PolygonData, TextData, Point, GroupData, ArcData } from '../../types';
-import { getPathsBoundingBox, movePath } from '../../lib/drawing';
+import type { AnyPath, StyleClipboardData, MaterialData, LibraryData, RectangleData, ImageData, PolygonData, TextData, Point, GroupData, ArcData } from '@/types';
+import { getPathsBoundingBox, movePath } from '@/lib/drawing';
 import type { AppActionsProps } from './useAppActions';
 
 /**

--- a/src/hooks/actions/useObjectActions.ts
+++ b/src/hooks/actions/useObjectActions.ts
@@ -2,11 +2,11 @@
  * 本文件定义了一个自定义 Hook，用于封装画布上对象的变换和组织操作。
  */
 import { useCallback, useRef } from 'react';
-import { rectangleToVectorPath, ellipseToVectorPath, lineToVectorPath, brushToVectorPath, polygonToVectorPath, arcToVectorPath, flipPath, getPathsBoundingBox, alignPaths, distributePaths, performBooleanOperation, scalePath, movePath } from '../../lib/drawing';
-import type { AnyPath, RectangleData, EllipseData, VectorPathData, BrushPathData, PolygonData, ArcData, GroupData, Alignment, DistributeMode, ImageData, TextData, TraceOptions } from '../../types';
+import { rectangleToVectorPath, ellipseToVectorPath, lineToVectorPath, brushToVectorPath, polygonToVectorPath, arcToVectorPath, flipPath, getPathsBoundingBox, alignPaths, distributePaths, performBooleanOperation, scalePath, movePath } from '@/lib/drawing';
+import type { AnyPath, RectangleData, EllipseData, VectorPathData, BrushPathData, PolygonData, ArcData, GroupData, Alignment, DistributeMode, ImageData, TextData, TraceOptions } from '@/types';
 import type { AppActionsProps } from './useAppActions';
-import { importSvg } from '../../lib/import';
-import { removeBackground, adjustHsv, type HsvAdjustment } from '../../lib/image';
+import { importSvg } from '@/lib/import';
+import { removeBackground, adjustHsv, type HsvAdjustment } from '@/lib/image';
 
 type BooleanOperation = 'unite' | 'subtract' | 'intersect' | 'exclude' | 'divide';
 

--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -13,9 +13,9 @@ import type {
   SelectionPathState,
   SelectionToolbarState,
   SelectionViewTransform,
-} from '../../types';
-import { updatePathAnchors, insertAnchorOnCurve, getSqDistToSegment, getPathsBoundingBox, dist, sampleCubicBezier, rotateResizeHandle } from '../../lib/drawing';
-import { isPointHittingPath, findDeepestHitPath } from '../../lib/hit-testing';
+} from '@/types';
+import { updatePathAnchors, insertAnchorOnCurve, getSqDistToSegment, getPathsBoundingBox, dist, sampleCubicBezier, rotateResizeHandle } from '@/lib/drawing';
+import { isPointHittingPath, findDeepestHitPath } from '@/lib/hit-testing';
 import { recursivelyUpdatePaths } from './utils';
 
 const HIT_RADIUS = 10; // 点击命中控制点的半径

--- a/src/hooks/selection-logic/pointerMove.ts
+++ b/src/hooks/selection-logic/pointerMove.ts
@@ -11,9 +11,9 @@ import type {
   SelectionPathState,
   SelectionToolbarState,
   SelectionViewTransform,
-} from '../../types';
-import { updatePathAnchors, movePath, rotatePath, getPathsBoundingBox, resizePath, scalePath, transformCropRect, dist } from '../../lib/drawing';
-import { isPointHittingPath } from '../../lib/hit-testing';
+} from '@/types';
+import { updatePathAnchors, movePath, rotatePath, getPathsBoundingBox, resizePath, scalePath, transformCropRect, dist } from '@/lib/drawing';
+import { isPointHittingPath } from '@/lib/hit-testing';
 import { recursivelyUpdatePaths } from './utils';
 
 const HIT_RADIUS = 10;

--- a/src/hooks/selection-logic/pointerUp.ts
+++ b/src/hooks/selection-logic/pointerUp.ts
@@ -8,9 +8,9 @@ import type {
   AnyPath,
   BBox,
   SelectionPathState,
-} from '../../types';
-import { getMarqueeRect } from '../../lib/drawing';
-import { isPathIntersectingMarquee, isPathIntersectingLasso } from '../../lib/hit-testing';
+} from '@/types';
+import { getMarqueeRect } from '@/lib/drawing';
+import { isPathIntersectingMarquee, isPathIntersectingLasso } from '@/lib/hit-testing';
 
 interface HandlePointerUpProps {
   e: React.PointerEvent<SVGSVGElement>;

--- a/src/hooks/selection-logic/utils.ts
+++ b/src/hooks/selection-logic/utils.ts
@@ -1,7 +1,7 @@
 /**
  * 本文件包含 useSelection hook 中使用的通用工具函数。
  */
-import type { AnyPath, GroupData } from '../../types';
+import type { AnyPath, GroupData } from '@/types';
 
 /**
  * 递归更新路径树中的路径。

--- a/src/hooks/toolbar-state/usePathActions.ts
+++ b/src/hooks/toolbar-state/usePathActions.ts
@@ -2,8 +2,8 @@
  * 本文件定义了一个自定义 Hook，用于管理与路径本身相关的操作，例如路径简化。
  */
 import { useState, useMemo } from 'react';
-import type { AnyPath, GroupData, VectorPathData } from '../../types';
-import { simplifyPath } from '../../lib/drawing';
+import type { AnyPath, GroupData, VectorPathData } from '@/types';
+import { simplifyPath } from '@/lib/drawing';
 
 interface PathActionsProps {
   paths: AnyPath[];

--- a/src/hooks/toolbar-state/useToolManagement.ts
+++ b/src/hooks/toolbar-state/useToolManagement.ts
@@ -2,8 +2,8 @@
  * 本文件定义了一个自定义 Hook，用于管理当前激活的工具和选择模式的状态。
  */
 import { useEffect } from 'react';
-import type { Tool, SelectionMode } from '../../types';
-import { getLocalStorageItem } from '../../lib/utils';
+import type { Tool, SelectionMode } from '@/types';
+import { getLocalStorageItem } from '@/lib/utils';
 import { useToolStore } from '@/context/toolStore';
 
 /**

--- a/src/lib/drawing/arc.ts
+++ b/src/lib/drawing/arc.ts
@@ -1,4 +1,4 @@
-import type { Point } from '../../types';
+import type { Point } from '@/types';
 
 const isFinitePoint = (p: Point | undefined | null): p is Point =>
   !!p && Number.isFinite(p.x) && Number.isFinite(p.y);

--- a/src/lib/drawing/arrange.ts
+++ b/src/lib/drawing/arrange.ts
@@ -1,7 +1,7 @@
 /**
  * 本文件包含了用于排列和分布画布上对象的函数。
  */
-import type { AnyPath, Alignment, DistributeMode, BBox } from '../../types';
+import type { AnyPath, Alignment, DistributeMode, BBox } from '@/types';
 import { getPathBoundingBox, getPathsBoundingBox } from './bbox';
 import { movePath } from './transform';
 

--- a/src/lib/drawing/bbox.ts
+++ b/src/lib/drawing/bbox.ts
@@ -1,9 +1,9 @@
-import type { BBox, AnyPath, Point, VectorPathData, BrushPathData, ArcData, GroupData, TextData } from '../../types';
+import type { BBox, AnyPath, Point, VectorPathData, BrushPathData, ArcData, GroupData, TextData } from '@/types';
 import { rotatePoint } from './geom';
 import { samplePath } from './path';
 import { getPolygonVertices } from './polygon';
 import { sampleArc } from './arc';
-import { DEFAULT_ROUGHNESS, DEFAULT_BOWING } from '../../constants';
+import { DEFAULT_ROUGHNESS, DEFAULT_BOWING } from '@/constants';
 
 export function getPathBoundingBox(path: AnyPath, includeStroke: boolean = true): BBox {
   let margin = 0;

--- a/src/lib/drawing/boolean.ts
+++ b/src/lib/drawing/boolean.ts
@@ -2,7 +2,7 @@
  * 本文件包含了使用 paper.js 进行布尔运算的逻辑。
  */
 import paper from 'paper';
-import type { AnyPath, VectorPathData, Anchor } from '../../types';
+import type { AnyPath, VectorPathData, Anchor } from '@/types';
 import {
   rectangleToVectorPath,
   ellipseToVectorPath,

--- a/src/lib/drawing/convert.ts
+++ b/src/lib/drawing/convert.ts
@@ -2,7 +2,7 @@
  * 本文件包含了用于图形类型转换和路径简化的函数。
  */
 import paper from 'paper';
-import type { AnyPath, Point, RectangleData, EllipseData, VectorPathData, Anchor, BrushPathData, PolygonData, ArcData } from '../../types';
+import type { AnyPath, Point, RectangleData, EllipseData, VectorPathData, Anchor, BrushPathData, PolygonData, ArcData } from '@/types';
 import { rotatePoint } from './geom';
 import { getPolygonVertices } from './polygon';
 

--- a/src/lib/drawing/geom.ts
+++ b/src/lib/drawing/geom.ts
@@ -1,4 +1,4 @@
-import type { Point } from '../../types';
+import type { Point } from '@/types';
 
 export function dist(p1: Point, p2: Point): number {
   return Math.sqrt(Math.pow(p1.x - p2.x, 2) + Math.pow(p1.y - p2.y, 2));

--- a/src/lib/drawing/path.ts
+++ b/src/lib/drawing/path.ts
@@ -4,7 +4,7 @@
  * 并提供了路径采样、更新和操作的实用工具。
  */
 
-import type { Point, Anchor, DragState, AnyPath, BrushPathData, VectorPathData, RectangleData, PolygonData, EllipseData, ArcData, TextData, FrameData } from '../../types';
+import type { Point, Anchor, DragState, AnyPath, BrushPathData, VectorPathData, RectangleData, PolygonData, EllipseData, ArcData, TextData, FrameData } from '@/types';
 import { lerpPoint, dist } from './geom';
 import { getPolygonPathD } from './polygon';
 import { calculateArcPathD } from './arc';

--- a/src/lib/drawing/polygon.ts
+++ b/src/lib/drawing/polygon.ts
@@ -1,4 +1,4 @@
-import type { Point } from '../../types';
+import type { Point } from '@/types';
 
 const isFiniteNumber = (n: number) => Number.isFinite(n);
 const isFinitePoint = (p: Point) => isFiniteNumber(p.x) && isFiniteNumber(p.y);

--- a/src/lib/drawing/transform.ts
+++ b/src/lib/drawing/transform.ts
@@ -1,7 +1,7 @@
 /**
  * 本文件包含了用于对画布上的对象进行几何变换的函数，如移动、旋转、缩放等。
  */
-import type { AnyPath, Point, RectangleData, EllipseData, ResizeHandlePosition, VectorPathData, ImageData, BrushPathData, PolygonData, ArcData, GroupData, TextData, FrameData, BBox } from '../../types';
+import type { AnyPath, Point, RectangleData, EllipseData, ResizeHandlePosition, VectorPathData, ImageData, BrushPathData, PolygonData, ArcData, GroupData, TextData, FrameData, BBox } from '@/types';
 import { rotatePoint } from './geom';
 import { rectangleToVectorPath, ellipseToVectorPath, polygonToVectorPath } from './convert';
 

--- a/src/lib/export/core/effects.ts
+++ b/src/lib/export/core/effects.ts
@@ -1,7 +1,7 @@
 /**
  * 本文件提供用于为 SVG 元素创建效果滤镜的辅助函数。
  */
-import type { AnyPath } from '../../types';
+import type { AnyPath } from '@/types';
 
 /**
  * 根据路径数据创建 SVG 滤镜元素。

--- a/src/lib/export/core/render.ts
+++ b/src/lib/export/core/render.ts
@@ -2,11 +2,11 @@
  * 本文件提供用于为 SVG 元素创建效果滤镜的辅助函数。
  */
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { AnyPath, VectorPathData, RectangleData, EllipseData, ImageData, BrushPathData, PolygonData, ArcData, GroupData, TextData, FrameData } from '../../types';
+import type { AnyPath, VectorPathData, RectangleData, EllipseData, ImageData, BrushPathData, PolygonData, ArcData, GroupData, TextData, FrameData } from '@/types';
 import { createSmoothPathNode } from '../smooth/path';
 import { renderRoughVectorPath } from '../rough/path';
 import { renderImage, renderRoughShape } from '../rough/shapes';
-import { sampleArc } from '../../drawing/arc';
+import { sampleArc } from '@/lib/drawing/arc';
 import { createEffectsFilter } from './effects';
 
 /**

--- a/src/lib/export/markers/rough.ts
+++ b/src/lib/export/markers/rough.ts
@@ -1,6 +1,6 @@
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { Point, EndpointStyle } from '../../types';
-import { rotatePoint } from '../../drawing';
+import type { Point, EndpointStyle } from '@/types';
+import { rotatePoint } from '@/lib/drawing';
 
 // Helper function to create an endpoint marker node.
 export function createCapNode(

--- a/src/lib/export/markers/svg.ts
+++ b/src/lib/export/markers/svg.ts
@@ -2,7 +2,7 @@
  * 本文件定义了用于为平滑路径创建 SVG <marker> 元素的函数。
  * 这些标记（如箭头、圆点）用于实现路径的起点和终点样式。
  */
-import type { EndpointStyle } from '../../types';
+import type { EndpointStyle } from '@/types';
 
 /**
  * 为平滑路径创建 SVG <marker> 元素。

--- a/src/lib/export/png/export.ts
+++ b/src/lib/export/png/export.ts
@@ -2,8 +2,8 @@
  * 本文件负责将路径数据导出为 PNG 格式。
  * 它首先将路径渲染为 SVG 字符串，然后使用 Canvas API 将 SVG 转换为 PNG Blob。
  */
-import type { AnyPath, PngExportOptions, BBox, FrameData } from '../../types';
-import { getPathsBoundingBox } from '../../drawing';
+import type { AnyPath, PngExportOptions, BBox, FrameData } from '@/types';
+import { getPathsBoundingBox } from '@/lib/drawing';
 import { pathsToSvgString } from '../svg/export';
 
 // Explicitly define all properties instead of extending PngExportOptions

--- a/src/lib/export/rough/path.ts
+++ b/src/lib/export/rough/path.ts
@@ -1,6 +1,6 @@
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { VectorPathData, EndpointStyle } from '../../types';
-import { samplePath } from '../../drawing';
+import type { VectorPathData, EndpointStyle } from '@/types';
+import { samplePath } from '@/lib/drawing';
 import { createCapNode } from '../markers/rough';
 
 /**

--- a/src/lib/export/rough/shapes.ts
+++ b/src/lib/export/rough/shapes.ts
@@ -1,6 +1,6 @@
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { RectangleData, EllipseData, ImageData, PolygonData, FrameData } from '../../types';
-import { getPolygonPathD, getRoundedRectPathD } from '../../drawing';
+import type { RectangleData, EllipseData, ImageData, PolygonData, FrameData } from '@/types';
+import { getPolygonPathD, getRoundedRectPathD } from '@/lib/drawing';
 
 export function renderImage(data: ImageData): SVGElement {
     const imgData = data as ImageData;

--- a/src/lib/export/smooth/path.ts
+++ b/src/lib/export/smooth/path.ts
@@ -2,10 +2,10 @@
  * 本文件定义了用于创建平滑（非手绘风格）SVG 路径节点的函数。
  * 主要用于导出 SVG，以确保输出的 SVG 代码简洁且符合标准。
  */
-import type { AnyPath, VectorPathData, RectangleData, EllipseData, EndpointStyle, BrushPathData, PolygonData, ArcData, FrameData } from '../../types';
-import { anchorsToPathD, pointsToPathD } from '../../path-fitting';
+import type { AnyPath, VectorPathData, RectangleData, EllipseData, EndpointStyle, BrushPathData, PolygonData, ArcData, FrameData } from '@/types';
+import { anchorsToPathD, pointsToPathD } from '@/lib/path-fitting';
 import { createSvgMarker } from '../markers/svg';
-import { getPolygonPathD, calculateArcPathD } from '../../drawing';
+import { getPolygonPathD, calculateArcPathD } from '@/lib/drawing';
 import { createEffectsFilter } from '../core/effects';
 
 export function createSmoothPathNode(data: AnyPath): SVGElement | null {

--- a/src/lib/export/svg/export.ts
+++ b/src/lib/export/svg/export.ts
@@ -2,9 +2,9 @@
  * 本文件负责处理 SVG 导出逻辑。
  * 它使用 `roughjs` 库将内部路径数据转换为 SVG 字符串，并可选择使用 SVGO 进行优化。
  */
-import type { AnyPath, BBox, FrameData, GroupData } from '../../types';
+import type { AnyPath, BBox, FrameData, GroupData } from '@/types';
 import rough from 'roughjs/bin/rough';
-import { getPathsBoundingBox } from '../../drawing';
+import { getPathsBoundingBox } from '@/lib/drawing';
 import { renderPathNode } from '../core/render';
 
 /**


### PR DESCRIPTION
## Summary
- replace ../../-style imports with @ alias across components, hooks, and lib modules
- verify @ alias mapping in vite.config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7cfbdb1b48323a6209a21b3e1a552