### PR TITLE
fix: correct layer reorder direction

### DIFF
--- a/src/hooks/frame-management-logic.ts
+++ b/src/hooks/frame-management-logic.ts
@@ -127,7 +127,7 @@ export const recursivelyReorderPaths = (paths: AnyPath[], draggedId: string, tar
           const newChildren = [...(p as GroupData).children, draggedPath!];
           currentPaths[i] = { ...p, children: newChildren };
         } else {
-          const insertIndex = position === 'above' ? i : i + 1;
+          const insertIndex = position === 'above' ? i + 1 : i;
           currentPaths.splice(insertIndex, 0, draggedPath!);
         }
         return currentPaths;


### PR DESCRIPTION
## Summary
- adjust layer reorder insertion indices to match the reversed rendering order

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb75a677c48323990012761a452613