### PR TITLE
fix(timeline): reduce spacing and frame preview size

### DIFF
--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -225,7 +225,7 @@ export const TimelinePanel: React.FC = () => {
                             {frames.map((frame, index) => (
                                 <div
                                     key={index}
-                                    className="relative group flex-shrink-0 w-[5.1rem] h-[85%]"
+                                    className="relative group flex-shrink-0 w-[5.1rem] h-[5.1rem]"
                                     draggable={!isPlaying}
                                     onDragStart={(e) => handleDragStart(e, index)}
                                     onDragOver={(e) => handleDragOver(e, index)}

--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -143,7 +143,7 @@ export const TimelinePanel: React.FC = () => {
             leaveFrom="opacity-100 max-h-48"
             leaveTo="opacity-0 max-h-0"
         >
-            <div className="p-3 h-48 w-full max-w-full flex flex-col gap-3">
+            <div className="p-3 h-48 w-full max-w-full flex flex-col">
                 <div className="flex items-center gap-4">
                       <div className="flex items-center gap-2">
                           <PanelButton onClick={handleRewind} title="回到开头" className="text-[var(--text-secondary)]">
@@ -223,9 +223,9 @@ export const TimelinePanel: React.FC = () => {
                     <div className="h-full w-full rounded-lg p-2 overflow-x-auto overflow-y-hidden min-w-0 timeline-frames-container" onDrop={handleDrop} onDragOver={e => e.preventDefault()}>
                         <div className="flex items-center gap-2 h-full">
                             {frames.map((frame, index) => (
-                                <div 
+                                <div
                                     key={index}
-                                    className="relative group flex-shrink-0 w-24 h-full"
+                                    className="relative group flex-shrink-0 w-[5.1rem] h-[85%]"
                                     draggable={!isPlaying}
                                     onDragStart={(e) => handleDragStart(e, index)}
                                     onDragOver={(e) => handleDragOver(e, index)}
@@ -236,7 +236,7 @@ export const TimelinePanel: React.FC = () => {
                                     <PanelButton
                                         variant="unstyled"
                                         onClick={() => handleFrameClick(index)}
-                                        className={`w-full h-full rounded-md transition-all duration-150 ${currentFrameIndex === index ? 'ring-2 ring-offset-2 ring-offset-[var(--ui-panel-bg)] ring-[var(--accent-primary)]' : 'ring-1 ring-white/10'}`}
+                                        className={`w-full h-full rounded-md transition-all duration-150 flex items-center justify-center ${currentFrameIndex === index ? 'ring-2 ring-offset-2 ring-offset-[var(--ui-panel-bg)] ring-[var(--accent-primary)]' : 'ring-1 ring-white/10'}`}
                                         disabled={isPlaying}
                                     >
                                         <FrameThumbnail frame={frame} />


### PR DESCRIPTION
## Summary
- remove the extra gap between timeline panel sections
- shrink the frame preview thumbnails to roughly 85% while keeping them centered

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ca05e2108323a1afbce7a42914e5