### PR TITLE
fix: align isolation editing behaviour

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -342,7 +342,7 @@ export const useAppStore = () => {
     const result = cropMagicWandResultRef.current;
     const { newSrc, imageData } = result;
 
-    pathState.setPaths(prev => prev.map(p =>
+    setActivePaths(prev => prev.map(p =>
       p.id === cropping.pathId ? { ...(p as PathImageData), src: newSrc } : p
     ));
     setCroppingState(prev => (
@@ -359,7 +359,7 @@ export const useAppStore = () => {
     }
     setCropEditedSrc(newSrc);
     clearCropSelection();
-  }, [appState.croppingState, pathState.setPaths, setCroppingState, clearCropSelection]);
+  }, [appState.croppingState, setActivePaths, setCroppingState, clearCropSelection]);
 
   const cancelMagicWandSelection = useCallback(() => {
     clearCropSelection();
@@ -440,6 +440,7 @@ export const useAppStore = () => {
   
   const groupIsolation = useGroupIsolation(pathState);
   const { activePaths, activePathState } = groupIsolation;
+  const { setPaths: setActivePaths } = activePathState;
 
   const viewTransform = useViewTransform();
   const toolbarState = useToolsStore(activePaths, pathState.selectedPathIds, activePathState.setPaths, pathState.setSelectedPathIds, pathState.beginCoalescing, pathState.endCoalescing);
@@ -541,7 +542,7 @@ export const useAppStore = () => {
       const newX = newCenter.x - newCenterLocal.x;
       const newY = newCenter.y - newCenterLocal.y;
 
-      pathState.setPaths(prev => prev.map(p =>
+      setActivePaths(prev => prev.map(p =>
         p.id === pathId
           ? { ...(p as PathImageData), src: newSrc, x: newX, y: newY, width: cropRect.width, height: cropRect.height, rotation }
           : p
@@ -557,7 +558,7 @@ export const useAppStore = () => {
     };
 
     void performCrop();
-  }, [appState.croppingState, appState.currentCropRect, pathState, setCroppingState, setCurrentCropRect, cropEditedSrc, clearCropSelection]);
+  }, [appState.croppingState, appState.currentCropRect, setActivePaths, pathState, setCroppingState, setCurrentCropRect, cropEditedSrc, clearCropSelection]);
 
   const cancelCrop = useCallback(() => {
     clearCropSelection();

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -15,7 +15,7 @@ const useGlobalEventHandlers = () => {
     selectedPathIds, setSelectedPathIds,
     currentPenPath, handleCancelPenPath, handleFinishPenPath,
     currentLinePath, handleCancelLinePath, handleFinishLinePath,
-    undo: handleUndo, redo: handleRedo, handleDeleteSelected, setPaths,
+    undo: handleUndo, redo: handleRedo, handleDeleteSelected,
     beginCoalescing, endCoalescing,
     tool, selectionMode, handleSetTool: setTool, setSelectionMode,
     drawingInteraction,
@@ -24,10 +24,12 @@ const useGlobalEventHandlers = () => {
     handleBringForward, handleSendBackward, handleBringToFront, handleSendToBack,
     handleGroup, handleUngroup,
     getPointerPosition, viewTransform: vt, lastPointerPosition,
-    groupIsolationPath, handleExitGroup,
+    groupIsolationPath, handleExitGroup, activePathState,
     croppingState,
     cancelCrop,
   } = useAppContext();
+
+  const { setPaths: setActivePaths } = activePathState;
 
   const { drawingShape, cancelDrawingShape } = drawingInteraction;
 
@@ -211,7 +213,7 @@ const useGlobalEventHandlers = () => {
         return;
       }
 
-      if (tool === 'selection' && selectionMode === 'move' && selectedPathIds.length > 0) {
+      if (tool === 'selection' && selectionMode === 'move' && selectedPathIds.length > 0 && !croppingState) {
         event.preventDefault();
 
         if (!nudgeTimeoutRef.current) {
@@ -232,7 +234,7 @@ const useGlobalEventHandlers = () => {
         }
 
         if (dx !== 0 || dy !== 0) {
-          setPaths((currentPaths: AnyPath[]) =>
+          setActivePaths((currentPaths: AnyPath[]) =>
             currentPaths.map((p) =>
               selectedPathIds.includes(p.id) ? movePath(p, dx, dy) : p
             )
@@ -254,7 +256,7 @@ const useGlobalEventHandlers = () => {
         clearTimeout(nudgeTimeoutRef.current);
       }
     };
-  }, [tool, selectionMode, selectedPathIds, setPaths, beginCoalescing, endCoalescing]);
+  }, [tool, selectionMode, selectedPathIds, croppingState, setActivePaths, beginCoalescing, endCoalescing]);
 
   // Global paste handler for images and shapes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- route keyboard nudging through the active group context so nested shapes move correctly
- apply crop edits to active paths and block nudging when the crop tool is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbd5cc941c83238d72ff38c2ac2ab8