### PR TITLE
fix(layers-panel): align layer item sizing

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -154,7 +154,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
         </Tab.List>
 
         <Tab.Panels className="flex-grow min-h-0 overflow-hidden">
-          <Tab.Panel className="flex flex-col gap-1 h-full focus:outline-none overflow-y-auto layers-panel-list pr-1">
+          <Tab.Panel className="flex flex-col gap-1 h-full focus:outline-none overflow-y-auto layers-panel-list">
             {menuActions.map((action, index) => {
               if (action.label === '---') {
                 return <div key={`sep-${index}`} className="border-b border-[var(--ui-separator)] my-2" />;

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -173,7 +173,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                         variant="unstyled"
                         ref={ref as any}
                         onClick={onClick}
-                        className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
+                        className="w-full h-7 flex items-center gap-2 px-2 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 ring-[var(--accent-primary)]"
                       >
                         <div className="w-4 h-4 flex flex-shrink-0 items-center justify-center text-[var(--text-secondary)]">{ICONS.BACKGROUND_COLOR}</div>
                         <span className="flex-grow">{t('canvasBackground')}</span>
@@ -206,7 +206,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                         ref={ref as any}
                         onClick={onClick}
                         disabled={!canExport}
-                        className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 ring-[var(--accent-primary)]"
+                        className="w-full h-7 flex items-center gap-2 px-2 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:ring-2 ring-[var(--accent-primary)]"
                       >
                         <div className="w-4 h-4 flex flex-shrink-0 items-center justify-center text-[var(--text-secondary)]">{ICONS.COPY_PNG}</div>
                         <span className="flex-grow">{action.label}</span>
@@ -230,7 +230,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                           ref={ref}
                           onClick={onClick}
                           disabled={frameCount <= 1}
-                          className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 ring-[var(--accent-primary)]"
+                          className="w-full h-7 flex items-center gap-2 px-2 rounded-md text-left text-sm transition-colors text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)] disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus-visible:ring-2 ring-[var(--accent-primary)]"
                         >
                           <div className="w-4 h-4 flex flex-shrink-0 items-center justify-center text-[var(--text-secondary)]">{ICONS.PLAY}</div>
                           <span className="flex-grow">{action.label}</span>
@@ -266,7 +266,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
                   }
                 }}
                 disabled={isDisabled}
-                className={`w-full flex items-center gap-2 px-2 py-1 rounded-md text-left text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                className={`w-full h-7 flex items-center gap-2 px-2 rounded-md text-left text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                   action.isDanger
                     ? 'text-[var(--danger-text)] hover:bg-[var(--danger-bg)] focus:bg-[var(--danger-bg)]'
                     : 'text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus:bg-[var(--ui-hover-bg)]'

--- a/src/components/layers-panel/LayerItem.tsx
+++ b/src/components/layers-panel/LayerItem.tsx
@@ -109,7 +109,7 @@ export const LayerItem: React.FC<LayerItemProps> = ({
       <div
         onClick={isEditing ? undefined : handleLayerClick}
         style={style}
-        className={`group flex items-center gap-2 px-2 py-1 rounded-md transition-colors cursor-grab select-none ${bgClass} ${isLocked ? 'opacity-60' : ''} ${isDropTarget && dropTarget.position === 'inside' ? 'ring-2 ring-inset ring-[var(--accent-primary)]' : ''}`}
+        className={`group flex h-7 items-center gap-2 pr-2 rounded-md transition-colors cursor-grab select-none ${bgClass} ${isLocked ? 'opacity-60' : ''} ${isDropTarget && dropTarget.position === 'inside' ? 'ring-2 ring-inset ring-[var(--accent-primary)]' : ''}`}
         draggable={!isLocked && !isEditing}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}

--- a/src/components/layers-panel/LayersPanel.tsx
+++ b/src/components/layers-panel/LayersPanel.tsx
@@ -159,7 +159,7 @@ export const LayersPanel: React.FC = () => {
     <div className="flex flex-col h-full">
       <div
         ref={listRef}
-        className="flex flex-col flex-grow overflow-y-auto layers-panel-list pr-1 pt-1 gap-1"
+        className="flex flex-col flex-grow overflow-y-auto layers-panel-list gap-1"
         onDragOver={handleContainerDragOver}
         onDrop={handleDrop}
       >

--- a/src/components/layers-panel/LayersPanel.tsx
+++ b/src/components/layers-panel/LayersPanel.tsx
@@ -157,9 +157,9 @@ export const LayersPanel: React.FC = () => {
 
   return (
     <div className="flex flex-col h-full">
-      <div 
+      <div
         ref={listRef}
-        className="flex-grow overflow-y-auto layers-panel-list pr-1 pt-1 space-y-1"
+        className="flex flex-col flex-grow overflow-y-auto layers-panel-list pr-1 pt-1 gap-1"
         onDragOver={handleContainerDragOver}
         onDrop={handleDrop}
       >


### PR DESCRIPTION
## Summary
- switch the layers panel list to use flex gap spacing instead of Tailwind space utilities
- eliminate the extra margin that made layer rows appear taller than main menu rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4e31da7c83238e813ee99a307c9b