### PR TITLE
refactor: unify panel control styles

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { HSLA, parseColor, hslaToHslaString, hslaToHex } from '../lib/color';
 import { ICONS } from '../constants';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from './panelStyles';
 
 // 预设颜色数组
 const PRESET_COLORS = [
@@ -188,30 +189,30 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, onInt
         </div>
         
         <div className="flex items-center justify-between gap-2 pt-1">
-           <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-[100px]">
+           <div className={`${PANEL_CLASSES.inputWrapper} w-28`}>
              <input
                type="text"
                value={hexInput}
                onChange={handleHexInputChange}
                onBlur={handleHexInputCommit}
-               onKeyDown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur() }}
-               className="w-full text-xs font-mono bg-transparent text-[var(--text-primary)] focus:outline-none"
+               onKeyDown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
+               className={`${PANEL_CLASSES.input} font-mono text-left`}
                aria-label="Hex color value"
              />
            </div>
-           
-           <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-[70px]">
+
+           <div className={`${PANEL_CLASSES.inputWrapper} w-20`}>
                <input
                  type="number"
                  min="0"
                  max="100"
                  value={Math.round(hsla.a * 100)}
                  onChange={handleAlphaInputChange}
-                 onBlur={(e) => { if (e.target.value === '') handleHslaChange({a: 1})}}
-                 className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
+                 onBlur={(e) => { if (e.target.value === '') handleHslaChange({ a: 1 }); }}
+                 className={`${PANEL_CLASSES.input} hide-spinners`}
                  aria-label="Alpha percentage"
                />
