### PR TITLE
fix: synchronize floating controls with timeline height

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -4,19 +4,19 @@
  */
 import React from 'react';
 import PanelButton from '@/components/PanelButton';
-import { ICONS } from '@/constants';
+import { ICONS, TIMELINE_PANEL_BOTTOM_OFFSET } from '@/constants';
 import { useAppContext } from '@/context/AppContext';
 
 /**
  * 裁剪模式下显示的工具栏组件，提供确认与取消裁剪操作。
  */
 export const CropToolbar: React.FC = () => {
-  const { confirmCrop, cancelCrop, isTimelineCollapsed } = useAppContext();
+  const { confirmCrop, cancelCrop } = useAppContext();
 
   return (
     <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)] transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+      style={{ bottom: TIMELINE_PANEL_BOTTOM_OFFSET }}
     >
       <PanelButton
         type="button"

--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -4,19 +4,19 @@
  */
 import React from 'react';
 import PanelButton from '@/components/PanelButton';
-import { ICONS, TIMELINE_PANEL_BOTTOM_OFFSET } from '@/constants';
+import { ICONS, getTimelinePanelBottomOffset } from '@/constants';
 import { useAppContext } from '@/context/AppContext';
 
 /**
  * 裁剪模式下显示的工具栏组件，提供确认与取消裁剪操作。
  */
 export const CropToolbar: React.FC = () => {
-  const { confirmCrop, cancelCrop } = useAppContext();
+  const { confirmCrop, cancelCrop, isTimelineCollapsed } = useAppContext();
 
   return (
     <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)] transition-all duration-300 ease-in-out"
-      style={{ bottom: TIMELINE_PANEL_BOTTOM_OFFSET }}
+      style={{ bottom: getTimelinePanelBottomOffset(isTimelineCollapsed) }}
     >
       <PanelButton
         type="button"

--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -2,7 +2,7 @@
  * 本文件定义了应用底部的时间线面板。
  * 它提供了动画播放控制和关键帧编辑的界面。
  */
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useAppContext } from '../context/AppContext';
 import { ICONS } from '../constants';
 import { Transition } from '@headlessui/react';
@@ -81,6 +81,48 @@ export const TimelinePanel: React.FC = () => {
         onionSkinOpacity, setOnionSkinOpacity,
     } = useAppContext();
 
+    const panelRef = useRef<HTMLDivElement | null>(null);
+
+    const updateTimelineHeight = useCallback(() => {
+        if (typeof document === 'undefined') return;
+        const element = panelRef.current;
+        const height = element?.getBoundingClientRect().height ?? 0;
+        document.documentElement.style.setProperty('--timeline-panel-height', `${height}px`);
+    }, []);
+
+    useEffect(() => {
+        updateTimelineHeight();
+    }, [isTimelineCollapsed, updateTimelineHeight]);
+
+    useEffect(() => {
+        if (typeof document === 'undefined') {
+            return () => {};
+        }
+
+        const element = panelRef.current;
+        const handleUpdate = () => updateTimelineHeight();
+
+        let observer: ResizeObserver | null = null;
+
+        if (element && typeof ResizeObserver !== 'undefined') {
+            observer = new ResizeObserver(handleUpdate);
+            observer.observe(element);
+        } else if (typeof window !== 'undefined') {
+            window.addEventListener('resize', handleUpdate);
+        }
+
+        handleUpdate();
+
+        return () => {
+            if (observer) {
+                observer.disconnect();
+            } else if (typeof window !== 'undefined') {
+                window.removeEventListener('resize', handleUpdate);
+            }
+            document.documentElement.style.removeProperty('--timeline-panel-height');
+        };
+    }, [updateTimelineHeight]);
+
     const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
     const [dropIndicator, setDropIndicator] = useState<{ index: number; side: 'left' | 'right' } | null>(null);
 
@@ -140,18 +182,19 @@ export const TimelinePanel: React.FC = () => {
     };
 
     return (
-        <Transition
-            show={!isTimelineCollapsed}
-            as="div"
-            className="w-full max-w-full flex-shrink-0 bg-[var(--ui-panel-bg)] border-t border-[var(--ui-panel-border)] overflow-hidden z-20"
-            enter="transition-[max-height,opacity] duration-300 ease-in-out"
-            enterFrom="opacity-0 max-h-0"
-            enterTo="opacity-100 max-h-40"
-            leave="transition-[max-height,opacity] duration-300 ease-in-out"
-            leaveFrom="opacity-100 max-h-40"
-            leaveTo="opacity-0 max-h-0"
-        >
-            <div className="px-2.5 pt-2 pb-1.5 w-full max-w-full flex flex-col">
+        <div ref={panelRef} className="w-full max-w-full flex-shrink-0 z-20">
+            <Transition
+                show={!isTimelineCollapsed}
+                as="div"
+                className="w-full max-w-full flex-shrink-0 bg-[var(--ui-panel-bg)] border-t border-[var(--ui-panel-border)] overflow-hidden z-20"
+                enter="transition-[max-height,opacity] duration-300 ease-in-out"
+                enterFrom="opacity-0 max-h-0"
+                enterTo="opacity-100 max-h-40"
+                leave="transition-[max-height,opacity] duration-300 ease-in-out"
+                leaveFrom="opacity-100 max-h-40"
+                leaveTo="opacity-0 max-h-0"
+            >
+                <div className="px-2.5 pt-2 pb-1.5 w-full max-w-full flex flex-col">
                 <div className="flex items-center gap-3">
                       <div className="flex items-center gap-1.5">
                           <PanelButton
@@ -288,6 +331,7 @@ export const TimelinePanel: React.FC = () => {
                     </div>
                 </div>
             </div>
-        </Transition>
+            </Transition>
+        </div>
     );
 };

