### PR TITLE
fix: 修复缩放后裁剪图像

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -496,26 +496,23 @@ export const useAppStore = () => {
         img.onerror = err => reject(err);
       });
 
+      const naturalWidth = img.naturalWidth || img.width;
+      const naturalHeight = img.naturalHeight || img.height;
+      const scaleX = naturalWidth / originalPath.width;
+      const scaleY = naturalHeight / originalPath.height;
+
+      const sourceX = (cropRect.x - originalPath.x) * scaleX;
+      const sourceY = (cropRect.y - originalPath.y) * scaleY;
+      const sourceWidth = Math.max(1, Math.round(cropRect.width * scaleX));
+      const sourceHeight = Math.max(1, Math.round(cropRect.height * scaleY));
+
       const canvas = document.createElement('canvas');
-      canvas.width = Math.round(cropRect.width);
-      canvas.height = Math.round(cropRect.height);
+      canvas.width = sourceWidth;
+      canvas.height = sourceHeight;
       const ctx = canvas.getContext('2d');
       if (!ctx) return;
 
-      const sourceX = cropRect.x - originalPath.x;
-      const sourceY = cropRect.y - originalPath.y;
-
-      ctx.drawImage(
-        img,
-        sourceX,
-        sourceY,
-        canvas.width,
-        canvas.height,
-        0,
-        0,
-        canvas.width,
-        canvas.height
-      );
+      ctx.drawImage(img, sourceX, sourceY, sourceWidth, sourceHeight, 0, 0, sourceWidth, sourceHeight);
 
       const newSrc = canvas.toDataURL();
       const rotation = originalPath.rotation ?? 0;


### PR DESCRIPTION
## Summary
- 按原始像素尺寸换算裁剪源区域，确保缩放后的图片可正确裁切
- 保持输出画布尺寸与源像素一致，避免质量损失

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbdc7c4b448323b217f7f11b0b8f8b