### PR TITLE
feat: allow typed inputs for trace parameters

### DIFF
--- a/src/components/TraceImagePopover.tsx
+++ b/src/components/TraceImagePopover.tsx
@@ -82,10 +82,10 @@ const ParameterInput: React.FC<ParameterInputProps> = ({ label, value, setValue,
 
   return (
     <div className="flex items-center gap-3">
-      <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex-1 min-w-0`} htmlFor={inputId}>
+      <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] shrink-0`} htmlFor={inputId}>
         {label}
       </label>
-      <div className={`${PANEL_CLASSES.inputWrapper} w-16 shrink-0`}>
+      <div className={`${PANEL_CLASSES.inputWrapper} flex-1`}>
         <input
           id={inputId}
           type="number"


### PR DESCRIPTION
## Summary
- replace the Trace Image popover sliders with numeric inputs so vector options accept explicit values
- add a reusable ParameterInput helper that clamps, snaps to step values, and keeps panel styling consistent

## Testing
- npm run build

## Screenshots
- Not available: the Trace Image controls only appear when an imported image is selected, which is not reproducible in the headless test environment.

------
https://chatgpt.com/codex/tasks/task_e_68ccb96840c48323a0288ef1435917fd