### PR TITLE
fix: clamp mask group export bounds

### DIFF
--- a/src/lib/drawing/bbox.ts
+++ b/src/lib/drawing/bbox.ts
@@ -78,6 +78,13 @@ export function getPathBoundingBox(path: AnyPath, includeStroke: boolean = true)
     }
     case 'group': {
       const groupPath = path as GroupData;
+
+      if (groupPath.mask === 'clip' && groupPath.children.length > 0) {
+        const maskShape = groupPath.children[groupPath.children.length - 1];
+        const maskBbox = getPathBoundingBox(maskShape, includeStroke);
+        return maskBbox || { x: 0, y: 0, width: 0, height: 0 };
+      }
+
       const bbox = getPathsBoundingBox(groupPath.children, includeStroke);
       return bbox || { x: 0, y: 0, width: 0, height: 0 };
     }


### PR DESCRIPTION
## Summary
- ensure mask (clip) groups report their bounding box using the mask shape
- avoid exporting large transparent margins when copying masked groups to PNG

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb6b0a3e5483238ba9d17351b7a61f