### PR TITLE
test: cover hooks and drawing algorithms

### DIFF
--- a/tests/hooks/useSelection.test.ts
+++ b/tests/hooks/useSelection.test.ts
@@ -1,0 +1,245 @@
+// useSelection 钩子交互逻辑测试
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSelection } from '@/hooks/useSelection';
+import type { Dispatch, SetStateAction } from 'react';
+import type {
+  AnyPath,
+  BBox,
+  RectangleData,
+  SelectionPathState,
+  SelectionToolbarState,
+  SelectionViewTransform,
+} from '@/types';
+
+const selectionLogicMocks = vi.hoisted(() => ({
+  handlePointerDownLogic: vi.fn(),
+  handlePointerMoveLogic: vi.fn(),
+  handlePointerUpLogic: vi.fn(),
+}));
+
+vi.mock('@/hooks/selection-logic/index', () => selectionLogicMocks);
+
+const { handlePointerDownLogic, handlePointerMoveLogic, handlePointerUpLogic } = selectionLogicMocks;
+
+type HookProps = {
+  pathState: SelectionPathState;
+  toolbarState: SelectionToolbarState;
+  viewTransform: SelectionViewTransform;
+  isGridVisible: boolean;
+  gridSize: number;
+  gridSubdivisions: number;
+  onDoubleClick: (path: AnyPath) => void;
+  croppingState: { pathId: string; originalPath: AnyPath } | null;
+  currentCropRect: BBox | null;
+  setCurrentCropRect: Dispatch<SetStateAction<BBox | null>>;
+  pushCropHistory: (rect: BBox) => void;
+};
+
+describe('useSelection', () => {
+  const baseShapeProps = {
+    id: 'rect-1',
+    tool: 'rectangle' as const,
+    x: 0,
+    y: 0,
+    width: 120,
+    height: 80,
+    rotation: 0,
+    color: '#000000',
+    fill: 'transparent',
+    fillStyle: 'hachure',
+    strokeWidth: 2,
+    roughness: 0,
+    bowing: 0,
+    fillWeight: 0,
+    hachureAngle: 0,
+    hachureGap: 0,
+    curveTightness: 0,
+    curveStepCount: 0,
+  } satisfies RectangleData;
+
+  let currentPaths: AnyPath[];
+  let selectedPathIds: string[];
+  let currentCropRect: BBox | null;
+  const beginCoalescing = vi.fn();
+  const endCoalescing = vi.fn();
+  const onDoubleClick = vi.fn();
+  const pushCropHistory = vi.fn();
+  const getPointerPosition = vi.fn(
+    (event: { clientX: number; clientY: number }) => ({ x: event.clientX + 1, y: event.clientY + 2 })
+  );
+  const setPaths: Dispatch<SetStateAction<AnyPath[]>> = updater => {
+    currentPaths = typeof updater === 'function' ? (updater as (prev: AnyPath[]) => AnyPath[])(currentPaths) : updater;
+  };
+  const setSelectedPathIds: Dispatch<SetStateAction<string[]>> = updater => {
+    selectedPathIds = typeof updater === 'function' ? (updater as (prev: string[]) => string[])(selectedPathIds) : updater;
+  };
+  const setCurrentCropRect: Dispatch<SetStateAction<BBox | null>> = updater => {
+    currentCropRect = typeof updater === 'function'
+      ? (updater as (prev: BBox | null) => BBox | null)(currentCropRect)
+      : updater;
+  };
+
+  const createPathState = (): SelectionPathState => ({
+    paths: currentPaths,
+    setPaths,
+    selectedPathIds,
+    setSelectedPathIds,
+    beginCoalescing,
+    endCoalescing,
+  });
+
+  const createToolbarState = (): SelectionToolbarState => ({
+    selectionMode: 'move',
+  });
+
+  const createViewTransform = (): SelectionViewTransform => ({
+    viewTransform: { scale: 1, translateX: 0, translateY: 0 },
+    getPointerPosition,
+  });
+
+  const createProps = (): HookProps => ({
+    pathState: createPathState(),
+    toolbarState: createToolbarState(),
+    viewTransform: createViewTransform(),
+    isGridVisible: true,
+    gridSize: 10,
+    gridSubdivisions: 2,
+    onDoubleClick,
+    croppingState: null,
+    currentCropRect,
+    setCurrentCropRect,
+    pushCropHistory,
+  });
+
+  beforeEach(() => {
+    currentPaths = [structuredClone(baseShapeProps)];
+    selectedPathIds = ['rect-1'];
+    currentCropRect = null;
+    getPointerPosition.mockClear();
+    beginCoalescing.mockClear();
+    endCoalescing.mockClear();
+    onDoubleClick.mockClear();
+    pushCropHistory.mockClear();
+    handlePointerDownLogic.mockReset();
+    handlePointerMoveLogic.mockReset();
+    handlePointerUpLogic.mockReset();
+  });
+
+  it('captures the pointer and delegates pointer down events to the logic layer', () => {
+    const { result } = renderHook((props: HookProps) => useSelection(props), { initialProps: createProps() });
+
+    handlePointerDownLogic.mockImplementation(({ setDragState }) => {
+      setDragState({
+        type: 'move',
+        pathIds: ['rect-1'],
+        originalPaths: currentPaths,
+        initialPointerPos: { x: 0, y: 0 },
+        initialSelectionBbox: { x: 0, y: 0, width: 0, height: 0 },
+      });
+    });
+
+    const setPointerCapture = vi.fn();
+    const event = {
+      pointerId: 7,
+      clientX: 15,
+      clientY: 25,
+      currentTarget: {
+        setPointerCapture,
+      },
+    } as unknown as React.PointerEvent<SVGSVGElement>;
+
+    act(() => {
+      result.current.onPointerDown(event);
+    });
+
+    expect(setPointerCapture).toHaveBeenCalledWith(7);
+    expect(getPointerPosition).toHaveBeenCalledWith(event, event.currentTarget);
+    expect(handlePointerDownLogic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        e: event,
+        point: { x: 16, y: 27 },
+        pathState: expect.objectContaining({ paths: currentPaths }),
+      })
+    );
+    expect(result.current.dragState?.type).toBe('move');
+  });
+
+  it('provides snapToGrid helper and updates hover state during pointer move', () => {
+    const { result, rerender } = renderHook((props: HookProps) => useSelection(props), { initialProps: createProps() });
+
+    let snapped: { x: number; y: number } | null = null;
+    handlePointerMoveLogic.mockImplementation(({ snapToGrid, setIsHoveringMovable, setIsHoveringEditable }) => {
+      setIsHoveringMovable(true);
+      setIsHoveringEditable(true);
+      snapped = snapToGrid({ x: 12, y: 13 });
+    });
+
+    const moveEvent = {
+      pointerId: 11,
+      currentTarget: {},
+    } as unknown as React.PointerEvent<SVGSVGElement>;
+
+    act(() => {
+      result.current.onPointerMove(moveEvent);
+    });
+
+    expect(snapped).toEqual({ x: 10, y: 15 });
+    expect(result.current.isHoveringMovable).toBe(true);
+    expect(result.current.isHoveringEditable).toBe(true);
+
+    const pointerEvent = {
+      pointerId: 11,
+      currentTarget: {
+        hasPointerCapture: vi.fn(() => true),
+        releasePointerCapture: vi.fn(),
+      },
+    } as unknown as React.PointerEvent<SVGSVGElement>;
+
+    act(() => {
+      result.current.onPointerUp(pointerEvent);
+    });
+
+    expect(handlePointerUpLogic).toHaveBeenCalled();
+    expect(result.current.isHoveringMovable).toBe(false);
+    expect(result.current.isHoveringEditable).toBe(false);
+
+    rerender(createProps());
+  });
+
+  it('clears stale drag state when referenced paths are removed', async () => {
+    const { result, rerender } = renderHook((props: HookProps) => useSelection(props), { initialProps: createProps() });
+
+    handlePointerDownLogic.mockImplementation(({ setDragState }) => {
+      setDragState({
+        type: 'move',
+        pathIds: ['rect-1'],
+        originalPaths: currentPaths,
+        initialPointerPos: { x: 0, y: 0 },
+        initialSelectionBbox: { x: 0, y: 0, width: 0, height: 0 },
+      });
+    });
+
+    const event = {
+      pointerId: 1,
+      clientX: 5,
+      clientY: 6,
+      currentTarget: {
+        setPointerCapture: vi.fn(),
+      },
+    } as unknown as React.PointerEvent<SVGSVGElement>;
+
+    act(() => {
+      result.current.onPointerDown(event);
+    });
+
+    expect(result.current.dragState?.type).toBe('move');
+
+    currentPaths = [];
+    rerender(createProps());
+
+    await waitFor(() => {
+      expect(result.current.dragState).toBeNull();
+    });
+  });
+});

