### PR TITLE
fix(selection): prune stale selection ids

### DIFF
--- a/src/hooks/usePaths.ts
+++ b/src/hooks/usePaths.ts
@@ -18,11 +18,31 @@ import { getLocalStorageItem } from '../lib/utils';
 export const usePaths = () => {
   const frameManagement = useFrameManagement();
   const liveDrawingState = useLiveDrawingState();
+  const { paths } = frameManagement;
   const [selectedPathIds, setSelectedPathIds] = useState<string[]>(() => getLocalStorageItem('whiteboard_selectedPathIds', []));
 
   useEffect(() => {
     localStorage.setItem('whiteboard_selectedPathIds', JSON.stringify(selectedPathIds));
   }, [selectedPathIds]);
+
+  useEffect(() => {
+    if (selectedPathIds.length === 0) return;
+
+    const existingIds = new Set<string>();
+    const stack = [...paths];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current) continue;
+      existingIds.add(current.id);
+      if (current.tool === 'group') {
+        stack.push(...current.children);
+      }
+    }
+
+    if (!selectedPathIds.some(id => !existingIds.has(id))) return;
+
+    setSelectedPathIds(prev => prev.filter(id => existingIds.has(id)));
+  }, [paths, selectedPathIds, setSelectedPathIds]);
 
   const { setPaths: setCurrentFramePaths } = frameManagement;
   const { currentBrushPath, setCurrentBrushPath, currentPenPath, setCurrentPenPath, currentLinePath, setCurrentLinePath } = liveDrawingState;


### PR DESCRIPTION
## Summary
- prune stale selection identifiers from the persisted selection state when the corresponding paths no longer exist
- ensure the selection toolbar hides once all actual shapes are deselected by sanitising the selection list against the current path tree

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccb6cfd1b883239aa94ee4a0c7a2a8