### PR TITLE
fix: ensure side toolbar percentages render fully

### DIFF
--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -156,7 +156,7 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
   const isFrameSelected = firstSelectedPath?.tool === 'frame';
 
   return (
-    <div className="sidebar-container bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 flex flex-col items-center gap-2 text-[var(--text-primary)]">
+    <div className="sidebar-container bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-1.5 flex flex-col items-center gap-1.5 text-[var(--text-primary)]">
       {isFrameSelected ? (
         <div className="text-center text-sm text-[var(--text-secondary)]">{framePropertiesLabel}</div>
       ) : isTextMode ? (

--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -70,7 +70,7 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
   const handleWheel = useWheelCoalescer(beginCoalescing, endCoalescing);
 
   return (
-    <div className="flex flex-col items-center w-14" title={label}>
+    <div className="flex flex-col items-center w-[3.75rem]" title={label}>
       <div
         className={`${PANEL_CLASSES.inputWrapper} w-full cursor-ns-resize`}
         onWheel={(e) => handleWheel(e, handleWheelUpdate)}

--- a/src/index.css
+++ b/src/index.css
@@ -138,8 +138,9 @@ textarea {
   }
 
   .panel-input-wrapper {
-    @apply flex items-center gap-2 rounded-md px-3 h-9 transition-colors;
-    width: 4.5rem;
+    @apply flex items-center gap-1 rounded-md px-2 h-8 transition-colors;
+    width: 100%;
+    min-width: 3.75rem;
     background-color: rgba(0, 0, 0, 0.2);
     border: 1px solid transparent;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
@@ -151,8 +152,10 @@ textarea {
   }
 
   .panel-input {
-    @apply w-full bg-transparent text-sm text-center outline-none;
+    @apply w-full bg-transparent text-center outline-none;
     color: var(--text-primary);
+    font-size: 0.75rem;
+    line-height: 1rem;
   }
 
   .panel-input:disabled {
@@ -161,8 +164,8 @@ textarea {
   }
 
   .panel-input-suffix {
-    @apply text-xs;
     color: var(--text-secondary);
+    font-size: 0.7rem;
   }
 
   .panel-segmented {


### PR DESCRIPTION
## Summary
- adjust numeric input spacing so the compact toolbar styling still shows three-digit percentages without clipping
- reduce side toolbar padding and vertical gaps to make the panel more compact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4d6745b88323b123a052755a1dde