### PR TITLE
fix: keep selection toolbar visible for selection tool

### DIFF
--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -175,7 +175,7 @@ export const CanvasOverlays: React.FC = () => {
                 {groupIsolationPath.length > 0 && <Breadcrumbs path={groupIsolationPath} onJumpTo={handleJumpToGroup} />}
             </div>
 
-            {tool === 'selection' && !croppingState && selectedPathIds.length > 0 && (
+            {tool === 'selection' && !croppingState && (
                 <div
                     className="absolute left-1/2 -translate-x-1/2 z-30"
                     style={{ bottom: timelineBottomOffset }}


### PR DESCRIPTION
## Summary
- show the selection toolbar whenever the selection tool is active, even with no selection
- keep existing controls gated by selection-dependent flags inside the toolbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccbb1ecf408323bbfaac199e7d6476