### PR TITLE
fix: sync floating controls with timeline height

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import PanelButton from '@/components/PanelButton';
-import { ICONS } from '@/constants';
+import { ICONS, getTimelinePanelBottomOffset } from '@/constants';
 import { useAppContext } from '@/context/AppContext';
 
 /**
@@ -15,8 +15,8 @@ export const CropToolbar: React.FC = () => {
 
   return (
     <div
-      className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)] transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+      className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)]"
+      style={{ bottom: getTimelinePanelBottomOffset(isTimelineCollapsed) }}
     >
       <PanelButton
         type="button"

--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -93,13 +93,19 @@ export const TimelinePanel: React.FC = () => {
     useLayoutEffect(() => {
         if (typeof document === 'undefined') return;
 
-        if (isTimelineCollapsed) {
-            setTimelinePanelHeight(0);
+        const element = panelRef.current;
+        if (!element) {
+            if (isTimelineCollapsed) {
+                setTimelinePanelHeight(0);
+            }
             return;
         }
 
-        const element = panelRef.current;
-        if (!element) return;
+        if (isTimelineCollapsed) {
+            const measuredHeight = element.scrollHeight || element.getBoundingClientRect().height || lastKnownHeightRef.current;
+            setTimelinePanelHeight(measuredHeight > 0 ? measuredHeight : 0);
+            return;
+        }
 
         const measuredHeight = element.scrollHeight || element.getBoundingClientRect().height;
         const nextHeight = measuredHeight || lastKnownHeightRef.current;
@@ -115,11 +121,19 @@ export const TimelinePanel: React.FC = () => {
         if (!element) return undefined;
 
         const handleUpdate = () => {
-            if (isTimelineCollapsed) return;
             const height = element.getBoundingClientRect().height;
-            if (height <= 0) return;
-            lastKnownHeightRef.current = height;
-            setTimelinePanelHeight(height);
+
+            if (height > 0) {
+                if (!isTimelineCollapsed) {
+                    lastKnownHeightRef.current = height;
+                }
+                setTimelinePanelHeight(height);
+                return;
+            }
+
+            if (isTimelineCollapsed) {
+                setTimelinePanelHeight(0);
+            }
         };
 
         if (typeof ResizeObserver !== 'undefined') {

--- a/src/components/layout/AboutButton.tsx
+++ b/src/components/layout/AboutButton.tsx
@@ -4,9 +4,9 @@
  */
 import React, { Fragment } from 'react';
 import { Popover, Transition } from '@headlessui/react';
