### PR TITLE
feat(text): streamline editing flow and metrics

### DIFF
--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -17,6 +17,7 @@ interface DrawingInteractionProps {
   isGridVisible: boolean;
   gridSize: number;
   gridSubdivisions: number;
+  setEditingTextPathId: (id: string | null) => void;
 }
 
 /**
@@ -31,6 +32,7 @@ export const useDrawing = ({
   isGridVisible,
   gridSize,
   gridSubdivisions,
+  setEditingTextPathId,
 }: DrawingInteractionProps) => {
   const [drawingShape, setDrawingShape] = useState<DrawingShape | null>(null);
   const [previewD, setPreviewD] = useState<string | null>(null);
@@ -156,7 +158,7 @@ export const useDrawing = ({
       }
       case 'text': {
         const defaultText = text || '文本';
-        const { width, height } = measureText(defaultText, fontSize, fontFamily);
+        const { width, height, lineHeight, baseline } = measureText(defaultText, fontSize, fontFamily);
 
         const newText: TextData = {
             id,
@@ -166,6 +168,8 @@ export const useDrawing = ({
             y: snappedPoint.y,
             width,
             height,
+            lineHeight,
+            baseline,
             fontFamily,
             fontSize,
             textAlign,
@@ -178,6 +182,8 @@ export const useDrawing = ({
         setPaths((prev: AnyPath[]) => [...prev, newText]);
         toolbarState.setTool('selection');
         pathState.setSelectedPathIds([id]);
+        setEditingTextPathId(id);
+        pathState.beginCoalescing();
         break;
       }
       case 'arc': {

--- a/src/hooks/useToolbarState.ts
+++ b/src/hooks/useToolbarState.ts
@@ -174,8 +174,8 @@ export const useToolbarState = (
     if (firstSelectedPath?.tool === 'text') {
         updateSelectedPaths((p) => {
             if (p.tool === 'text') {
-                const { width, height } = measureText(newText, p.fontSize, p.fontFamily);
-                return { text: newText, width, height };
+                const measurement = measureText(newText, p.fontSize, p.fontFamily);
+                return { text: newText, ...measurement };
             }
             return {};
         });
@@ -188,8 +188,8 @@ export const useToolbarState = (
     if (firstSelectedPath?.tool === 'text') {
         updateSelectedPaths((p) => {
             if (p.tool === 'text') {
-                const { width, height } = measureText(p.text, p.fontSize, newFamily);
-                return { fontFamily: newFamily, width, height };
+                const measurement = measureText(p.text, p.fontSize, newFamily);
+                return { fontFamily: newFamily, ...measurement };
             }
             return {};
         });
@@ -202,8 +202,8 @@ export const useToolbarState = (
     if (firstSelectedPath?.tool === 'text') {
         updateSelectedPaths((p) => {
             if (p.tool === 'text') {
-                const { width, height } = measureText(p.text, newSize, p.fontFamily);
-                return { fontSize: newSize, width, height };
+                const measurement = measureText(p.text, newSize, p.fontFamily);
+                return { fontSize: newSize, ...measurement };
             }
             return {};
         });

--- a/src/lib/drawing/text.ts
+++ b/src/lib/drawing/text.ts
@@ -5,31 +5,95 @@
 const canvas = document.createElement('canvas');
 const ctx = canvas.getContext('2d')!;
 
+const DEFAULT_LINE_HEIGHT_RATIO = 1.25;
+const FALLBACK_ASCENT_RATIO = 0.8;
+const FALLBACK_DESCENT_RATIO = 0.2;
+
+const LINE_HEIGHT_OVERRIDES: Record<string, number> = {
+  excalifont: 1.25,
+  'xiaolai sc': 1.3,
+  kalam: 1.3,
+  lora: 1.35,
+  'noto sans sc': 1.2,
+  'roboto mono': 1.2,
+};
+
+const sanitizeFontFamily = (fontFamily: string): string => {
+  const primary = fontFamily.split(',')[0] ?? fontFamily;
+  return primary.trim().replace(/^['"]|['"]$/g, '');
+};
+
+export interface TextMeasurement {
+  width: number;
+  height: number;
+  baseline: number;
+  lineHeight: number;
+}
+
 /**
- * 使用 2D 画布上下文测量给定文本的尺寸。
+ * 获取某个字体的行高倍数配置。
+ * 行高会影响包围盒高度与编辑器内文本的排版。
+ */
+export const getLineHeightMultiplier = (fontFamily: string): number => {
+  const key = sanitizeFontFamily(fontFamily).toLowerCase();
+  return LINE_HEIGHT_OVERRIDES[key] ?? DEFAULT_LINE_HEIGHT_RATIO;
+};
+
+/**
+ * 使用 2D 画布上下文测量给定文本的尺寸与排版指标。
  * @param text - 要测量的文本字符串。
  * @param fontSize - 字体大小（像素）。
  * @param fontFamily - 字体系列。
- * @returns 包含宽度和高度的对象。
+ * @returns 包含宽度、高度、基线与行高的对象。
  */
