### PR TITLE
fix: prevent main menu focus ring clipping

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -124,7 +124,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
           ))}
         </Tab.List>
 
-        <Tab.Panels className="flex-grow min-h-0 overflow-hidden">
+        <Tab.Panels className="flex-grow min-h-0">
           <Tab.Panel className="flex flex-col gap-1 h-full focus:outline-none overflow-y-auto layers-panel-list pr-1">
             {menuActions.map((action, index) => {
               if (action.label === '---') {


### PR DESCRIPTION
## Summary
- remove the overflow clipping on the main menu tab panels so focus outlines remain visible

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68c8cfe9596c83238d3b9b5a641e9dc2