### PR TITLE
feat: enable crop nudging with arrow keys

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -762,7 +762,7 @@ export const useAppStore = () => {
     setPngExportOptions, setIsStyleLibraryOpen, setStyleLibraryPosition, setIsTimelineCollapsed,
     setFps, setIsPlaying, setContextMenu, setStyleClipboard, setStyleLibrary,
     setMaterialLibrary, setEditingTextPathId, setActiveFileHandle, setActiveFileName, setIsLoading,
-    showConfirmation, hideConfirmation, setCroppingState, setCurrentCropRect,
+    showConfirmation, hideConfirmation, setCroppingState, setCurrentCropRect, pushCropHistory,
     setCropTool, setCropMagicWandOptions, selectMagicWandAt, applyMagicWandSelection, cancelMagicWandSelection,
     confirmCrop, cancelCrop, handleTextChange, handleTextEditCommit, handleSetTool, handleToggleStyleLibrary,
     handleClear,


### PR DESCRIPTION
## Summary
- expose the crop history helper through the app store so keyboard handlers can reuse it
- handle arrow key presses in cropping mode to nudge the crop rectangle within the image bounds
- debounce crop nudges so history entries are grouped for undo/redo

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbd1b2358083239be414282bac9052