### PR TITLE
fix: adjust crop toolbar layout

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -69,7 +69,6 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
       style={{ bottom: timelineBottomOffset }}
     >
       <div className="flex flex-col gap-2">
-        <span className="text-sm font-medium text-[var(--text-secondary)]">{t('cropMode')}</span>
         <div className="flex items-center gap-1 rounded-lg bg-[var(--ui-element-bg)] p-1">
           <button
             type="button"
@@ -106,7 +105,7 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
         <div className="flex flex-wrap items-center gap-3">
           <label className="flex items-center gap-2 text-sm text-[var(--text-secondary)]" htmlFor="magic-wand-threshold">
             {t('threshold')}
-            <div className={`${PANEL_CLASSES.inputWrapper} w-24`}>
+            <div className={`${PANEL_CLASSES.inputWrapper} w-16`}>
               <input
                 id="magic-wand-threshold"
                 type="number"
@@ -138,28 +137,25 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
       )}
 
       {cropTool === 'magic-wand' && (
-        <div className="flex flex-wrap items-center gap-3 text-xs text-[var(--text-secondary)]">
-          <span>{t('clickImageToSelectArea')}</span>
-          <div className="flex items-center gap-2">
-            <PanelButton
-              type="button"
-              onClick={applyMagicWandSelection}
-              disabled={!hasSelection}
-              className="!w-auto px-3 gap-1 bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:bg-[var(--accent-bg)] hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
-            >
-              {React.cloneElement(ICONS.CHECK, { className: 'h-4 w-4' })}
-              <span>{t('applySelection')}</span>
-            </PanelButton>
-            <PanelButton
-              type="button"
-              onClick={cancelMagicWandSelection}
-              disabled={!hasSelection}
-              className="!w-auto px-3 gap-1 text-[var(--danger-text)] hover:bg-[var(--danger-bg)] disabled:opacity-60 disabled:cursor-not-allowed"
-            >
-              {React.cloneElement(ICONS.X, { className: 'h-4 w-4' })}
-              <span>{t('clearSelection')}</span>
-            </PanelButton>
-          </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <PanelButton
+            type="button"
+            onClick={applyMagicWandSelection}
+            disabled={!hasSelection}
+            className="!w-auto px-3 gap-1 bg-[var(--accent-solid-bg)] text-[var(--text-on-accent-solid)] hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {React.cloneElement(ICONS.CHECK, { className: 'h-4 w-4' })}
+            <span>{t('applySelection')}</span>
+          </PanelButton>
+          <PanelButton
+            type="button"
+            onClick={cancelMagicWandSelection}
+            disabled={!hasSelection}
+            className="!w-auto px-3 gap-1 bg-[var(--danger-text)] text-[var(--text-on-accent-solid)] hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {React.cloneElement(ICONS.X, { className: 'h-4 w-4' })}
+            <span>{t('clearSelection')}</span>
+          </PanelButton>
         </div>
       )}
 

--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -5,6 +5,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from '@/components/panelStyles';
 import { ICONS, getTimelinePanelBottomOffset } from '@/constants';
 
 interface CropToolbarProps {
@@ -48,7 +49,14 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
   );
 
   const handleThresholdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setCropMagicWandOptions({ threshold: Number(event.target.value) });
