### PR TITLE
fix: remove extra focus halo from language selector

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -32,7 +32,7 @@ const LanguageSelector: React.FC = () => {
       <Popover.Button
         as={PanelButton}
         variant="unstyled"
-        className={`w-full ${PANEL_CLASSES.inputWrapper} justify-between text-sm text-left text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)] focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]`}
+        className={`w-full ${PANEL_CLASSES.inputWrapper} justify-between text-sm text-left text-[var(--text-primary)] hover:bg-[var(--ui-hover-bg)]`}
       >
         <div className="w-4 h-4 flex items-center justify-center text-[var(--text-secondary)]">{ICONS.LANGUAGE}</div>
         <span className="flex-grow">{t('language')}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,11 @@ textarea {
     box-shadow: 0 0 0 2px rgba(var(--oc-blue-6-rgb), 0.2);
   }
 
+  button.panel-input-wrapper:focus-visible {
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 2px rgba(var(--oc-blue-6-rgb), 0.2);
+  }
+
   .panel-input {
     @apply w-full bg-transparent text-center outline-none;
     color: var(--text-primary);

--- a/src/index.css
+++ b/src/index.css
@@ -146,7 +146,7 @@ textarea {
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
   }
 
-  .panel-input-wrapper:focus-within {
+  .panel-input-wrapper:not(button):focus-within {
     border-color: var(--accent-primary);
     box-shadow: 0 0 0 2px rgba(var(--oc-blue-6-rgb), 0.2);
   }


### PR DESCRIPTION
## Summary
- prevent panel input wrappers that are buttons from showing the focus-within ring
- ensures the language selector no longer displays a thick outline on first click while keeping input focus styling intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb9da40a888323ae93b799b3f58224