### PR TITLE
Align main menu tabs height with style library

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -110,7 +110,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
               {({ selected }) => (
                 <PanelButton
                   variant="unstyled"
-                  className={`flex-1 flex items-center justify-center gap-2 rounded-md py-2 text-sm font-medium leading-5 transition-colors duration-150 ease-in-out ring-offset-2 ring-offset-[var(--ui-panel-bg)] ring-[var(--accent-primary)] ${
+                  className={`flex-1 flex items-center justify-center gap-2 rounded-md py-1.5 text-sm font-medium leading-5 transition-colors duration-150 ease-in-out ring-offset-2 ring-offset-[var(--ui-panel-bg)] ring-[var(--accent-primary)] ${
                     selected
                       ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
                       : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'


### PR DESCRIPTION
## Summary
- reduce the vertical padding on the Menu/Layers tabs so they match the style/material controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c92ac6342c8323862099b9cab25f3c