--- a/tests/hooks/useToolbarState.test.ts
+++ b/tests/hooks/useToolbarState.test.ts
@@ -1,0 +1,332 @@
+// useToolbarState 钩子状态更新测试
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useToolbarState } from '@/hooks/useToolbarState';
+import { COLORS, DEFAULT_BOWING, DEFAULT_CURVE_STEP_COUNT, DEFAULT_CURVE_TIGHTNESS, DEFAULT_DISABLE_MULTI_STROKE, DEFAULT_DISABLE_MULTI_STROKE_FILL, DEFAULT_FILL_WEIGHT, DEFAULT_HACHURE_ANGLE, DEFAULT_HACHURE_GAP, DEFAULT_PRESERVE_VERTICES, DEFAULT_ROUGHNESS } from '@/constants';
+import type { AnyPath, RectangleData, TextData } from '@/types';
+import type { Dispatch, SetStateAction } from 'react';
+
+const drawingColorSetter = vi.fn();
+const drawingFillSetter = vi.fn();
+const drawingFillStyleSetter = vi.fn();
+const drawingStrokeWidthSetter = vi.fn();
+const drawingOpacitySetter = vi.fn();
+const drawingSidesSetter = vi.fn();
+const drawingBorderRadiusSetter = vi.fn();
+const drawingStrokeLineDashSetter = vi.fn();
+const drawingStrokeLineCapStartSetter = vi.fn();
+const drawingStrokeLineCapEndSetter = vi.fn();
+const drawingEndpointSizeSetter = vi.fn();
+const drawingEndpointFillSetter = vi.fn();
+const drawingIsRoughSetter = vi.fn();
+const drawingRoughnessSetter = vi.fn();
+const drawingBowingSetter = vi.fn();
+const drawingFillWeightSetter = vi.fn();
+const drawingHachureAngleSetter = vi.fn();
+const drawingHachureGapSetter = vi.fn();
+const drawingCurveTightnessSetter = vi.fn();
+const drawingCurveStepCountSetter = vi.fn();
+const drawingPreserveVerticesSetter = vi.fn();
+const drawingDisableMultiStrokeSetter = vi.fn();
+const drawingDisableMultiStrokeFillSetter = vi.fn();
+const drawingTextSetter = vi.fn();
+const drawingFontFamilySetter = vi.fn();
+const drawingFontSizeSetter = vi.fn();
+const drawingTextAlignSetter = vi.fn();
+const drawingBlurSetter = vi.fn();
+const drawingShadowEnabledSetter = vi.fn();
+const drawingShadowOffsetXSetter = vi.fn();
+const drawingShadowOffsetYSetter = vi.fn();
+const drawingShadowBlurSetter = vi.fn();
+const drawingShadowColorSetter = vi.fn();
+
+vi.mock('@/hooks/toolbar-state/property-hooks', () => ({
+  useDrawingColor: () => ({ drawingColor: '#222222', setDrawingColor: drawingColorSetter }),
+  useDrawingFill: () => ({ drawingFill: 'transparent', setDrawingFill: drawingFillSetter }),
+  useDrawingFillStyle: () => ({ drawingFillStyle: 'hachure', setDrawingFillStyle: drawingFillStyleSetter }),
+  useDrawingStrokeWidth: () => ({ drawingStrokeWidth: 0, setDrawingStrokeWidth: drawingStrokeWidthSetter }),
+  useDrawingOpacity: () => ({ drawingOpacity: 1, setDrawingOpacity: drawingOpacitySetter }),
+  useDrawingSides: () => ({ drawingSides: 6, setDrawingSides: drawingSidesSetter }),
+  useDrawingBorderRadius: () => ({ drawingBorderRadius: 0, setDrawingBorderRadius: drawingBorderRadiusSetter }),
+  useDrawingStrokeLineDash: () => ({ drawingStrokeLineDash: undefined, setDrawingStrokeLineDash: drawingStrokeLineDashSetter }),
+  useDrawingStrokeLineCapStart: () => ({ drawingStrokeLineCapStart: 'round', setDrawingStrokeLineCapStart: drawingStrokeLineCapStartSetter }),
+  useDrawingStrokeLineCapEnd: () => ({ drawingStrokeLineCapEnd: 'round', setDrawingStrokeLineCapEnd: drawingStrokeLineCapEndSetter }),
+  useDrawingEndpointSize: () => ({ drawingEndpointSize: 1, setDrawingEndpointSize: drawingEndpointSizeSetter }),
+  useDrawingEndpointFill: () => ({ drawingEndpointFill: 'hollow', setDrawingEndpointFill: drawingEndpointFillSetter }),
+  useDrawingIsRough: () => ({ drawingIsRough: true, setDrawingIsRough: drawingIsRoughSetter }),
+  useDrawingRoughness: () => ({ drawingRoughness: DEFAULT_ROUGHNESS, setDrawingRoughness: drawingRoughnessSetter }),
+  useDrawingBowing: () => ({ drawingBowing: DEFAULT_BOWING, setDrawingBowing: drawingBowingSetter }),
+  useDrawingFillWeight: () => ({ drawingFillWeight: DEFAULT_FILL_WEIGHT, setDrawingFillWeight: drawingFillWeightSetter }),
+  useDrawingHachureAngle: () => ({ drawingHachureAngle: DEFAULT_HACHURE_ANGLE, setDrawingHachureAngle: drawingHachureAngleSetter }),
+  useDrawingHachureGap: () => ({ drawingHachureGap: DEFAULT_HACHURE_GAP, setDrawingHachureGap: drawingHachureGapSetter }),
+  useDrawingCurveTightness: () => ({ drawingCurveTightness: DEFAULT_CURVE_TIGHTNESS, setDrawingCurveTightness: drawingCurveTightnessSetter }),
+  useDrawingCurveStepCount: () => ({ drawingCurveStepCount: DEFAULT_CURVE_STEP_COUNT, setDrawingCurveStepCount: drawingCurveStepCountSetter }),
+  useDrawingPreserveVertices: () => ({ drawingPreserveVertices: DEFAULT_PRESERVE_VERTICES, setDrawingPreserveVertices: drawingPreserveVerticesSetter }),
+  useDrawingDisableMultiStroke: () => ({ drawingDisableMultiStroke: DEFAULT_DISABLE_MULTI_STROKE, setDrawingDisableMultiStroke: drawingDisableMultiStrokeSetter }),
+  useDrawingDisableMultiStrokeFill: () => ({ drawingDisableMultiStrokeFill: DEFAULT_DISABLE_MULTI_STROKE_FILL, setDrawingDisableMultiStrokeFill: drawingDisableMultiStrokeFillSetter }),
+  useDrawingText: () => ({ drawingText: '文本', setDrawingText: drawingTextSetter }),
+  useDrawingFontFamily: () => ({ drawingFontFamily: 'Excalifont', setDrawingFontFamily: drawingFontFamilySetter }),
+  useDrawingFontSize: () => ({ drawingFontSize: 24, setDrawingFontSize: drawingFontSizeSetter }),
+  useDrawingTextAlign: () => ({ drawingTextAlign: 'left', setDrawingTextAlign: drawingTextAlignSetter }),
+  useDrawingBlur: () => ({ drawingBlur: 0, setDrawingBlur: drawingBlurSetter }),
+  useDrawingShadowEnabled: () => ({ drawingShadowEnabled: false, setDrawingShadowEnabled: drawingShadowEnabledSetter }),
+  useDrawingShadowOffsetX: () => ({ drawingShadowOffsetX: 2, setDrawingShadowOffsetX: drawingShadowOffsetXSetter }),
+  useDrawingShadowOffsetY: () => ({ drawingShadowOffsetY: 2, setDrawingShadowOffsetY: drawingShadowOffsetYSetter }),
+  useDrawingShadowBlur: () => ({ drawingShadowBlur: 4, setDrawingShadowBlur: drawingShadowBlurSetter }),
+  useDrawingShadowColor: () => ({ drawingShadowColor: 'rgba(0,0,0,0.5)', setDrawingShadowColor: drawingShadowColorSetter }),
+}));
+
+const setToolMock = vi.fn();
+const setSelectionModeMock = vi.fn();
+let currentTool: 'brush' | 'selection' | 'pen' | 'rectangle' | 'polygon' | 'ellipse' | 'line' | 'arc' | 'text' | 'frame' = 'brush';
+let currentSelectionMode: 'move' | 'edit' | 'lasso' = 'move';
+const useToolManagementMock = vi.fn(() => ({
+  tool: currentTool,
+  setTool: setToolMock,
+  selectionMode: currentSelectionMode,
+  setSelectionMode: setSelectionModeMock,
+}));
+
+vi.mock('@/hooks/toolbar-state/useToolManagement', () => ({
+  useToolManagement: (...args: unknown[]) => useToolManagementMock(...args),
+}));
+
+const pathActions = { beginSimplify: vi.fn(), setSimplify: vi.fn(), endSimplify: vi.fn(), isSimplifiable: false };
+const usePathActionsMock = vi.fn(() => pathActions);
+
+vi.mock('@/hooks/toolbar-state/usePathActions', () => ({
+  usePathActions: (...args: unknown[]) => usePathActionsMock(...args),
+}));
+
+const drawingMocks = vi.hoisted(() => ({
+  measureTextMock: vi.fn(() => ({ width: 80, height: 40 })),
+}));
+
+vi.mock('@/lib/drawing', () => ({
+  measureText: drawingMocks.measureTextMock,
+}));
+
+const { measureTextMock } = drawingMocks;
+
+type HookProps = {
+  paths: AnyPath[];
+  selectedPathIds: string[];
+};
+
+describe('useToolbarState', () => {
+  const rectangleBase: RectangleData = {
+    id: 'rect-1',
+    tool: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 120,
+    height: 80,
+    color: '#00AA00',
+    fill: 'transparent',
+    fillStyle: 'hachure',
+    strokeWidth: 0,
+    roughness: 0,
+    bowing: 0,
+    fillWeight: 0,
+    hachureAngle: 0,
+    hachureGap: 0,
+    curveTightness: 0,
+    curveStepCount: 0,
+  } as RectangleData;
+
+  const textBase: TextData = {
+    id: 'text-1',
+    tool: 'text',
+    text: 'hello',
+    fontFamily: 'Excalifont',
+    fontSize: 24,
+    textAlign: 'left',
+    x: 10,
+    y: 20,
+    width: 60,
+    height: 40,
+    color: '#000000',
+    fill: 'transparent',
+    fillStyle: 'hachure',
+    strokeWidth: 1,
+    roughness: 0,
+    bowing: 0,
+    fillWeight: 0,
+    hachureAngle: 0,
+    hachureGap: 0,
+    curveTightness: 0,
+    curveStepCount: 0,
+  } as TextData;
+
+  let currentPaths: AnyPath[];
+  let currentSelectedIds: string[];
+  const beginCoalescing = vi.fn();
+  const endCoalescing = vi.fn();
+
+  const setPaths: Dispatch<SetStateAction<AnyPath[]>> = updater => {
+    currentPaths = typeof updater === 'function' ? (updater as (prev: AnyPath[]) => AnyPath[])(currentPaths) : updater;
+  };
+
+  const setSelectedPathIds: Dispatch<SetStateAction<string[]>> = updater => {
+    currentSelectedIds = typeof updater === 'function' ? (updater as (prev: string[]) => string[])(currentSelectedIds) : updater;
+  };
+
+  const render = (props: HookProps) =>
+    renderHook(
+      ({ paths, selectedPathIds }: HookProps) =>
+        useToolbarState(paths, selectedPathIds, setPaths, setSelectedPathIds, beginCoalescing, endCoalescing),
+      { initialProps: props }
+    );
+
+  const setterMocks = [
+    drawingColorSetter,
+    drawingFillSetter,
+    drawingFillStyleSetter,
+    drawingStrokeWidthSetter,
+    drawingOpacitySetter,
+    drawingSidesSetter,
+    drawingBorderRadiusSetter,
+    drawingStrokeLineDashSetter,
+    drawingStrokeLineCapStartSetter,
+    drawingStrokeLineCapEndSetter,
+    drawingEndpointSizeSetter,
+    drawingEndpointFillSetter,
+    drawingIsRoughSetter,
+    drawingRoughnessSetter,
+    drawingBowingSetter,
+    drawingFillWeightSetter,
+    drawingHachureAngleSetter,
+    drawingHachureGapSetter,
+    drawingCurveTightnessSetter,
+    drawingCurveStepCountSetter,
+    drawingPreserveVerticesSetter,
+    drawingDisableMultiStrokeSetter,
+    drawingDisableMultiStrokeFillSetter,
+    drawingTextSetter,
+    drawingFontFamilySetter,
+    drawingFontSizeSetter,
+    drawingTextAlignSetter,
+    drawingBlurSetter,
+    drawingShadowEnabledSetter,
+    drawingShadowOffsetXSetter,
+    drawingShadowOffsetYSetter,
+    drawingShadowBlurSetter,
+    drawingShadowColorSetter,
+  ];
+
+  beforeEach(() => {
+    currentPaths = [];
+    currentSelectedIds = [];
+    currentTool = 'brush';
+    currentSelectionMode = 'move';
+    measureTextMock.mockReset();
+    measureTextMock.mockReturnValue({ width: 80, height: 40 });
+    setterMocks.forEach(mock => mock.mockReset());
+    setToolMock.mockReset();
+    setSelectionModeMock.mockReset();
+    useToolManagementMock.mockClear();
+    usePathActionsMock.mockClear();
+    pathActions.beginSimplify.mockClear();
+    pathActions.setSimplify.mockClear();
+    pathActions.endSimplify.mockClear();
+  });
+
+  it('updates selected paths when setting color and enforces minimum stroke width', () => {
+    currentPaths = [structuredClone(rectangleBase)];
+    currentSelectedIds = ['rect-1'];
+    const { result, rerender } = render({ paths: currentPaths, selectedPathIds: currentSelectedIds });
+
+    act(() => {
+      result.current.setColor('#FF0000');
+    });
+
+    rerender({ paths: currentPaths, selectedPathIds: currentSelectedIds });
+
+    const updated = currentPaths[0] as RectangleData;
+    expect(updated.color).toBe('#FF0000');
+    expect(updated.strokeWidth).toBe(1);
+    expect(drawingColorSetter).not.toHaveBeenCalled();
+    expect(drawingStrokeWidthSetter).not.toHaveBeenCalled();
+    expect(result.current.color).toBe('#FF0000');
+  });
+
+  it('falls back to drawing defaults when no path is selected', () => {
+    currentPaths = [structuredClone(rectangleBase)];
+    currentSelectedIds = [];
+    currentTool = 'brush';
+    const { result } = render({ paths: currentPaths, selectedPathIds: currentSelectedIds });
+
+    act(() => {
+      result.current.setColor('#00FF88');
+    });
+
+    expect(drawingColorSetter).toHaveBeenCalledWith('#00FF88');
+    expect(drawingStrokeWidthSetter).toHaveBeenCalledWith(1);
+  });
+
+  it('updates text geometry using measureText for selected text paths', () => {
+    currentPaths = [structuredClone(textBase)];
+    currentSelectedIds = ['text-1'];
+    measureTextMock.mockReturnValueOnce({ width: 120, height: 60 });
+    const { result, rerender } = render({ paths: currentPaths, selectedPathIds: currentSelectedIds });
+
+    act(() => {
+      result.current.setText('new content');
+    });
+
+    rerender({ paths: currentPaths, selectedPathIds: currentSelectedIds });
+
+    const updated = currentPaths[0] as TextData;
+    expect(updated.text).toBe('new content');
+    expect(updated.width).toBe(120);
+    expect(updated.height).toBe(60);
+    expect(measureTextMock).toHaveBeenCalledWith('new content', textBase.fontSize, textBase.fontFamily);
+    expect(drawingTextSetter).not.toHaveBeenCalled();
+  });
+
+  it('resets drawing defaults and tool state', () => {
+    currentPaths = [];
+    currentSelectedIds = [];
+    currentTool = 'selection';
+    const { result } = render({ paths: currentPaths, selectedPathIds: currentSelectedIds });
+
+    act(() => {
+      result.current.resetState();
+    });
+
+    expect(drawingColorSetter).toHaveBeenCalledWith(COLORS[0]);
+    expect(drawingFillSetter).toHaveBeenCalledWith('transparent');
+    expect(drawingFillStyleSetter).toHaveBeenCalledWith('hachure');
+    expect(drawingStrokeWidthSetter).toHaveBeenCalledWith(8);
+    expect(drawingOpacitySetter).toHaveBeenCalledWith(1);
+    expect(drawingSidesSetter).toHaveBeenCalledWith(6);
+    expect(drawingBorderRadiusSetter).toHaveBeenCalledWith(0);
+    expect(drawingStrokeLineDashSetter).toHaveBeenCalledWith(undefined);
+    expect(drawingStrokeLineCapStartSetter).toHaveBeenCalledWith('round');
+    expect(drawingStrokeLineCapEndSetter).toHaveBeenCalledWith('round');
+    expect(drawingEndpointSizeSetter).toHaveBeenCalledWith(1);
+    expect(drawingEndpointFillSetter).toHaveBeenCalledWith('hollow');
+    expect(drawingIsRoughSetter).toHaveBeenCalledWith(true);
+    expect(drawingRoughnessSetter).toHaveBeenCalledWith(DEFAULT_ROUGHNESS);
+    expect(drawingBowingSetter).toHaveBeenCalledWith(DEFAULT_BOWING);
+    expect(drawingFillWeightSetter).toHaveBeenCalledWith(DEFAULT_FILL_WEIGHT);
+    expect(drawingHachureAngleSetter).toHaveBeenCalledWith(DEFAULT_HACHURE_ANGLE);
+    expect(drawingHachureGapSetter).toHaveBeenCalledWith(DEFAULT_HACHURE_GAP);
+    expect(drawingCurveTightnessSetter).toHaveBeenCalledWith(DEFAULT_CURVE_TIGHTNESS);
+    expect(drawingCurveStepCountSetter).toHaveBeenCalledWith(DEFAULT_CURVE_STEP_COUNT);
+    expect(drawingPreserveVerticesSetter).toHaveBeenCalledWith(DEFAULT_PRESERVE_VERTICES);
+    expect(drawingDisableMultiStrokeSetter).toHaveBeenCalledWith(DEFAULT_DISABLE_MULTI_STROKE);
+    expect(drawingDisableMultiStrokeFillSetter).toHaveBeenCalledWith(DEFAULT_DISABLE_MULTI_STROKE_FILL);
+    expect(drawingTextSetter).toHaveBeenCalledWith('文本');
+    expect(drawingFontFamilySetter).toHaveBeenCalledWith('Excalifont');
+    expect(drawingFontSizeSetter).toHaveBeenCalledWith(24);
+    expect(drawingTextAlignSetter).toHaveBeenCalledWith('left');
+    expect(drawingBlurSetter).toHaveBeenCalledWith(0);
+    expect(drawingShadowEnabledSetter).toHaveBeenCalledWith(false);
+    expect(drawingShadowOffsetXSetter).toHaveBeenCalledWith(2);
+    expect(drawingShadowOffsetYSetter).toHaveBeenCalledWith(2);
+    expect(drawingShadowBlurSetter).toHaveBeenCalledWith(4);
+    expect(drawingShadowColorSetter).toHaveBeenCalledWith('rgba(0,0,0,0.5)');
+    expect(setToolMock).toHaveBeenCalledWith('brush');
+  });
+});

