### PR TITLE
fix: widen numeric inputs in side toolbar

### DIFF
--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -70,9 +70,9 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
   const handleWheel = useWheelCoalescer(beginCoalescing, endCoalescing);
 
   return (
-    <div className="flex flex-col items-center w-14" title={label}>
+    <div className="flex flex-col items-center w-[5rem]" title={label}>
       <div
-        className={`${PANEL_CLASSES.inputWrapper} w-full cursor-ns-resize`}
+        className={`${PANEL_CLASSES.inputWrapper} min-w-[5rem] w-full cursor-ns-resize`}
         onWheel={(e) => handleWheel(e, handleWheelUpdate)}
       >
         <input

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -70,9 +70,9 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
   const handleWheel = useWheelCoalescer(beginCoalescing, endCoalescing);
 
   return (
-    <div className="flex flex-col items-center w-[5rem]" title={label}>
+    <div className="flex flex-col items-center w-[4.5rem]" title={label}>
       <div
-        className={`${PANEL_CLASSES.inputWrapper} min-w-[5rem] w-full cursor-ns-resize`}
+        className={`${PANEL_CLASSES.inputWrapper} min-w-[4.5rem] w-full cursor-ns-resize`}
         onWheel={(e) => handleWheel(e, handleWheelUpdate)}
       >
         <input


### PR DESCRIPTION
## Summary
- widen side toolbar numeric inputs to 5rem so three-digit values and units remain visible
- enforce a matching minimum width on the input wrapper to prevent truncation when scrolling values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98e3593d083239c7228ce2a3574c9