### PR TITLE
Fix group isolation editing behaviors

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -212,6 +212,9 @@ export const useAppStore = () => {
 
   const pathState = usePathsStore();
   const { paths, frames, setCurrentFrameIndex, setSelectedPathIds } = pathState;
+  const groupIsolation = useGroupIsolation(pathState);
+  const { activePaths, activePathState } = groupIsolation;
+  const updateActivePaths = activePathState.setPaths;
 
   const currentDocumentSignature = useMemo(
     () => createDocumentSignature(frames, uiState.backgroundColor, uiState.fps),
@@ -342,7 +345,7 @@ export const useAppStore = () => {
     const result = cropMagicWandResultRef.current;
     const { newSrc, imageData } = result;
 
-    pathState.setPaths(prev => prev.map(p =>
+    updateActivePaths(prev => prev.map(p =>
       p.id === cropping.pathId ? { ...(p as PathImageData), src: newSrc } : p
     ));
     setCroppingState(prev => (
@@ -359,7 +362,7 @@ export const useAppStore = () => {
     }
     setCropEditedSrc(newSrc);
     clearCropSelection();
-  }, [appState.croppingState, pathState.setPaths, setCroppingState, clearCropSelection]);
+  }, [appState.croppingState, updateActivePaths, setCroppingState, clearCropSelection]);
 
   const cancelMagicWandSelection = useCallback(() => {
     clearCropSelection();
@@ -438,11 +441,8 @@ export const useAppStore = () => {
     );
   }, [canClearAllData, pathState, showConfirmation, setSelectedPathIds]);
   
-  const groupIsolation = useGroupIsolation(pathState);
-  const { activePaths, activePathState } = groupIsolation;
-
   const viewTransform = useViewTransform();
-  const toolbarState = useToolsStore(activePaths, pathState.selectedPathIds, activePathState.setPaths, pathState.setSelectedPathIds, pathState.beginCoalescing, pathState.endCoalescing);
+  const toolbarState = useToolsStore(activePaths, pathState.selectedPathIds, updateActivePaths, pathState.setSelectedPathIds, pathState.beginCoalescing, pathState.endCoalescing);
   
   const handleResetPreferences = useCallback(() => {
     showConfirmation(
@@ -477,8 +477,8 @@ export const useAppStore = () => {
   }, [showConfirmation, setUiState, toolbarState, setActiveFileName]);
 
   const handleTextChange = useCallback((pathId: string, newText: string) => {
-      activePathState.setPaths(prev => prev.map(p => (p.id === pathId && p.tool === 'text') ? { ...p, text: newText, ...measureText(newText, (p as TextData).fontSize, (p as TextData).fontFamily) } : p));
-  }, [activePathState]);
+      updateActivePaths(prev => prev.map(p => (p.id === pathId && p.tool === 'text') ? { ...p, text: newText, ...measureText(newText, (p as TextData).fontSize, (p as TextData).fontFamily) } : p));
+  }, [updateActivePaths]);
   const handleTextEditCommit = useCallback(() => { pathState.endCoalescing(); setEditingTextPathId(null); }, [pathState, setEditingTextPathId]);
   
   const confirmCrop = useCallback(() => {
@@ -541,7 +541,7 @@ export const useAppStore = () => {
       const newX = newCenter.x - newCenterLocal.x;
       const newY = newCenter.y - newCenterLocal.y;
 
-      pathState.setPaths(prev => prev.map(p =>
+      updateActivePaths(prev => prev.map(p =>
         p.id === pathId
           ? { ...(p as PathImageData), src: newSrc, x: newX, y: newY, width: cropRect.width, height: cropRect.height, rotation }
           : p
@@ -557,7 +557,7 @@ export const useAppStore = () => {
     };
 
     void performCrop();
-  }, [appState.croppingState, appState.currentCropRect, pathState, setCroppingState, setCurrentCropRect, cropEditedSrc, clearCropSelection]);
+  }, [appState.croppingState, appState.currentCropRect, updateActivePaths, pathState, setCroppingState, setCurrentCropRect, cropEditedSrc, clearCropSelection]);
 
   const cancelCrop = useCallback(() => {
     clearCropSelection();

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -25,6 +25,7 @@ const useGlobalEventHandlers = () => {
     handleGroup, handleUngroup,
     getPointerPosition, viewTransform: vt, lastPointerPosition,
     groupIsolationPath, handleExitGroup,
+    activePathState,
     croppingState,
     cancelCrop,
   } = useAppContext();
@@ -198,6 +199,8 @@ const useGlobalEventHandlers = () => {
     cancelCrop,
   ]);
 
+  const { setPaths: updateActivePaths } = activePathState;
+
   // Nudge selected items with arrow keys using a native event listener for reliability
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -232,7 +235,7 @@ const useGlobalEventHandlers = () => {
         }
 
         if (dx !== 0 || dy !== 0) {
-          setPaths((currentPaths: AnyPath[]) =>
+          updateActivePaths((currentPaths: AnyPath[]) =>
             currentPaths.map((p) =>
               selectedPathIds.includes(p.id) ? movePath(p, dx, dy) : p
             )
@@ -254,7 +257,7 @@ const useGlobalEventHandlers = () => {
         clearTimeout(nudgeTimeoutRef.current);
       }
     };
-  }, [tool, selectionMode, selectedPathIds, setPaths, beginCoalescing, endCoalescing]);
+  }, [tool, selectionMode, selectedPathIds, updateActivePaths, beginCoalescing, endCoalescing]);
 
   // Global paste handler for images and shapes
   useEffect(() => {

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -27,6 +27,9 @@ const useGlobalEventHandlers = () => {
     groupIsolationPath, handleExitGroup,
     activePathState,
     croppingState,
+    currentCropRect,
+    cropTool,
+    nudgeCropRect,
     cancelCrop,
   } = useAppContext();
 
@@ -214,6 +217,33 @@ const useGlobalEventHandlers = () => {
         return;
       }
 
+      const amount = shiftKey ? 10 : 1;
+      let dx = 0;
+      let dy = 0;
+
+      switch (key) {
+        case 'ArrowUp': dy = -amount; break;
+        case 'ArrowDown': dy = amount; break;
+        case 'ArrowLeft': dx = -amount; break;
+        case 'ArrowRight': dx = amount; break;
+      }
+
+      const isCroppingSelection =
+        cropTool === 'crop' &&
+        Boolean(croppingState && currentCropRect) &&
+        selectedPathIds.length === 1 &&
+        croppingState?.pathId === selectedPathIds[0];
+
+      if (isCroppingSelection) {
+        event.preventDefault();
+
+        if (dx !== 0 || dy !== 0) {
+          nudgeCropRect(dx, dy);
+        }
+
+        return;
+      }
+
       if (tool === 'selection' && selectionMode === 'move' && selectedPathIds.length > 0) {
         event.preventDefault();
 
@@ -221,17 +251,6 @@ const useGlobalEventHandlers = () => {
           beginCoalescing();
         } else {
           clearTimeout(nudgeTimeoutRef.current);
-        }
-
-        const amount = shiftKey ? 10 : 1;
-        let dx = 0;
-        let dy = 0;
-
-        switch (key) {
-          case 'ArrowUp': dy = -amount; break;
-          case 'ArrowDown': dy = amount; break;
-          case 'ArrowLeft': dx = -amount; break;
-          case 'ArrowRight': dx = amount; break;
         }
 
         if (dx !== 0 || dy !== 0) {
@@ -257,7 +276,18 @@ const useGlobalEventHandlers = () => {
         clearTimeout(nudgeTimeoutRef.current);
       }
     };
-  }, [tool, selectionMode, selectedPathIds, updateActivePaths, beginCoalescing, endCoalescing]);
+  }, [
+    tool,
+    selectionMode,
+    selectedPathIds,
+    updateActivePaths,
+    beginCoalescing,
+    endCoalescing,
+    cropTool,
+    croppingState,
+    currentCropRect,
+    nudgeCropRect,
+  ]);
 
   // Global paste handler for images and shapes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- route all isolation edits through the group-aware path state so nested items update correctly
- ensure keyboard nudges operate on the active isolation paths while leaving global path setters for other handlers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbc70155f88323b610a1e0b7b1e337