--- a/tests/lib/drawing/transform.test.ts
+++ b/tests/lib/drawing/transform.test.ts
@@ -1,0 +1,160 @@
+// 图形变换核心算法测试
+import { describe, expect, it } from 'vitest';
+import { movePath, rotatePath, rotateResizeHandle, scalePath } from '@/lib/drawing/transform';
+import type { BrushPathData, GroupData, Point, RectangleData, VectorPathData } from '@/types';
+
+const shapeBase = {
+  color: '#000000',
+  fill: 'transparent',
+  fillStyle: 'hachure',
+  strokeWidth: 1,
+  roughness: 0,
+  bowing: 0,
+  fillWeight: 0,
+  hachureAngle: 0,
+  hachureGap: 0,
+  curveTightness: 0,
+  curveStepCount: 0,
+} as const;
+
+describe('movePath', () => {
+  it('moves primitive paths and group children consistently', () => {
+    const brush: BrushPathData = {
+      ...shapeBase,
+      id: 'brush-1',
+      tool: 'brush',
+      points: [
+        { x: 0, y: 0 },
+        { x: 10, y: 5 },
+      ],
+    };
+
+    const movedBrush = movePath(brush, 5, -2);
+    expect(movedBrush.points).toEqual([
+      { x: 5, y: -2 },
+      { x: 15, y: 3 },
+    ]);
+
+    const rect: RectangleData = {
+      ...shapeBase,
+      id: 'rect-1',
+      tool: 'rectangle',
+      x: 20,
+      y: 30,
+      width: 40,
+      height: 20,
+    };
+
+    const group: GroupData = {
+      ...shapeBase,
+      id: 'group-1',
+      tool: 'group',
+      children: [rect],
+    };
+
+    const movedGroup = movePath(group, -3, 4);
+    const movedChild = (movedGroup.children[0] as RectangleData);
+    expect(movedChild.x).toBe(17);
+    expect(movedChild.y).toBe(34);
+  });
+});
+
+describe('scalePath', () => {
+  it('applies scaling relative to the pivot and tracks sign flips', () => {
+    const rect: RectangleData = {
+      ...shapeBase,
+      id: 'rect-2',
+      tool: 'rectangle',
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 10,
+    };
+
+    const scaled = scalePath(rect, { x: 10, y: 20 }, -1, 2);
+    expect(scaled.x).toBe(-20);
+    expect(scaled.y).toBe(20);
+    expect(scaled.width).toBe(30);
+    expect(scaled.height).toBe(20);
+    expect(scaled.scaleX).toBe(-1);
+    expect(scaled.scaleY).toBe(1);
+  });
+
+  it('scales group children recursively', () => {
+    const child: RectangleData = {
+      ...shapeBase,
+      id: 'rect-3',
+      tool: 'rectangle',
+      x: 5,
+      y: 5,
+      width: 10,
+      height: 6,
+    };
+
+    const group: GroupData = {
+      ...shapeBase,
+      id: 'group-2',
+      tool: 'group',
+      children: [child],
+    };
+
+    const pivot: Point = { x: 10, y: 10 };
+    const scaledGroup = scalePath(group, pivot, 2, 3);
+    const scaledChild = scaledGroup.children[0] as RectangleData;
+    expect(scaledChild.width).toBeCloseTo(20);
+    expect(scaledChild.height).toBeCloseTo(18);
+    expect(scaledChild.x).toBeCloseTo(0);
+    expect(scaledChild.y).toBeCloseTo(-5);
+  });
+});
+
+describe('rotatePath', () => {
+  it('updates axis-aligned shapes around an arbitrary center', () => {
+    const rect: RectangleData = {
+      ...shapeBase,
+      id: 'rect-4',
+      tool: 'rectangle',
+      x: 20,
+      y: 10,
+      width: 10,
+      height: 20,
+      rotation: 0,
+    };
+
+    const rotated = rotatePath(rect, { x: 0, y: 0 }, Math.PI / 2);
+    expect(rotated.x).toBeCloseTo(-25);
+    expect(rotated.y).toBeCloseTo(15);
+    expect(rotated.rotation).toBeCloseTo(Math.PI / 2);
+  });
+
+  it('rotates vector anchors and their handles', () => {
+    const vector: VectorPathData = {
+      ...shapeBase,
+      id: 'line-1',
+      tool: 'line',
+      anchors: [
+        {
+          point: { x: 10, y: 0 },
+          handleIn: { x: 5, y: 0 },
+          handleOut: { x: 15, y: 0 },
+        },
+      ],
+    };
+
+    const rotated = rotatePath(vector, { x: 0, y: 0 }, Math.PI);
+    const anchor = rotated.anchors[0];
+    expect(anchor.point.x).toBeCloseTo(-10);
+    expect(anchor.point.y).toBeCloseTo(0);
+    expect(anchor.handleIn.x).toBeCloseTo(-5);
+    expect(anchor.handleIn.y).toBeCloseTo(0);
+    expect(anchor.handleOut.x).toBeCloseTo(-15);
+    expect(anchor.handleOut.y).toBeCloseTo(0);
+  });
+});
+
+describe('rotateResizeHandle', () => {
+  it('re-maps handle positions according to rotation', () => {
+    expect(rotateResizeHandle('top', Math.PI / 2)).toBe('right');
+    expect(rotateResizeHandle('top-left', Math.PI)).toBe('bottom-right');
+  });
+});

