### PR TITLE
fix: 修复编组隔离下的箭头微调与裁剪

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -13,6 +13,7 @@ import { useSelection } from './useSelection';
 import { usePointerInteraction } from './usePointerInteraction';
 import { useAppActions } from './actions/useAppActions';
 import { useGroupIsolation } from './useGroupIsolation';
+import { recursivelyUpdatePath } from '@/hooks/frame-management-logic';
 import { getLocalStorageItem } from '../lib/utils';
 import * as idb from '../lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
@@ -342,9 +343,12 @@ export const useAppStore = () => {
     const result = cropMagicWandResultRef.current;
     const { newSrc, imageData } = result;
 
-    pathState.setPaths(prev => prev.map(p =>
-      p.id === cropping.pathId ? { ...(p as PathImageData), src: newSrc } : p
-    ));
+    pathState.setPaths(prev =>
+      recursivelyUpdatePath(prev, cropping.pathId, path => ({
+        ...(path as PathImageData),
+        src: newSrc,
+      }))
+    );
     setCroppingState(prev => (
       prev && prev.pathId === cropping.pathId
         ? { ...prev, originalPath: { ...prev.originalPath, src: newSrc } }
@@ -541,11 +545,17 @@ export const useAppStore = () => {
       const newX = newCenter.x - newCenterLocal.x;
       const newY = newCenter.y - newCenterLocal.y;
 
-      pathState.setPaths(prev => prev.map(p =>
-        p.id === pathId
-          ? { ...(p as PathImageData), src: newSrc, x: newX, y: newY, width: cropRect.width, height: cropRect.height, rotation }
-          : p
-      ));
+      pathState.setPaths(prev =>
+        recursivelyUpdatePath(prev, pathId, path => ({
+          ...(path as PathImageData),
+          src: newSrc,
+          x: newX,
+          y: newY,
+          width: cropRect.width,
+          height: cropRect.height,
+          rotation,
+        }))
+      );
 
       setCroppingState(null);
       setCurrentCropRect(null);

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -7,6 +7,7 @@ import React, { useEffect, Dispatch, SetStateAction, useRef } from 'react';
 import hotkeys from 'hotkeys-js';
 import type { AnyPath, DrawingShape, ImageData, Point, Tool, VectorPathData, SelectionMode } from '../types';
 import { movePath } from '../lib/drawing';
+import { recursivelyUpdatePath } from '@/hooks/frame-management-logic';
 import { useAppContext } from '../context/AppContext';
 
 
@@ -290,11 +291,13 @@ const useGlobalEventHandlers = () => {
         }
 
         if (dx !== 0 || dy !== 0) {
-          setPaths((currentPaths: AnyPath[]) =>
-            currentPaths.map((p) =>
-              selectedPathIds.includes(p.id) ? movePath(p, dx, dy) : p
-            )
-          );
+          setPaths((currentPaths: AnyPath[]) => {
+            let updatedPaths = currentPaths;
+            for (const id of selectedPathIds) {
+              updatedPaths = recursivelyUpdatePath(updatedPaths, id, (path) => movePath(path, dx, dy));
+            }
+            return updatedPaths;
+          });
         }
 
         nudgeTimeoutRef.current = window.setTimeout(() => {


### PR DESCRIPTION
## Summary
- 使用递归路径更新逻辑，让方向键微调能够作用于编组内部元素
- 在裁剪与魔棒更新中复用递归更新，确保隔离模式下的图像路径能正确写回

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbdad9ea148323bb99b336bfc93774