### PR TITLE
fix: restore crop toolbar state wiring

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -6,19 +6,59 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import PanelButton from '@/components/PanelButton';
 import { ICONS, getTimelinePanelBottomOffset } from '@/constants';
-import { useAppContext } from '@/context/AppContext';
 
+interface CropToolbarProps {
+  isTimelineCollapsed: boolean;
+  cropTool: 'crop' | 'magic-wand';
+  setCropTool: (tool: 'crop' | 'magic-wand') => void;
+  cropMagicWandOptions: { threshold: number; contiguous: boolean };
+  setCropMagicWandOptions: (opts: Partial<{ threshold: number; contiguous: boolean }>) => void;
+  cropSelectionContours: Array<{ d: string; inner: boolean }> | null;
+  applyMagicWandSelection: () => void;
+  cancelMagicWandSelection: () => void;
+  confirmCrop: () => void;
+  cancelCrop: () => void;
+}
 
 /**
  * 裁剪模式下显示的工具栏组件，提供裁剪、抠图及确认/取消裁剪等操作。
  */
-export const CropToolbar: React.FC = () => {
-  const { confirmCrop, cancelCrop } = useAppContext();
+export const CropToolbar: React.FC<CropToolbarProps> = ({
+  isTimelineCollapsed,
+  cropTool,
+  setCropTool,
+  cropMagicWandOptions,
+  setCropMagicWandOptions,
+  cropSelectionContours,
+  applyMagicWandSelection,
+  cancelMagicWandSelection,
+  confirmCrop,
+  cancelCrop,
+}) => {
+  const { t } = useTranslation();
+
+  const hasSelection = useMemo(
+    () => (cropSelectionContours?.length ?? 0) > 0,
+    [cropSelectionContours]
+  );
+
+  const timelineBottomOffset = useMemo(
+    () => getTimelinePanelBottomOffset(),
+    [isTimelineCollapsed]
+  );
+
+  const handleThresholdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCropMagicWandOptions({ threshold: Number(event.target.value) });
+  };
+
+  const handleContiguousToggle = () => {
+    setCropMagicWandOptions({ contiguous: !cropMagicWandOptions.contiguous });
+  };
 
   return (
     <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)]"
-      style={{ bottom: getTimelinePanelBottomOffset() }}
+      style={{ bottom: timelineBottomOffset }}
     >
       <div className="flex flex-wrap items-center gap-3">
         <span className="text-sm text-[var(--text-secondary)]">{t('cropMode')}</span>
@@ -137,4 +177,4 @@ export const CropToolbar: React.FC = () => {
       </div>
     </div>
   );
-}
+};


### PR DESCRIPTION
## Summary
- connect the crop toolbar to the provided props so it can toggle tools and magic-wand options correctly
- obtain translations through `useTranslation` and guard against missing magic-wand selections to prevent runtime errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbd11298108323a6fc147adc8c4bfd