--- a/src/components/layout/AboutButton.tsx
+++ b/src/components/layout/AboutButton.tsx
@@ -4,9 +4,8 @@
  */
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS } from '@/constants';
+import { CONTROL_BUTTON_CLASS, TIMELINE_PANEL_BOTTOM_OFFSET } from '@/constants';
 
 const links = [
   { name: 'vtracer - PNG转矢量工具', href: 'https://www.visioncortex.org/vtracer/' },
@@ -17,12 +16,10 @@ const links = [
  * 关于按钮组件
  */
 export const AboutButton: React.FC = () => {
-  const { isTimelineCollapsed } = useAppContext();
-
   return (
-    <div 
+    <div
       className="absolute right-4 z-30 transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+      style={{ bottom: TIMELINE_PANEL_BOTTOM_OFFSET }}
     >
         <Popover className="relative">
           <Popover.Button

--- a/src/components/layout/AboutButton.tsx
+++ b/src/components/layout/AboutButton.tsx
@@ -5,7 +5,8 @@
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS, TIMELINE_PANEL_BOTTOM_OFFSET } from '@/constants';
+import { CONTROL_BUTTON_CLASS, getTimelinePanelBottomOffset } from '@/constants';
+import { useAppContext } from '@/context/AppContext';
 
 const links = [
   { name: 'vtracer - PNG转矢量工具', href: 'https://www.visioncortex.org/vtracer/' },
@@ -16,10 +17,12 @@ const links = [
  * 关于按钮组件
  */
 export const AboutButton: React.FC = () => {
+  const { isTimelineCollapsed } = useAppContext();
+
   return (
     <div
       className="absolute right-4 z-30 transition-all duration-300 ease-in-out"
-      style={{ bottom: TIMELINE_PANEL_BOTTOM_OFFSET }}
+      style={{ bottom: getTimelinePanelBottomOffset(isTimelineCollapsed) }}
     >
         <Popover className="relative">
           <Popover.Button

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -6,7 +6,7 @@ import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS } from '@/constants';
+import { CONTROL_BUTTON_CLASS, TIMELINE_PANEL_BOTTOM_OFFSET } from '@/constants';
 import { Toolbar } from '../Toolbar';
 import { SelectionToolbar } from '../SelectionToolbar';
 import { ContextMenu } from '../ContextMenu';
@@ -171,9 +171,9 @@ export const CanvasOverlays: React.FC = () => {
             </div>
 
             {tool === 'selection' && !croppingState && selectedPathIds.length > 0 && (
-                <div 
+                <div
                     className="absolute left-1/2 -translate-x-1/2 z-30 transition-all duration-300 ease-in-out"
-                    style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+                    style={{ bottom: TIMELINE_PANEL_BOTTOM_OFFSET }}
                 >
                     <SelectionToolbar
                         selectionMode={selectionMode} setSelectionMode={store.setSelectionMode}
@@ -216,7 +216,7 @@ export const CanvasOverlays: React.FC = () => {
             <div
                 className="absolute left-4 z-30 flex items-center gap-2"
                 style={{
-                    bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)',
+                    bottom: TIMELINE_PANEL_BOTTOM_OFFSET,
                     transition: 'bottom 300ms ease-in-out'
                 }}
             >

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -6,7 +6,7 @@ import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS, TIMELINE_PANEL_BOTTOM_OFFSET } from '@/constants';
+import { CONTROL_BUTTON_CLASS, getTimelinePanelBottomOffset } from '@/constants';
 import { Toolbar } from '../Toolbar';
 import { SelectionToolbar } from '../SelectionToolbar';
 import { ContextMenu } from '../ContextMenu';
@@ -163,6 +163,11 @@ export const CanvasOverlays: React.FC = () => {
     }, [selectedPathIds.length, canGroup, canUngroup, canConvertToPath, styleClipboard, tool, selectionMode, contextMenu, handleCut, handleCopy, handlePaste, handleCopyStyle, handlePasteStyle, handleFlip, handleGroup, handleUngroup, handleBringForward, handleSendBackward, handleBringToFront, handleSendToBack, handleCopyAsSvg, handleCopyAsPng, handleConvertToPath]);
     
 
+    const timelineBottomOffset = useMemo(
+        () => getTimelinePanelBottomOffset(isTimelineCollapsed),
+        [isTimelineCollapsed]
+    );
+
     return (
         <>
             <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center gap-2">
@@ -173,7 +178,7 @@ export const CanvasOverlays: React.FC = () => {
             {tool === 'selection' && !croppingState && selectedPathIds.length > 0 && (
                 <div
                     className="absolute left-1/2 -translate-x-1/2 z-30 transition-all duration-300 ease-in-out"
-                    style={{ bottom: TIMELINE_PANEL_BOTTOM_OFFSET }}
+                    style={{ bottom: timelineBottomOffset }}
                 >
                     <SelectionToolbar
                         selectionMode={selectionMode} setSelectionMode={store.setSelectionMode}
@@ -216,7 +221,7 @@ export const CanvasOverlays: React.FC = () => {
             <div
                 className="absolute left-4 z-30 flex items-center gap-2"
                 style={{
-                    bottom: TIMELINE_PANEL_BOTTOM_OFFSET,
+                    bottom: timelineBottomOffset,
                     transition: 'bottom 300ms ease-in-out'
                 }}
             >

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { useAppContext } from '@/context/AppContext';
 import { SideToolbar } from '../SideToolbar';
-import { ICONS, CONTROL_BUTTON_CLASS } from '@/constants';
+import { ICONS, CONTROL_BUTTON_CLASS, TIMELINE_PANEL_HEIGHT_VAR } from '@/constants';
 import PanelButton from '@/components/PanelButton';
 
 /**
@@ -13,7 +13,7 @@ import PanelButton from '@/components/PanelButton';
  */
 export const SideToolbarPanel: React.FC = () => {
     const store = useAppContext();
-    const { isSideToolbarCollapsed, setIsSideToolbarCollapsed, handleToggleStyleLibrary, isTimelineCollapsed, handleAdjustImageHsv } = store;
+    const { isSideToolbarCollapsed, setIsSideToolbarCollapsed, handleToggleStyleLibrary, handleAdjustImageHsv } = store;
     
     return (
         <>
@@ -31,7 +31,7 @@ export const SideToolbarPanel: React.FC = () => {
             <div 
                 className={`absolute right-4 z-20 transition-all duration-300 ease-in-out`}
                 style={{
-                    top: isTimelineCollapsed ? '50%' : 'calc(50% - 6rem)',
+                    top: `calc(50% - (${TIMELINE_PANEL_HEIGHT_VAR}) / 2)`,
                     transform: `translateY(-50%) ${isSideToolbarCollapsed ? 'translateX(calc(100% + 1rem))' : 'translateX(0)'}`,
                 }}
             >

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -41,6 +41,9 @@ export const COLORS = [
 export const CONTROL_BUTTON_CLASS =
   'flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]';
 
+export const TIMELINE_PANEL_HEIGHT_VAR = 'var(--timeline-panel-height, 0px)';
+export const TIMELINE_PANEL_BOTTOM_OFFSET = `calc(${TIMELINE_PANEL_HEIGHT_VAR} + 1rem)`;
+
 // RoughJS 的默认参数
 export const DEFAULT_ROUGHNESS = 2.5;
 export const DEFAULT_BOWING = 1;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -43,6 +43,9 @@ export const CONTROL_BUTTON_CLASS =
 
 export const TIMELINE_PANEL_HEIGHT_VAR = 'var(--timeline-panel-height, 0px)';
 export const TIMELINE_PANEL_BOTTOM_OFFSET = `calc(${TIMELINE_PANEL_HEIGHT_VAR} + 1rem)`;
+export const TIMELINE_PANEL_COLLAPSED_OFFSET = '1rem';
+export const getTimelinePanelBottomOffset = (isCollapsed: boolean) =>
+  isCollapsed ? TIMELINE_PANEL_COLLAPSED_OFFSET : TIMELINE_PANEL_BOTTOM_OFFSET;
 
 // RoughJS 的默认参数
 export const DEFAULT_ROUGHNESS = 2.5;

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,7 @@
   --ui-element-bg-hover: var(--oc-gray-8);
   --ui-element-bg-active: var(--oc-gray-7);
   --ui-element-bg-inactive: rgba(0, 0, 0, 0.3);
+  --timeline-panel-height: 0px;
 
   /* Canvas Specific */
   --grid-line: rgba(var(--oc-gray-7-rgb), 0.5);


### PR DESCRIPTION
## Summary
- track the timeline panel height with a ResizeObserver and expose it via a CSS variable
- update floating controls (undo/redo, crop toolbar, about button) to use the shared timeline offset instead of hard-coded values
- align the side toolbar position with the dynamic timeline height and seed the new CSS variable default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4f25d1d08323972a39ec0564dad3