+    const parsedValue = Number(event.target.value);
+
+    if (Number.isNaN(parsedValue)) {
+      return;
+    }
+
+    const clampedValue = Math.min(120, Math.max(1, parsedValue));
+    setCropMagicWandOptions({ threshold: clampedValue });
   };
 
   const handleContiguousToggle = () => {
@@ -98,19 +106,19 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
         <div className="flex flex-wrap items-center gap-3">
           <label className="flex items-center gap-2 text-sm text-[var(--text-secondary)]" htmlFor="magic-wand-threshold">
             {t('threshold')}
-            <input
-              id="magic-wand-threshold"
-              type="range"
-              min={1}
-              max={120}
-              step={1}
-              value={cropMagicWandOptions.threshold}
-              onChange={handleThresholdChange}
-              className="themed-slider w-36"
-            />
-            <span className="w-10 text-right font-medium text-[var(--text-primary)]">
-              {cropMagicWandOptions.threshold}
-            </span>
+            <div className={`${PANEL_CLASSES.inputWrapper} w-24`}>
+              <input
+                id="magic-wand-threshold"
+                type="number"
+                min={1}
+                max={120}
+                step={1}
+                value={cropMagicWandOptions.threshold}
+                onChange={handleThresholdChange}
+                inputMode="numeric"
+                className={`${PANEL_CLASSES.input} hide-spinners text-right`}
+              />
+            </div>
           </label>
 
           <PanelButton

--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -63,41 +63,48 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
     setCropMagicWandOptions({ contiguous: !cropMagicWandOptions.contiguous });
   };
 