-               <span className="text-xs text-[var(--text-secondary)]">%</span>
+               <span className={PANEL_CLASSES.inputSuffix}>%</span>
            </div>
            
             {'EyeDropper' in window && (

--- a/src/components/FloatingAnimationExporter.tsx
+++ b/src/components/FloatingAnimationExporter.tsx
@@ -9,6 +9,7 @@ import type { AnimationExportOptions, FrameData } from '../types';
 import { useAppContext } from '../context/AppContext';
 import { ICONS } from '../constants';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from './panelStyles';
 
 interface FloatingAnimationExporterProps {
     children: (props: { ref: React.RefObject<any>, onClick: () => void }) => React.ReactNode;
@@ -107,17 +108,17 @@ export const FloatingAnimationExporter: React.FC<FloatingAnimationExporterProps>
     const exporterElement = (
         <Transition show={isOpen} as={Fragment} enter="transition ease-out duration-100" enterFrom="transform opacity-0 scale-95" enterTo="transform opacity-100 scale-100" leave="transition ease-in duration-75" leaveFrom="transform opacity-100 scale-100" leaveTo="transform opacity-0 scale-95">
             <div ref={panelRef} className="fixed z-50 w-60 bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] p-4" style={{ left: position.x, top: position.y }}>
-                <div className="flex flex-col gap-4">
-                    <h3 className="text-sm font-bold text-center text-[var(--text-primary)]">导出动画</h3>
-                    
+                <div className={PANEL_CLASSES.section}>
+                    <h3 className={PANEL_CLASSES.sectionTitle}>导出动画</h3>
+
                     <div>
-                        <label className="text-sm font-medium text-[var(--text-primary)]">导出区域</label>
+                        <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>导出区域</label>
                         <Popover className="relative mt-1">
                             <Popover.Button
                                 as={PanelButton}
                                 variant="unstyled"
                                 disabled={allFrameShapes.length === 0}
-                                className="w-full flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
+                                className={`${PANEL_CLASSES.inputWrapper} w-full justify-between text-sm text-left text-[var(--text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:opacity-50`}
                             >
                                 <span className="truncate">{getFrameLabel(clipToFrameId)}</span>
                                 <div className="w-4 h-4 text-[var(--text-secondary)] flex-shrink-0">{ICONS.CHEVRON_DOWN}</div>
@@ -159,8 +160,8 @@ export const FloatingAnimationExporter: React.FC<FloatingAnimationExporterProps>
                     </div>
 
                     <RadioGroup value={format} onChange={setFormat}>
-                        <RadioGroup.Label className="text-sm font-medium">格式</RadioGroup.Label>
-                        <div className="flex gap-2 mt-1">
+                        <RadioGroup.Label className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>格式</RadioGroup.Label>
+                        <div className={`${PANEL_CLASSES.controlsRow} mt-1`}>
                             <RadioGroup.Option value="sequence" as={Fragment}>
                                 {({ checked }) => (
                                   <PanelButton
@@ -184,10 +185,18 @@ export const FloatingAnimationExporter: React.FC<FloatingAnimationExporterProps>
                         </div>
                     </RadioGroup>
 
-                    <div className={`grid grid-cols-2 items-center gap-2 transition-opacity ${format !== 'spritesheet' ? 'opacity-50 pointer-events-none' : ''}`}>
-                        <label htmlFor="spritesheet-cols" className="text-sm font-medium text-[var(--text-primary)]">列数</label>
-                        <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px]">
-                            <input id="spritesheet-cols" type="number" min="1" step="1" value={columns} onChange={e => setColumns(Math.max(1, parseInt(e.target.value) || 1))} className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners" />
+                    <div className={`grid grid-cols-2 items-center gap-3 transition-opacity ${format !== 'spritesheet' ? 'opacity-50 pointer-events-none' : ''}`}>
+                        <label htmlFor="spritesheet-cols" className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>列数</label>
+                        <div className={`${PANEL_CLASSES.inputWrapper} w-full`}>
+                            <input
+                                id="spritesheet-cols"
+                                type="number"
+                                min="1"
+                                step="1"
+                                value={columns}
+                                onChange={e => setColumns(Math.max(1, parseInt(e.target.value) || 1))}
+                                className={`${PANEL_CLASSES.input} hide-spinners`}
+                            />
                         </div>
                     </div>
                     

--- a/src/components/FloatingPngExporter.tsx
+++ b/src/components/FloatingPngExporter.tsx
@@ -7,6 +7,7 @@ import { createPortal } from 'react-dom';
 import { Transition, Switch } from '@headlessui/react';
 import type { PngExportOptions } from '../types';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from './panelStyles';
 
 interface FloatingPngExporterProps {
     children: (props: { ref: React.RefObject<any>, onClick: () => void }) => React.ReactNode;
@@ -18,8 +19,8 @@ interface FloatingPngExporterProps {
 }
 
 const SwitchControl: React.FC<{ label: string; enabled: boolean; setEnabled: (enabled: boolean) => void; }> = ({ label, enabled, setEnabled }) => (
-    <div className="flex items-center justify-between">
-        <label htmlFor={label} className="text-sm font-medium text-[var(--text-primary)]">{label}</label>
+    <div className={`${PANEL_CLASSES.control} justify-between`}>
+        <label htmlFor={label} className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>{label}</label>
         <Switch
             id={label}
             checked={enabled}
@@ -128,11 +129,11 @@ export const FloatingPngExporter: React.FC<FloatingPngExporterProps> = ({
                 className="fixed z-50 w-56 bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] p-4"
                 style={{ left: position.x, top: position.y }}
             >
-                <div className="flex flex-col gap-4">
-                    <h3 className="text-sm font-bold text-center text-[var(--text-primary)]">PNG 导出选项</h3>
-                    <div className="grid grid-cols-2 items-center gap-2">
-                        <label htmlFor="png-scale" className="text-sm font-medium text-[var(--text-primary)]">比例</label>
-                        <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px]">
+                <div className={PANEL_CLASSES.section}>
+                    <h3 className={PANEL_CLASSES.sectionTitle}>PNG 导出选项</h3>
+                    <div className="grid grid-cols-2 items-center gap-3">
+                        <label htmlFor="png-scale" className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>比例</label>
+                        <div className={`${PANEL_CLASSES.inputWrapper} w-full`}>
                             <input
                                 id="png-scale"
                                 type="number"
@@ -141,9 +142,9 @@ export const FloatingPngExporter: React.FC<FloatingPngExporterProps> = ({
                                 step="0.1"
                                 value={pngExportOptions.scale}
                                 onChange={e => setPngExportOptions(prev => ({ ...prev, scale: Math.max(0.1, parseFloat(e.target.value)) || 1 }))}
-                                className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                className={`${PANEL_CLASSES.input} hide-spinners`}
                             />
-                            <span className="text-xs text-[var(--text-secondary)]">x</span>
+                            <span className={PANEL_CLASSES.inputSuffix}>x</span>
                         </div>
                     </div>
                     <SwitchControl label="透明背景" enabled={pngExportOptions.transparentBg} setEnabled={val => setPngExportOptions(prev => ({ ...prev, transparentBg: val }))} />

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -6,6 +6,7 @@ import { Popover, Transition } from '@headlessui/react';
 import { useTranslation } from 'react-i18next';
 import { ICONS } from '@/constants';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from './panelStyles';
 import i18n, { supportedLangs, type Lang } from '@/lib/i18n';
 
 /**
@@ -31,7 +32,7 @@ const LanguageSelector: React.FC = () => {
       <Popover.Button
         as={PanelButton}
         variant="unstyled"
-        className="w-full flex items-center gap-3 p-2 h-9 rounded-md bg-black/20 text-sm text-left text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
+        className={`w-full ${PANEL_CLASSES.inputWrapper} justify-between text-sm text-left text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]`}
       >
         <div className="w-4 h-4 flex items-center justify-center text-[var(--text-secondary)]">{ICONS.LANGUAGE}</div>
         <span className="flex-grow">{t('language')}</span>

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -6,6 +6,7 @@
 import React, { Fragment, useState } from 'react';
 import { Popover, Transition, RadioGroup } from '@headlessui/react';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from './panelStyles';
 import { ICONS } from '../constants';
 import type { SelectionMode, Alignment, DistributeMode } from '../types';
 import { Slider, SwitchControl } from './side-toolbar';
@@ -208,7 +209,7 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
                     <div className="h-px bg-[var(--ui-separator)]" />
 
                     <div>
-                      <label className="text-sm font-semibold text-[var(--text-primary)]">{t('distribute')}</label>
+                      <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] font-semibold`}>{t('distribute')}</label>
                       <div className="flex items-center gap-2 mt-2">
                         <PanelButton
                           variant="unstyled"
@@ -230,25 +231,25 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
                       <div className="grid grid-cols-2 gap-4 mt-3">
                          <div>
                             <RadioGroup value={distributeMode} onChange={setDistributeMode}>
-                              <RadioGroup.Label className="text-sm font-semibold text-[var(--text-primary)] mb-1 block">{t('evenSpacing')}</RadioGroup.Label>
-                              <div className="flex bg-[var(--ui-element-bg)] rounded-md p-1">
+                              <RadioGroup.Label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] font-semibold mb-1 block`}>{t('evenSpacing')}</RadioGroup.Label>
+                              <div className={PANEL_CLASSES.segmentGroup}>
                                 <RadioGroup.Option value="edges" className={({checked}) => `flex-1 text-center text-sm py-1 rounded-md cursor-pointer ${checked ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'}`}>{t('edges')}</RadioGroup.Option>
                                 <RadioGroup.Option value="centers" className={({checked}) => `flex-1 text-center text-sm py-1 rounded-md cursor-pointer ${checked ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'}`}>{t('centers')}</RadioGroup.Option>
                               </div>
                             </RadioGroup>
                          </div>
                          <div>
-                            <label htmlFor="dist-spacing" className="text-sm font-semibold text-[var(--text-primary)] mb-1 block">{t('fixedSpacing')}</label>
-                             <div className="flex items-center bg-[var(--ui-element-bg)] rounded-md h-[30px] px-[7px]">
+                            <label htmlFor="dist-spacing" className={`${PANEL_CLASSES.label} text-[var(--text-primary)] font-semibold mb-1 block`}>{t('fixedSpacing')}</label>
+                             <div className={`${PANEL_CLASSES.inputWrapper} w-full`}>
                               <input
                                 id="dist-spacing"
                                 type="number"
                                 placeholder={t('auto')}
                                 value={distributeSpacing}
                                 onChange={(e) => setDistributeSpacing(e.target.value)}
-                                className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
+                                className={`${PANEL_CLASSES.input} hide-spinners`}
                               />
-                              <span className="text-xs text-[var(--text-secondary)]">px</span>
+                              <span className={PANEL_CLASSES.inputSuffix}>px</span>
                             </div>
                          </div>
                       </div>

--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -8,6 +8,7 @@ import { ICONS } from '../constants';
 import { Transition } from '@headlessui/react';
 import { pathsToSvgString } from '../lib/export';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from './panelStyles';
 import type { Frame } from '../types';
 
 /**
@@ -144,68 +145,95 @@ export const TimelinePanel: React.FC = () => {
             leaveTo="opacity-0 max-h-0"
         >
             <div className="p-3 h-48 w-full max-w-full flex flex-col">
-                <div className="flex items-center gap-4">
-                      <div className="flex items-center gap-2">
-                          <PanelButton onClick={handleRewind} title="回到开头" className="text-[var(--text-secondary)]">
-                              {ICONS.REWIND}
-                          </PanelButton>
-                          <PanelButton
-                              onClick={handlePlayPause}
-                              title={isPlaying ? '暂停' : '播放'}
-                              className={isPlaying ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)]'}
-                          >
-                              {isPlaying ? ICONS.PAUSE : ICONS.PLAY}
-                          </PanelButton>
-                      </div>
-                    <div className="flex items-center gap-2">
-                         <label htmlFor="fps-input" className="text-sm font-medium text-[var(--text-secondary)]">FPS</label>
-                         <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
-                           <input
-                             id="fps-input" type="number" min="1" max="60" step="1"
-                             value={fps} onChange={(e) => setFps(Math.max(1, parseInt(e.target.value) || 1))}
-                             className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
-                           />
-                         </div>
+                <div className={PANEL_CLASSES.controlsRow}>
+                    <div className={PANEL_CLASSES.control}>
+                        <PanelButton onClick={handleRewind} title="回到开头" className="text-[var(--text-secondary)]">
+                            {ICONS.REWIND}
+                        </PanelButton>
+                        <PanelButton
+                            onClick={handlePlayPause}
+                            title={isPlaying ? '暂停' : '播放'}
+                            className={isPlaying ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)]'}
+                        >
+                            {isPlaying ? ICONS.PAUSE : ICONS.PLAY}
+                        </PanelButton>
                     </div>
-                      <div className="flex items-center gap-2">
-                          <PanelButton
-                              onClick={() => setIsOnionSkinEnabled(p => !p)}
-                              title="洋葱皮"
-                              className={isOnionSkinEnabled ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)]'}
-                          >
-                              {ICONS.ONION_SKIN}
-                          </PanelButton>
-                          <div className={`flex items-center gap-4 transition-opacity ${isOnionSkinEnabled ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
-                            <div className="flex items-center gap-2">
-                                <label htmlFor="onion-opacity-input" className="text-sm font-medium text-[var(--text-secondary)]">透明度</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-16">
-                                <input
-                                    id="onion-opacity-input" type="number" min="0" max="100" step="1"
-                                    value={Math.round(onionSkinOpacity * 100)}
-                                    onChange={(e) => setOnionSkinOpacity(Math.max(0, Math.min(100, parseInt(e.target.value) || 0)) / 100)}
-                                    className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
-                                />
-                                 <span className="text-xs text-[var(--text-secondary)]">%</span>
+                    <div className={PANEL_CLASSES.control}>
+                        <label htmlFor="fps-input" className={PANEL_CLASSES.label}>FPS</label>
+                        <div className={PANEL_CLASSES.inputWrapper}>
+                            <input
+                                id="fps-input"
+                                type="number"
+                                min="1"
+                                max="60"
+                                step="1"
+                                value={fps}
+                                onChange={(e) => setFps(Math.max(1, parseInt(e.target.value) || 1))}
+                                className={`${PANEL_CLASSES.input} hide-spinners`}
+                            />
+                        </div>
+                    </div>
+                    <div className={PANEL_CLASSES.control}>
+                        <PanelButton
+                            onClick={() => setIsOnionSkinEnabled(p => !p)}
+                            title="洋葱皮"
+                            className={isOnionSkinEnabled ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]' : 'text-[var(--text-secondary)]'}
+                        >
+                            {ICONS.ONION_SKIN}
+                        </PanelButton>
+                        <div
+                            className={`${PANEL_CLASSES.controlsRow} transition-opacity ${
+                                isOnionSkinEnabled ? 'opacity-100' : 'opacity-0 pointer-events-none'
+                            }`}
+                        >
+                            <div className={PANEL_CLASSES.control}>
+                                <label htmlFor="onion-opacity-input" className={PANEL_CLASSES.label}>透明度</label>
+                                <div className={PANEL_CLASSES.inputWrapper}>
+                                    <input
+                                        id="onion-opacity-input"
+                                        type="number"
+                                        min="0"
+                                        max="100"
+                                        step="1"
+                                        value={Math.round(onionSkinOpacity * 100)}
+                                        onChange={(e) =>
+                                            setOnionSkinOpacity(
+                                                Math.max(0, Math.min(100, parseInt(e.target.value) || 0)) / 100
+                                            )
+                                        }
+                                        className={`${PANEL_CLASSES.input} hide-spinners`}
+                                    />
+                                    <span className={PANEL_CLASSES.inputSuffix}>%</span>
                                 </div>
                             </div>
-                            <div className="flex items-center gap-2">
-                                <label htmlFor="prev-frames-input" className="text-sm font-medium text-[var(--text-secondary)]">之前</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-14">
-                                <input
-                                    id="prev-frames-input" type="number" min="0" max="10" step="1"
-                                    value={onionSkinPrevFrames} onChange={(e) => setOnionSkinPrevFrames(Math.max(0, parseInt(e.target.value) || 0))}
-                                    className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
-                                />
+                            <div className={PANEL_CLASSES.control}>
+                                <label htmlFor="prev-frames-input" className={PANEL_CLASSES.label}>之前</label>
+                                <div className={PANEL_CLASSES.inputWrapper}>
+                                    <input
+                                        id="prev-frames-input"
+                                        type="number"
+                                        min="0"
+                                        max="10"
+                                        step="1"
+                                        value={onionSkinPrevFrames}
+                                        onChange={(e) => setOnionSkinPrevFrames(Math.max(0, parseInt(e.target.value) || 0))}
+                                        className={`${PANEL_CLASSES.input} hide-spinners`}
+                                    />
                                 </div>
                             </div>
-                            <div className="flex items-center gap-2">
-                                <label htmlFor="next-frames-input" className="text-sm font-medium text-[var(--text-secondary)]">之后</label>
-                                <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-14">
-                                <input
-                                    id="next-frames-input" type="number" min="0" max="10" step="1"
-                                    value={onionSkinNextFrames} onChange={(e) => setOnionSkinNextFrames(Math.max(0, parseInt(e.target.value) || 0))}
-                                    className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
-                                />
+                            <div className={PANEL_CLASSES.control}>
+                                <label htmlFor="next-frames-input" className={PANEL_CLASSES.label}>之后</label>
+                                <div className={PANEL_CLASSES.inputWrapper}>
+                                    <input
+                                        id="next-frames-input"
+                                        type="number"
+                                        min="0"
+                                        max="10"
+                                        step="1"
+                                        value={onionSkinNextFrames}
+                                        onChange={(e) => setOnionSkinNextFrames(Math.max(0, parseInt(e.target.value) || 0))}
+                                        className={`${PANEL_CLASSES.input} hide-spinners`}
+                                    />
                                 </div>
                             </div>
                         </div>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -9,6 +9,7 @@ import PanelButton from '@/components/PanelButton';
 import { ICONS } from '../constants';
 import type { Tool } from '../types';
 import { useTranslation } from 'react-i18next';
+import { PANEL_CLASSES } from './panelStyles';
 
 interface ToolbarProps {
   tool: Tool;
@@ -97,7 +98,7 @@ export const Toolbar: React.FC<ToolbarProps> = ({
         >
           <Popover.Panel className="absolute top-full mt-2 left-1/2 -translate-x-1/2 w-56 bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] p-3">
             <div className="grid grid-cols-[auto,1fr] gap-x-2 gap-y-2 items-center">
-              <label htmlFor="grid-toggle" className="text-sm font-medium justify-self-start">{t('showGrid')}</label>
+              <label htmlFor="grid-toggle" className={`${PANEL_CLASSES.label} text-[var(--text-primary)] justify-self-start`}>{t('showGrid')}</label>
               <div className="justify-self-end">
                 <Switch
                   id="grid-toggle"
@@ -109,8 +110,8 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                 </Switch>
               </div>
 
-              <label htmlFor="grid-size" className="text-sm font-medium justify-self-start">{t('gridSize')}</label>
-              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20 justify-self-end">
+              <label htmlFor="grid-size" className={`${PANEL_CLASSES.label} text-[var(--text-primary)] justify-self-start`}>{t('gridSize')}</label>
+              <div className={`${PANEL_CLASSES.inputWrapper} w-20 justify-self-end`}>
                 <input
                   id="grid-size"
                   type="number"
@@ -119,14 +120,14 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                   step="5"
                   value={gridSize}
                   onChange={(e) => setGridSize(Math.max(5, Number(e.target.value)))}
-                  className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
+                  className={`${PANEL_CLASSES.input} hide-spinners`}
                   disabled={!isGridVisible}
                 />
-                <span className="text-xs text-[var(--text-secondary)]">px</span>
+                <span className={PANEL_CLASSES.inputSuffix}>px</span>
               </div>
 
-              <label htmlFor="grid-subdivisions" className="text-sm font-medium justify-self-start">{t('subdivisions')}</label>
-              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20 justify-self-end">
+              <label htmlFor="grid-subdivisions" className={`${PANEL_CLASSES.label} text-[var(--text-primary)] justify-self-start`}>{t('subdivisions')}</label>
+              <div className={`${PANEL_CLASSES.inputWrapper} w-20 justify-self-end`}>
                 <input
                   id="grid-subdivisions"
                   type="number"
@@ -135,13 +136,13 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                   step="1"
                   value={gridSubdivisions}
                   onChange={(e) => setGridSubdivisions(Math.max(2, Number(e.target.value)))}
-                  className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
+                  className={`${PANEL_CLASSES.input} hide-spinners`}
                   disabled={!isGridVisible}
                 />
               </div>
 
-              <label htmlFor="grid-opacity" className="text-sm font-medium justify-self-start">{t('opacity')}</label>
-              <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-20 justify-self-end">
+              <label htmlFor="grid-opacity" className={`${PANEL_CLASSES.label} text-[var(--text-primary)] justify-self-start`}>{t('opacity')}</label>
+              <div className={`${PANEL_CLASSES.inputWrapper} w-20 justify-self-end`}>
                 <input
                   id="grid-opacity"
                   type="number"
@@ -150,10 +151,10 @@ export const Toolbar: React.FC<ToolbarProps> = ({
                   step="1"
                   value={Math.round(gridOpacity * 100)}
                   onChange={(e) => setGridOpacity(Math.max(0, Math.min(100, Number(e.target.value))) / 100)}
-                  className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)] hide-spinners"
+                  className={`${PANEL_CLASSES.input} hide-spinners`}
                   disabled={!isGridVisible}
                 />
-                <span className="text-xs text-[var(--text-secondary)]">%</span>
+                <span className={PANEL_CLASSES.inputSuffix}>%</span>
               </div>
             </div>
           </Popover.Panel>

--- a/src/components/panelStyles.ts
+++ b/src/components/panelStyles.ts
@@ -1,0 +1,14 @@
+export const PANEL_CLASSES = {
+  section: 'panel-section',
+  sectionTitle: 'panel-section-title',
+  controlsRow: 'panel-controls',
+  control: 'panel-control',
+  label: 'panel-label',
+  inputWrapper: 'panel-input-wrapper',
+  input: 'panel-input',
+  inputSuffix: 'panel-input-suffix',
+  segmentGroup: 'panel-segmented',
+  segmentGrid: 'panel-segmented-grid',
+} as const;
+
+export type PanelClassKey = keyof typeof PANEL_CLASSES;

--- a/src/components/side-toolbar/DashControl.tsx
+++ b/src/components/side-toolbar/DashControl.tsx
@@ -5,6 +5,7 @@ import type { EndpointStyle } from '@/types';
 import PanelButton from '@/components/PanelButton';
 import { useDashGapInput } from '@/hooks/side-toolbar/useDashGapInput';
 import { SwitchControl } from './shared';
+import { PANEL_CLASSES } from '../panelStyles';
 
 interface DashControlProps {
     strokeWidth: number;
@@ -37,12 +38,12 @@ export const DashControl: React.FC<DashControlProps> = React.memo((props) => {
                 </Popover.Button>
                 <Transition as={Fragment} enter="transition ease-out duration-200" enterFrom="opacity-0 translate-y-1" enterTo="opacity-100 translate-y-0" leave="transition ease-in duration-150" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-1">
                     <Popover.Panel className="absolute bottom-0 mb-0 right-full mr-2 w-48 bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] z-20 p-4">
-                        <div className="flex flex-col gap-4">
+                        <div className={PANEL_CLASSES.section}>
                             <SwitchControl label="虚线" enabled={dashGap.isDashed} setEnabled={dashGap.handleToggleDashed} />
                             <div className={`space-y-3 transition-opacity ${!dashGap.isDashed ? 'opacity-50 pointer-events-none' : ''}`}>
                                 <div className="grid grid-cols-2 items-center gap-2">
-                                    <label htmlFor="dash-length-input" className="text-sm font-medium text-[var(--text-primary)]">虚线长度</label>
-                                    <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] cursor-ns-resize" onWheel={dashGap.handleDashWheel} title="使用滚轮调节">
+                                    <label htmlFor="dash-length-input" className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>虚线长度</label>
+                                    <div className={`${PANEL_CLASSES.inputWrapper} cursor-ns-resize`} onWheel={dashGap.handleDashWheel} title="使用滚轮调节">
                                         <input
                                             id="dash-length-input"
                                             type="text"
@@ -52,15 +53,15 @@ export const DashControl: React.FC<DashControlProps> = React.memo((props) => {
                                             onChange={(e) => dashGap.setLocalDash(e.target.value.replace(/[^0-9]/g, ''))}
                                             onBlur={dashGap.handleCommit}
                                             onKeyDown={(e) => { if (e.key === 'Enter') { dashGap.handleCommit(); (e.currentTarget as HTMLInputElement).blur(); }}}
-                                            className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)]"
+                                            className={PANEL_CLASSES.input}
                                             aria-label="虚线长度"
                                         />
-                                        <span className="text-xs text-[var(--text-secondary)]">px</span>
+                                        <span className={PANEL_CLASSES.inputSuffix}>px</span>
                                     </div>
                                 </div>
                                 <div className="grid grid-cols-2 items-center gap-2">
-                                    <label htmlFor="dash-gap-input" className="text-sm font-medium text-[var(--text-primary)]">虚线间隔</label>
-                                    <div className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] cursor-ns-resize" onWheel={dashGap.handleGapWheel} title="使用滚轮调节">
+                                    <label htmlFor="dash-gap-input" className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>虚线间隔</label>
+                                    <div className={`${PANEL_CLASSES.inputWrapper} cursor-ns-resize`} onWheel={dashGap.handleGapWheel} title="使用滚轮调节">
                                         <input
                                             id="dash-gap-input"
                                             type="text"
@@ -70,10 +71,10 @@ export const DashControl: React.FC<DashControlProps> = React.memo((props) => {
                                             onChange={(e) => dashGap.setLocalGap(e.target.value.replace(/[^0-9]/g, ''))}
                                             onBlur={dashGap.handleCommit}
                                             onKeyDown={(e) => { if (e.key === 'Enter') { dashGap.handleCommit(); (e.currentTarget as HTMLInputElement).blur(); }}}
-                                            className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)]"
+                                            className={PANEL_CLASSES.input}
                                             aria-label="虚线间隔"
                                         />
-                                        <span className="text-xs text-[var(--text-secondary)]">px</span>
+                                        <span className={PANEL_CLASSES.inputSuffix}>px</span>
                                     </div>
                                 </div>
                             </div>

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useWheelCoalescer } from '@/hooks/side-toolbar/useWheelCoalescer';
+import { PANEL_CLASSES } from '../panelStyles';
 
 interface NumericInputProps {
   label: string;
@@ -71,7 +72,7 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
   return (
     <div className="flex flex-col items-center w-14" title={label}>
       <div
-        className="flex items-center bg-black/20 rounded-md h-[30px] px-[7px] w-full cursor-ns-resize"
+        className={`${PANEL_CLASSES.inputWrapper} w-full cursor-ns-resize`}
         onWheel={(e) => handleWheel(e, handleWheelUpdate)}
       >
         <input
@@ -94,10 +95,10 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
               e.currentTarget.blur();
             }
           }}
-          className="w-full bg-transparent text-xs text-center outline-none text-[var(--text-primary)]"
+          className={PANEL_CLASSES.input}
           aria-label={label}
         />
-        <span className="text-xs text-[var(--text-secondary)]">{unit}</span>
+        <span className={PANEL_CLASSES.inputSuffix}>{unit}</span>
       </div>
     </div>
   );

--- a/src/components/side-toolbar/TextProperties.tsx
+++ b/src/components/side-toolbar/TextProperties.tsx
@@ -7,6 +7,7 @@ import { Popover, Transition } from '@headlessui/react';
 import { ICONS } from '@/constants';
 import { NumericInput } from './NumericInput';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from '../panelStyles';
 
 interface TextPropertiesProps {
   text: string;
@@ -83,7 +84,7 @@ export const TextProperties: React.FC<TextPropertiesProps> = ({
           <Popover.Button
             as={PanelButton}
             variant="unstyled"
-            className="w-full flex items-center justify-between p-2 h-9 rounded-md bg-black/20 text-sm text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-primary)]"
+            className={`${PANEL_CLASSES.inputWrapper} w-full justify-between text-sm text-[var(--text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]`}
           >
               <span style={{fontFamily: fontFamily}}>{FONT_OPTIONS.find(f => f.name === fontFamily)?.label ?? fontFamily}</span>
               <div className="w-4 h-4 text-[var(--text-secondary)]">{ICONS.CHEVRON_DOWN}</div>
@@ -130,7 +131,7 @@ export const TextProperties: React.FC<TextPropertiesProps> = ({
       />
       
       <div className="flex flex-col items-center w-full" title="对齐">
-        <div className="flex bg-black/20 rounded-md p-1 w-full">
+        <div className={`${PANEL_CLASSES.segmentGroup} w-full`}>
             {ALIGN_OPTIONS.map(opt => (
               <PanelButton
                 variant="unstyled"

--- a/src/components/side-toolbar/shared.tsx
+++ b/src/components/side-toolbar/shared.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Switch } from '@headlessui/react';
 import { FloatingColorPicker } from '../FloatingColorPicker';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from '../panelStyles';
 
 interface SwitchControlProps {
   label: string;
@@ -10,8 +11,8 @@ interface SwitchControlProps {
 }
 
 export const SwitchControl: React.FC<SwitchControlProps> = React.memo(({ label, enabled, setEnabled }) => (
-  <div className="flex items-center justify-between">
-    <label htmlFor={label} className="text-sm font-medium text-[var(--text-primary)]">{label}</label>
+  <div className={`${PANEL_CLASSES.control} justify-between`}>
+    <label htmlFor={label} className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>{label}</label>
     <Switch
       id={label}
       checked={enabled}
@@ -45,10 +46,10 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
 
   return (
     <div className="grid grid-cols-[auto,1fr] items-center gap-x-4">
-      <label className="text-sm font-medium text-[var(--text-primary)] whitespace-nowrap" htmlFor={label}>{label}</label>
+      <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] whitespace-nowrap`} htmlFor={label}>{label}</label>
       <div className="w-full">
-        <input 
-          type="range" 
+        <input
+          type="range"
           id={label} 
           min={min} 
           max={max} 
@@ -72,8 +73,8 @@ export const EndpointGrid = <T extends string>({ label, options, value, onChange
   onChange: (value: T) => void;
 }) => (
   <div className="flex flex-col gap-2">
-    <label className="text-sm font-medium text-[var(--text-primary)]">{label}</label>
-    <div className="grid grid-cols-3 gap-1 bg-black/20 rounded-md p-1">
+    <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>{label}</label>
+    <div className={`${PANEL_CLASSES.segmentGrid} grid-cols-3`}>
       {options.map(opt => (
         <PanelButton
           variant="unstyled"
@@ -99,8 +100,8 @@ interface SegmentedControlProps<T extends string> {
 
 export const PopoverSegmentedControl = <T extends string>({ label, options, value, onChange, disabled = false }: SegmentedControlProps<T>) => (
   <div className="flex flex-col gap-2">
-    <label className="text-sm font-medium text-[var(--text-primary)]">{label}</label>
-    <div className={`flex items-center bg-black/20 rounded-md p-1 w-full ${disabled ? 'cursor-not-allowed' : ''}`}>
+    <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)]`}>{label}</label>
+    <div className={`${PANEL_CLASSES.segmentGroup} w-full ${disabled ? 'cursor-not-allowed' : ''}`}>
       {options.map(opt => (
         <PanelButton
           variant="unstyled"
@@ -125,7 +126,7 @@ export const PopoverColorControl: React.FC<{ label: string, color: string, setCo
     };
     return (
         <div className="grid grid-cols-[auto,1fr] items-center gap-x-4">
-            <label className="text-sm font-medium text-[var(--text-primary)] whitespace-nowrap">{label}</label>
+            <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] whitespace-nowrap`}>{label}</label>
             <FloatingColorPicker
                 color={color}
                 onChange={setColor}

--- a/src/index.css
+++ b/src/index.css
@@ -114,6 +114,68 @@ textarea {
   font-size: 85%;
 }
 
+@layer components {
+  .panel-section {
+    @apply flex flex-col gap-4;
+  }
+
+  .panel-section-title {
+    @apply text-sm font-semibold text-center;
+    color: var(--text-primary);
+  }
+
+  .panel-controls {
+    @apply flex flex-wrap items-center gap-4;
+  }
+
+  .panel-control {
+    @apply flex items-center gap-2;
+  }
+
+  .panel-label {
+    @apply text-sm font-medium;
+    color: var(--text-secondary);
+  }
+
+  .panel-input-wrapper {
+    @apply flex items-center gap-2 rounded-md px-3 h-9 transition-colors;
+    width: 4.5rem;
+    background-color: rgba(0, 0, 0, 0.2);
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+  }
+
+  .panel-input-wrapper:focus-within {
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 2px rgba(var(--oc-blue-6-rgb), 0.2);
+  }
+
+  .panel-input {
+    @apply w-full bg-transparent text-sm text-center outline-none;
+    color: var(--text-primary);
+  }
+
+  .panel-input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .panel-input-suffix {
+    @apply text-xs;
+    color: var(--text-secondary);
+  }
+
+  .panel-segmented {
+    @apply flex rounded-md p-1 gap-1;
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+
+  .panel-segmented-grid {
+    @apply grid rounded-md p-1 gap-1;
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+}
+
 
 body.light-bg-canvas {
   --grid-line: rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## Summary
- add shared panel style utility classes and TypeScript mappings for reuse
- refactor timeline, exporters, toolbar, language selector, and side toolbar inputs to use the shared styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8e0406864832385479a486a426304