-export function measureText(text: string, fontSize: number, fontFamily: string): { width: number, height: number } {
-    const family = fontFamily.includes(' ') ? `'${fontFamily}'` : fontFamily;
-    ctx.font = `${fontSize}px ${family}`;
-    const lines = text.split('\n');
-    let maxWidth = 0;
-    
-    // 测量宽度
-    for (const line of lines) {
-        const metrics = ctx.measureText(line);
-        if (metrics.width > maxWidth) {
-            maxWidth = metrics.width;
-        }
-    }
-    
-    // 高度是根据字体大小、行数和行高乘数估算的
-    // 对于 Excalifont，1.25 是一个合适的行高
-    const lineHeight = fontSize * 1.25;
-    const height = lines.length * lineHeight;
+export function measureText(text: string, fontSize: number, fontFamily: string): TextMeasurement {
+  const family = sanitizeFontFamily(fontFamily);
+  const familyWithQuotes = family.includes(' ') ? `'${family}'` : family;
+  ctx.font = `${fontSize}px ${familyWithQuotes}`;
 
-    return { width: maxWidth, height };
+  const lines = text.split('\n');
+  const lineCount = Math.max(lines.length, 1);
+
+  let maxWidth = 0;
+  let maxAscent = 0;
+  let maxDescent = 0;
+
+  const fallbackAscent = fontSize * FALLBACK_ASCENT_RATIO;
+  const fallbackDescent = fontSize * FALLBACK_DESCENT_RATIO;
+
+  for (const rawLine of lines) {
+    const line = rawLine.length > 0 ? rawLine : 'M';
+    const metrics = ctx.measureText(line);
+    const boundingWidth = (metrics.actualBoundingBoxLeft ?? 0) + (metrics.actualBoundingBoxRight ?? 0);
+    const measuredWidth = Math.max(metrics.width, boundingWidth);
+    if (measuredWidth > maxWidth) {
+      maxWidth = measuredWidth;
+    }
+
+    const ascent = metrics.actualBoundingBoxAscent ?? fallbackAscent;
+    if (ascent > maxAscent) {
+      maxAscent = ascent;
+    }
+    const descent = metrics.actualBoundingBoxDescent ?? fallbackDescent;
+    if (descent > maxDescent) {
+      maxDescent = descent;
+    }
+  }
+
+  if (maxAscent === 0) maxAscent = fallbackAscent;
+  if (maxDescent === 0) maxDescent = fallbackDescent;
+
+  const baseHeight = maxAscent + maxDescent;
+  const lineHeightMultiplier = getLineHeightMultiplier(family);
+  const lineHeight = baseHeight * lineHeightMultiplier;
+  const leading = Math.max(lineHeight - baseHeight, 0);
+  const baseline = maxAscent + leading / 2;
+  const height = baseHeight + leading + (lineCount - 1) * lineHeight;
+
+  return {
+    width: maxWidth,
+    height,
+    baseline,
+    lineHeight,
+  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,10 @@ export interface TextData extends ShapeBase {
   y: number;
   width: number;
   height: number;
+  /** 基线到文本顶部的距离（像素）。 */
+  baseline?: number;
+  /** 行高（像素）。用于准确的包围盒与编辑器排版。 */
+  lineHeight?: number;
 }
 
 export interface ArcData extends ShapeBase {


### PR DESCRIPTION
## Summary
- begin text editing immediately after creation, coalescing history and throttling text updates with requestAnimationFrame to reduce rerenders
- sync the textarea overlay with rotation/scale transforms and use stored line-height data for consistent editing visuals
- derive text width/height/baseline from TextMetrics and propagate the metrics through toolbar updates and export rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8ccff408c832395e7ed1122fa04a6