-import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS } from '@/constants';
+import { CONTROL_BUTTON_CLASS, getTimelinePanelBottomOffset } from '@/constants';
+import { useAppContext } from '@/context/AppContext';
 
 const links = [
   { name: 'vtracer - PNG转矢量工具', href: 'https://www.visioncortex.org/vtracer/' },
@@ -20,9 +20,9 @@ export const AboutButton: React.FC = () => {
   const { isTimelineCollapsed } = useAppContext();
 
   return (
-    <div 
-      className="absolute right-4 z-30 transition-all duration-300 ease-in-out"
-      style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+    <div
+      className="absolute right-4 z-30"
+      style={{ bottom: getTimelinePanelBottomOffset(isTimelineCollapsed) }}
     >
         <Popover className="relative">
           <Popover.Button

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -6,7 +6,7 @@ import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
-import { CONTROL_BUTTON_CLASS } from '@/constants';
+import { CONTROL_BUTTON_CLASS, getTimelinePanelBottomOffset } from '@/constants';
 import { Toolbar } from '../Toolbar';
 import { SelectionToolbar } from '../SelectionToolbar';
 import { ContextMenu } from '../ContextMenu';
@@ -163,6 +163,11 @@ export const CanvasOverlays: React.FC = () => {
     }, [selectedPathIds.length, canGroup, canUngroup, canConvertToPath, styleClipboard, tool, selectionMode, contextMenu, handleCut, handleCopy, handlePaste, handleCopyStyle, handlePasteStyle, handleFlip, handleGroup, handleUngroup, handleBringForward, handleSendBackward, handleBringToFront, handleSendToBack, handleCopyAsSvg, handleCopyAsPng, handleConvertToPath]);
     
 
+    const timelineBottomOffset = useMemo(
+        () => getTimelinePanelBottomOffset(isTimelineCollapsed),
+        [isTimelineCollapsed]
+    );
+
     return (
         <>
             <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center gap-2">
@@ -171,9 +176,9 @@ export const CanvasOverlays: React.FC = () => {
             </div>
 
             {tool === 'selection' && !croppingState && selectedPathIds.length > 0 && (
-                <div 
-                    className="absolute left-1/2 -translate-x-1/2 z-30 transition-all duration-300 ease-in-out"
-                    style={{ bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)' }}
+                <div
+                    className="absolute left-1/2 -translate-x-1/2 z-30"
+                    style={{ bottom: timelineBottomOffset }}
                 >
                     <SelectionToolbar
                         selectionMode={selectionMode} setSelectionMode={store.setSelectionMode}
@@ -216,8 +221,7 @@ export const CanvasOverlays: React.FC = () => {
             <div
                 className="absolute left-4 z-30 flex items-center gap-2"
                 style={{
-                    bottom: isTimelineCollapsed ? '1rem' : 'calc(12rem + 1rem)',
-                    transition: 'bottom 300ms ease-in-out'
+                    bottom: timelineBottomOffset,
                 }}
             >
                 <PanelButton

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { useAppContext } from '@/context/AppContext';
 import { SideToolbar } from '../SideToolbar';
-import { ICONS, CONTROL_BUTTON_CLASS } from '@/constants';
+import { ICONS, CONTROL_BUTTON_CLASS, TIMELINE_PANEL_HEIGHT_VAR } from '@/constants';
 import PanelButton from '@/components/PanelButton';
 
 /**
@@ -13,7 +13,7 @@ import PanelButton from '@/components/PanelButton';
  */
 export const SideToolbarPanel: React.FC = () => {
     const store = useAppContext();
-    const { isSideToolbarCollapsed, setIsSideToolbarCollapsed, handleToggleStyleLibrary, isTimelineCollapsed, handleAdjustImageHsv } = store;
+    const { isSideToolbarCollapsed, setIsSideToolbarCollapsed, handleToggleStyleLibrary, handleAdjustImageHsv } = store;
     
     return (
         <>
@@ -31,7 +31,7 @@ export const SideToolbarPanel: React.FC = () => {
             <div 
                 className={`absolute right-4 z-20 transition-all duration-300 ease-in-out`}
                 style={{
-                    top: isTimelineCollapsed ? '50%' : 'calc(50% - 6rem)',
+                    top: `calc(50% - (${TIMELINE_PANEL_HEIGHT_VAR}) / 2)`,
                     transform: `translateY(-50%) ${isSideToolbarCollapsed ? 'translateX(calc(100% + 1rem))' : 'translateX(0)'}`,
                 }}
             >

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -41,6 +41,12 @@ export const COLORS = [
 export const CONTROL_BUTTON_CLASS =
   'flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]';
 
+export const TIMELINE_PANEL_HEIGHT_VAR = 'var(--timeline-panel-height, 0px)';
+export const TIMELINE_PANEL_BOTTOM_OFFSET = `calc(${TIMELINE_PANEL_HEIGHT_VAR} + 1rem)`;
+export const TIMELINE_PANEL_COLLAPSED_OFFSET = '1rem';
+export const getTimelinePanelBottomOffset = (isCollapsed: boolean) =>
+  isCollapsed ? TIMELINE_PANEL_COLLAPSED_OFFSET : TIMELINE_PANEL_BOTTOM_OFFSET;
+
 // RoughJS 的默认参数
 export const DEFAULT_ROUGHNESS = 2.5;
 export const DEFAULT_BOWING = 1;

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,7 @@
   --ui-element-bg-hover: var(--oc-gray-8);
   --ui-element-bg-active: var(--oc-gray-7);
   --ui-element-bg-inactive: rgba(0, 0, 0, 0.3);
+  --timeline-panel-height: 0px;
 
   /* Canvas Specific */
   --grid-line: rgba(var(--oc-gray-7-rgb), 0.5);


### PR DESCRIPTION
## Summary
- stop animating bottom offsets for the selection toolbar and undo/redo controls so they follow the live timeline height instead of easing toward it
- remove bottom-position transitions from the crop toolbar and about button to keep them pinned to the panel edge during collapse/expand

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca4f25d1d08323972a39ec0564dad3