### PR TITLE
fix: default selection tool

### DIFF
--- a/src/context/toolStore.ts
+++ b/src/context/toolStore.ts
@@ -9,7 +9,7 @@ export interface ToolState {
 }
 
 export const useToolStore = create<ToolState>((set) => ({
-  tool: 'brush',
+  tool: 'selection',
   selectionMode: 'move',
   setTool: (t) => set({ tool: t }),
   setSelectionMode: (m) => set({ selectionMode: m }),

--- a/tests/context/toolStore.test.ts
+++ b/tests/context/toolStore.test.ts
@@ -4,14 +4,14 @@ import { useToolStore } from '@/context/toolStore';
 
 // 每次测试前重置状态
 beforeEach(() => {
-  useToolStore.setState({ tool: 'brush', selectionMode: 'move' });
+  useToolStore.setState({ tool: 'selection', selectionMode: 'move' });
 });
 
 describe('useToolStore', () => {
   // 验证默认状态
-  it('default state is brush/move', () => {
+  it('default state is selection/move', () => {
     const state = useToolStore.getState();
-    expect(state.tool).toBe('brush');
+    expect(state.tool).toBe('selection');
     expect(state.selectionMode).toBe('move');
   });
 


### PR DESCRIPTION
## Summary
- set the tool store to initialize with the selection tool
- update the tool store unit test expectations to reflect the new default

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc9183fac832383282dee2ed3d4eb