### PR TITLE
Remove background option from selection toolbar

### DIFF
--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -9,7 +9,7 @@ import PanelButton from '@/components/PanelButton';
 import { PANEL_CLASSES } from './panelStyles';
 import { ICONS } from '../constants';
 import type { SelectionMode, Alignment, DistributeMode } from '../types';
-import { Slider, SwitchControl } from './side-toolbar';
+import { Slider } from './side-toolbar';
 import { TraceImagePopover } from './TraceImagePopover';
 import type { TraceOptions } from '../types';
 import { useTranslation } from 'react-i18next';
@@ -30,15 +30,11 @@ interface SelectionToolbarProps {
   onMask: () => void;
   isTraceable: boolean;
   onTraceImage: (options: TraceOptions) => void;
-  canRemoveBackground: boolean;
-  beginRemoveBackground: (opts: { threshold: number; contiguous: boolean }) => void;
-  applyRemoveBackground: () => void;
-  cancelRemoveBackground: () => void;
 }
 
 
 export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
-  selectionMode, 
+  selectionMode,
   setSelectionMode,
   isSimplifiable,
   beginSimplify,
@@ -51,16 +47,11 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
   onMask,
   isTraceable,
   onTraceImage,
-  canRemoveBackground,
-  beginRemoveBackground,
-  applyRemoveBackground,
-  cancelRemoveBackground,
 }) => {
   const { t } = useTranslation();
   const [simplifyValue, setSimplifyValue] = useState(0);
   const [distributeMode, setDistributeMode] = useState<DistributeMode>('edges');
   const [distributeSpacing, setDistributeSpacing] = useState<string>('');
-  const [removeBgOpen, setRemoveBgOpen] = useState(false);
 
   const modes = [
     { name: 'move', title: t('modeMove'), icon: ICONS.MOVE },
@@ -150,30 +141,6 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
       )}
 
       {isTraceable && <TraceImagePopover onTrace={onTraceImage} />}
-      {canRemoveBackground && (
-        <div className="relative">
-          <PanelButton
-            title={t('removeBackground')}
-            onClick={() => {
-              if (removeBgOpen) cancelRemoveBackground();
-              setRemoveBgOpen(o => !o);
-            }}
-            variant="unstyled"
-            className="flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] focus-visible:ring-opacity-75 text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
-          >
-            {ICONS.REMOVE_BG}
-          </PanelButton>
-          {removeBgOpen && (
-            <div className="absolute bottom-full mb-2 left-1/2 -translate-x-1/2 w-60 bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] p-4">
-              <RemoveBgPanel
-                onBegin={beginRemoveBackground}
-                onApply={() => { applyRemoveBackground(); setRemoveBgOpen(false); }}
-                onCancel={() => { cancelRemoveBackground(); setRemoveBgOpen(false); }}
-              />
-            </div>
-          )}
-        </div>
-      )}
 
       {canAlignOrDistribute && (
           <Popover className="relative">
@@ -303,37 +270,6 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
         </PanelButton>
       )}
 
-    </div>
-  );
-};
-
-const RemoveBgPanel: React.FC<{
-  onBegin: (opts: { threshold: number; contiguous: boolean }) => void;
-  onApply: () => void;
-  onCancel: () => void;
-}> = ({ onBegin, onApply, onCancel }) => {
-  const [threshold, setThreshold] = useState(10);
-  const [contiguous, setContiguous] = useState(true);
-  const { t } = useTranslation();
-
-  React.useEffect(() => {
-    onBegin({ threshold, contiguous });
-  }, [onBegin, threshold, contiguous]);
-
-  return (
-    <div className="space-y-4">
-      <h3 className="text-sm font-bold text-center text-[var(--text-primary)]">{t('removeBackground')}</h3>
-      <SwitchControl label={t('contiguous')} enabled={contiguous} setEnabled={setContiguous} />
-      <Slider label={t('threshold')} value={threshold} setValue={setThreshold} min={0} max={255} step={1} onInteractionStart={() => {}} onInteractionEnd={() => {}} />
-      <p className="text-xs text-[var(--text-secondary)] text-center">{t('clickImageToSelectArea')}</p>
-      <div className="flex gap-2">
-        <button onClick={onApply} className="flex-1 h-8 rounded-md bg-[var(--accent-bg)] text-[var(--accent-primary)] text-sm">
-          {t('remove')}
-        </button>
-        <button onClick={onCancel} className="flex-1 h-8 rounded-md bg-[var(--ui-element-bg-hover)] text-[var(--text-primary)] text-sm">
-          {t('cancel')}
-        </button>
-      </div>
     </div>
   );
 };

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -86,9 +86,6 @@ export const CanvasOverlays: React.FC = () => {
         handleDistribute,
         handleBooleanOperation,
         handleTraceImage,
-        beginRemoveBackground,
-        applyRemoveBackground,
-        cancelRemoveBackground,
         confirmationDialog,
         hideConfirmation,
         editingTextPathId: activeEditingTextPathId, // rename to avoid conflict
@@ -124,12 +121,6 @@ export const CanvasOverlays: React.FC = () => {
         [paths, selectedPathIds]
     );
     const isTraceable = useMemo(() => {
-        if (selectedPathIds.length !== 1) return false;
-        const path = paths.find((p: AnyPath) => p.id === selectedPathIds[0]);
-        return path?.tool === 'image';
-    }, [paths, selectedPathIds]);
-
-    const canRemoveBackground = useMemo(() => {
         if (selectedPathIds.length !== 1) return false;
         const path = paths.find((p: AnyPath) => p.id === selectedPathIds[0]);
         return path?.tool === 'image';
@@ -198,10 +189,6 @@ export const CanvasOverlays: React.FC = () => {
                         onMask={handleMask}
                         isTraceable={isTraceable}
                         onTraceImage={handleTraceImage}
-                        canRemoveBackground={canRemoveBackground}
-                        beginRemoveBackground={beginRemoveBackground}
-                        applyRemoveBackground={applyRemoveBackground}
-                        cancelRemoveBackground={cancelRemoveBackground}
                     />
                 </div>
             )}


### PR DESCRIPTION
## Summary
- remove the remove-background controls from the selection toolbar component
- stop CanvasOverlays from passing remove-background actions into the selection toolbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbdaf57dfc8323be1b9fa55cf6fe3c