--- a/tests/lib/hit-testing.test.ts
+++ b/tests/lib/hit-testing.test.ts
@@ -1,11 +1,11 @@
 // 命中检测函数测试
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('paper', () => ({}));
-import { isPointHittingPath, isPointInPolygon } from '@/lib/hit-testing';
-import type { RectangleData, EllipseData, BrushPathData, Point } from '@/types';
+import { findDeepestHitPath, isPathIntersectingLasso, isPathIntersectingMarquee, isPointHittingPath, isPointInPolygon } from '@/lib/hit-testing';
+import type { AnyPath, RectangleData, EllipseData, BrushPathData, Point, GroupData } from '@/types';
 
 const baseShape = {
-  id: '1',
+  id: 'shape-base',
   color: '#000',
   fill: 'transparent',
   fillStyle: 'solid',
@@ -18,6 +18,24 @@ const baseShape = {
   curveTightness: 0,
   curveStepCount: 0,
 } as const;
+
+const createRectangle = (overrides: Partial<RectangleData> = {}): RectangleData => ({
+  ...baseShape,
+  tool: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 80,
+  fill: '#f00',
+  ...overrides,
+}) as RectangleData;
+
+const createGroup = (children: AnyPath[], overrides: Partial<GroupData> = {}): GroupData => ({
+  ...baseShape,
+  tool: 'group',
+  children,
+  ...overrides,
+}) as GroupData;
 
 describe('命中检测函数测试', () => {
   describe('isPointHittingPath', () => {
@@ -86,6 +104,62 @@ describe('命中检测函数测试', () => {
 
       // 正方形外部的点不应命中
       expect(isPointInPolygon({ x: 150, y: 150 }, polygon)).toBe(false);
+    });
+  });
+
+  describe('findDeepestHitPath', () => {
+    it('优先返回组内命中的子元素并忽略锁定图形', () => {
+      const locked = createRectangle({ id: 'locked', x: 200, y: 200, width: 20, height: 20, isLocked: true });
+      const child = createRectangle({ id: 'child', x: 10, y: 10, width: 40, height: 30 });
+      const group = createGroup([child], { id: 'group', isCollapsed: false });
+      const point = { x: 20, y: 20 };
+
+      const hit = findDeepestHitPath(point, [locked, group], 1);
+      expect(hit?.id).toBe('child');
+    });
+
+    it('跳过折叠的组', () => {
+      const collapsed = createGroup([createRectangle({ id: 'hidden', x: 5, y: 5, width: 10, height: 10 })], { id: 'collapsed', isCollapsed: true });
+      const point = { x: 8, y: 8 };
+      expect(findDeepestHitPath(point, [collapsed], 1)).toBeNull();
+    });
+  });
+
+  describe('isPathIntersectingMarquee', () => {
+    it('识别与旋转矩形的交集', () => {
+      const rotated = createRectangle({ id: 'rotated', x: 40, y: 20, width: 40, height: 30, rotation: Math.PI / 4 });
+      const marquee = { x: 30, y: 15, width: 60, height: 60 };
+      expect(isPathIntersectingMarquee(rotated, marquee)).toBe(true);
+      expect(isPathIntersectingMarquee(rotated, { x: 200, y: 200, width: 20, height: 20 })).toBe(false);
+    });
+
+    it('对组内任一成员命中即返回 true', () => {
+      const inside = createRectangle({ id: 'inside', x: 10, y: 10, width: 20, height: 20 });
+      const outside = createRectangle({ id: 'outside', x: 200, y: 200, width: 10, height: 10 });
+      const group = createGroup([inside, outside], { id: 'group-marquee' });
+      const marquee = { x: 0, y: 0, width: 80, height: 80 };
+      expect(isPathIntersectingMarquee(group, marquee)).toBe(true);
+    });
+  });
+
+  describe('isPathIntersectingLasso', () => {
+    const lasso: Point[] = [
+      { x: 0, y: 0 },
+      { x: 60, y: 0 },
+      { x: 60, y: 60 },
+      { x: 0, y: 60 },
+    ];
+
+    it('判断单个图形被套索完全包含', () => {
+      const rect = createRectangle({ id: 'lasso-rect', x: 10, y: 10, width: 20, height: 20 });
+      expect(isPathIntersectingLasso(rect, lasso)).toBe(true);
+    });
+
+    it('组内任一子元素不在套索中则返回 false', () => {
+      const inside = createRectangle({ id: 'lasso-inside', x: 15, y: 15, width: 10, height: 10 });
+      const outside = createRectangle({ id: 'lasso-outside', x: 100, y: 100, width: 15, height: 15 });
+      const group = createGroup([inside, outside], { id: 'group-lasso' });
+      expect(isPathIntersectingLasso(group, lasso)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add useSelection interaction tests verifying pointer logic and state resets
- add useToolbarState tests for selection updates, default fallbacks, and reset behavior
- cover transform helpers and hit-testing algorithms with new cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8cfaf582c8323bd9422f446458a6b