+  const segmentedButtonBase =
+    'flex items-center gap-2 h-9 px-3 rounded-md text-sm font-medium transition-colors';
+  const textButtonBase =
+    'flex items-center gap-2 h-9 px-3 rounded-md text-sm font-medium transition-colors disabled:opacity-60 disabled:cursor-not-allowed';
+
   return (
     <div
       className="absolute left-1/2 -translate-x-1/2 z-30 flex flex-wrap items-start gap-4 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-3 text-[var(--text-primary)]"
       style={{ bottom: timelineBottomOffset }}
     >
       <div className="flex flex-col gap-2">
-        <div className="flex items-center gap-1 rounded-lg bg-[var(--ui-element-bg)] p-1">
-          <button
+        <div className={PANEL_CLASSES.segmentGroup}>
+          <PanelButton
             type="button"
-            className={`flex items-center gap-1 rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+            variant="unstyled"
+            className={`${segmentedButtonBase} ${
               cropTool === 'crop'
                 ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
-                : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
             }`}
             onClick={() => setCropTool('crop')}
             aria-pressed={cropTool === 'crop'}
             title={t('cropAdjust')}
           >
-            {React.cloneElement(ICONS.FRAME, { className: 'h-4 w-4' })}
+            {ICONS.FRAME}
             <span>{t('cropAdjust')}</span>
-          </button>
-          <button
+          </PanelButton>
+          <PanelButton
             type="button"
-            className={`flex items-center gap-1 rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+            variant="unstyled"
+            className={`${segmentedButtonBase} ${
               cropTool === 'magic-wand'
                 ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
-                : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
             }`}
             onClick={() => setCropTool('magic-wand')}
             aria-pressed={cropTool === 'magic-wand'}
             title={t('cropMagicWand')}
           >
-            {React.cloneElement(ICONS.TRACE_IMAGE, { className: 'h-4 w-4' })}
+            {ICONS.TRACE_IMAGE}
             <span>{t('cropMagicWand')}</span>
-          </button>
+          </PanelButton>
         </div>
       </div>
 
@@ -122,11 +129,12 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
 
           <PanelButton
             type="button"
+            variant="unstyled"
             onClick={handleContiguousToggle}
-            className={`!w-auto px-3 gap-2 text-sm font-medium transition-colors ${
+            className={`${segmentedButtonBase} ${
               cropMagicWandOptions.contiguous
-                ? '!bg-[var(--accent-bg)] text-[var(--accent-primary)]'
-                : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'
+                ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
+                : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
             }`}
             aria-pressed={cropMagicWandOptions.contiguous}
             title={t('contiguous')}
@@ -140,20 +148,22 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
         <div className="flex flex-wrap items-center gap-2">
           <PanelButton
             type="button"
+            variant="unstyled"
             onClick={applyMagicWandSelection}
             disabled={!hasSelection}
-            className="!w-auto px-3 gap-1 bg-[var(--accent-solid-bg)] text-[var(--text-on-accent-solid)] hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+            className={`${textButtonBase} bg-[var(--accent-solid-bg)] text-[var(--text-on-accent-solid)] hover:opacity-90`}
           >
-            {React.cloneElement(ICONS.CHECK, { className: 'h-4 w-4' })}
+            {ICONS.CHECK}
             <span>{t('applySelection')}</span>
           </PanelButton>
           <PanelButton
             type="button"
+            variant="unstyled"
             onClick={cancelMagicWandSelection}
             disabled={!hasSelection}
-            className="!w-auto px-3 gap-1 bg-[var(--danger-text)] text-[var(--text-on-accent-solid)] hover:opacity-90 disabled:opacity-60 disabled:cursor-not-allowed"
+            className={`${textButtonBase} bg-[var(--danger-bg)] text-[var(--danger-text)] hover:opacity-90`}
           >
-            {React.cloneElement(ICONS.X, { className: 'h-4 w-4' })}
+            {ICONS.X}
             <span>{t('clearSelection')}</span>
           </PanelButton>
         </div>
@@ -164,18 +174,20 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
           type="button"
           title={t('cancel')}
           onClick={cancelCrop}
-          className="!w-auto px-3 gap-1 text-[var(--danger-text)] hover:bg-[var(--danger-bg)]"
+          variant="unstyled"
+          className={`${textButtonBase} text-[var(--danger-text)] hover:bg-[var(--danger-bg)]`}
         >
-          {React.cloneElement(ICONS.X, { className: 'h-5 w-5' })}
+          {ICONS.X}
           <span>{t('cancel')}</span>
         </PanelButton>
         <PanelButton
           type="button"
           title={t('confirm')}
           onClick={confirmCrop}
-          className="!w-auto px-3 gap-1 bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:bg-[var(--accent-bg)] hover:opacity-90"
+          variant="unstyled"
+          className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
         >
-          {React.cloneElement(ICONS.CHECK, { className: 'h-5 w-5' })}
+          {ICONS.CHECK}
           <span>{t('confirm')}</span>
         </PanelButton>
       </div>

--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -57,12 +57,12 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
 
   return (
     <div
-      className="absolute left-1/2 -translate-x-1/2 z-30 flex items-center gap-2 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-2 text-[var(--text-primary)]"
+      className="absolute left-1/2 -translate-x-1/2 z-30 flex flex-wrap items-start gap-4 bg-[var(--ui-panel-bg)] backdrop-blur-lg shadow-xl border border-[var(--ui-panel-border)] rounded-xl p-3 text-[var(--text-primary)]"
       style={{ bottom: timelineBottomOffset }}
     >
-      <div className="flex flex-wrap items-center gap-3">
-        <span className="text-sm text-[var(--text-secondary)]">{t('cropMode')}</span>
-        <div className="flex items-center gap-1 bg-[var(--ui-element-bg)] rounded-lg p-1">
+      <div className="flex flex-col gap-2">
+        <span className="text-sm font-medium text-[var(--text-secondary)]">{t('cropMode')}</span>
+        <div className="flex items-center gap-1 rounded-lg bg-[var(--ui-element-bg)] p-1">
           <button
             type="button"
             className={`flex items-center gap-1 rounded-md px-3 py-1 text-sm font-medium transition-colors ${
@@ -155,7 +155,7 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
         </div>
       )}
 
-      <div className="flex flex-wrap items-center gap-2 justify-end">
+      <div className="flex flex-wrap items-center justify-end gap-2">
         <PanelButton
           type="button"
           title={t('cancel')}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -296,7 +296,7 @@ const resources = {
       simplify: '简化',
       removeBackground: '抠图',
       cropMode: '裁剪模式',
-      cropAdjust: '裁剪框',
+      cropAdjust: '裁剪',
       cropMagicWand: '抠图',
       applySelection: '应用选区',
       clearSelection: '清除选区',


### PR DESCRIPTION
## Summary
- refactor the crop toolbar container so the crop and magic-wand toggles live in their own column
- increase padding and spacing to better separate mode controls from magic-wand options and action buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbdb5524d08323a6c34275530bed43