### PR TITLE
Fix timeline overlay controls alignment

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -16,7 +16,11 @@ export const CropToolbar: React.FC = () => {
   return (
     <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)] transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)' }}
+      style={{
+        bottom: isTimelineCollapsed
+          ? '1rem'
+          : 'calc(var(--timeline-panel-height, 12rem) + var(--timeline-floating-gap, 0.25rem))'
+      }}
     >
       <PanelButton
         type="button"

--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -16,7 +16,7 @@ export const CropToolbar: React.FC = () => {
   return (
     <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)] transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)' }}
     >
       <PanelButton
         type="button"

--- a/src/components/layout/AboutButton.tsx
+++ b/src/components/layout/AboutButton.tsx
@@ -22,7 +22,7 @@ export const AboutButton: React.FC = () => {
   return (
     <div 
       className="absolute right-4 z-30 transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)' }}
     >
         <Popover className="relative">
           <Popover.Button

--- a/src/components/layout/AboutButton.tsx
+++ b/src/components/layout/AboutButton.tsx
@@ -22,7 +22,11 @@ export const AboutButton: React.FC = () => {
   return (
     <div 
       className="absolute right-4 z-30 transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)' }}
+      style={{
+        bottom: isTimelineCollapsed
+          ? '1rem'
+          : 'calc(var(--timeline-panel-height, 12rem) + var(--timeline-floating-gap, 0.25rem))'
+      }}
     >
         <Popover className="relative">
           <Popover.Button

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -173,7 +173,11 @@ export const CanvasOverlays: React.FC = () => {
             {tool === 'selection' && !croppingState && selectedPathIds.length > 0 && (
                 <div 
                     className="absolute left-1/2 -translate-x-1/2 z-30 transition-all duration-300 ease-in-out"
-                    style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)' }}
+                    style={{
+                        bottom: isTimelineCollapsed
+                            ? '1rem'
+                            : 'calc(var(--timeline-panel-height, 12rem) + var(--timeline-floating-gap, 0.25rem))'
+                    }}
                 >
                     <SelectionToolbar
                         selectionMode={selectionMode} setSelectionMode={store.setSelectionMode}
@@ -216,7 +220,9 @@ export const CanvasOverlays: React.FC = () => {
             <div
                 className="absolute left-4 z-30 flex items-center gap-2"
                 style={{
-                    bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)',
+                    bottom: isTimelineCollapsed
+                        ? '1rem'
+                        : 'calc(var(--timeline-panel-height, 12rem) + var(--timeline-floating-gap, 0.25rem))',
                     transition: 'bottom 300ms ease-in-out'
                 }}
             >

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -173,7 +173,7 @@ export const CanvasOverlays: React.FC = () => {
             {tool === 'selection' && !croppingState && selectedPathIds.length > 0 && (
                 <div 
                     className="absolute left-1/2 -translate-x-1/2 z-30 transition-all duration-300 ease-in-out"
-                    style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+                    style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)' }}
                 >
                     <SelectionToolbar
                         selectionMode={selectionMode} setSelectionMode={store.setSelectionMode}
@@ -216,7 +216,7 @@ export const CanvasOverlays: React.FC = () => {
             <div
                 className="absolute left-4 z-30 flex items-center gap-2"
                 style={{
-                    bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)',
+                    bottom: isTimelineCollapsed ? '1rem' : 'calc(var(--timeline-panel-height, 12rem) + 1rem)',
                     transition: 'bottom 300ms ease-in-out'
                 }}
             >

--- a/src/index.css
+++ b/src/index.css
@@ -64,6 +64,7 @@
   --ui-element-bg-active: var(--oc-gray-7);
   --ui-element-bg-inactive: rgba(0, 0, 0, 0.3);
   --timeline-panel-height: 12rem;
+  --timeline-floating-gap: 0.25rem;
 
   /* Canvas Specific */
   --grid-line: rgba(var(--oc-gray-7-rgb), 0.5);

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,7 @@
   --ui-element-bg-hover: var(--oc-gray-8);
   --ui-element-bg-active: var(--oc-gray-7);
   --ui-element-bg-inactive: rgba(0, 0, 0, 0.3);
+  --timeline-panel-height: 12rem;
 
   /* Canvas Specific */
   --grid-line: rgba(var(--oc-gray-7-rgb), 0.5);


### PR DESCRIPTION
## Summary
- measure the expanded timeline panel height and expose it via the --timeline-panel-height CSS variable
- reuse the shared CSS variable when positioning floating toolbars/buttons above the timeline
- provide a default value so overlays fall back gracefully before the panel is measured

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92a57ac148323889d73c5a312d0ca