### PR TITLE
feat: support ctrl+a selecting unlocked objects

### DIFF
--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -29,7 +29,7 @@ const useGlobalEventHandlers = () => {
     cancelCrop,
   } = useAppContext();
 
-  const { setPaths: setActivePaths } = activePathState;
+  const { setPaths: setActivePaths, paths: activePaths } = activePathState;
 
   const { drawingShape, cancelDrawingShape } = drawingInteraction;
 
@@ -105,6 +105,32 @@ const useGlobalEventHandlers = () => {
       handleUngroup();
     });
 
+    hotkeys('command+a, ctrl+a', (event) => {
+      const activeElement = document.activeElement as HTMLElement | null;
+      const isInput =
+        activeElement?.tagName === 'INPUT' ||
+        activeElement?.tagName === 'TEXTAREA' ||
+        activeElement?.isContentEditable;
+
+      if (isInput) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const unlockedIds = activePaths
+        .filter(path => path.isLocked !== true)
+        .map(path => path.id);
+
+      if (unlockedIds.length === 0) {
+        setSelectedPathIds([]);
+        return;
+      }
+
+      setSelectedPathIds(unlockedIds);
+      setTool('selection');
+    });
+
     // --- Group 2: Shortcuts that MUST fire even in input fields ---
     // We temporarily override the filter for these.
     const originalFilter = hotkeys.filter;
@@ -166,6 +192,7 @@ const useGlobalEventHandlers = () => {
       hotkeys.unbind('command+s, ctrl+s');
       hotkeys.unbind('command+g, ctrl+g');
       hotkeys.unbind('command+shift+g, ctrl+shift+g');
+      hotkeys.unbind('command+a, ctrl+a');
     };
   }, [
     selectedPathIds,
@@ -200,6 +227,7 @@ const useGlobalEventHandlers = () => {
     handleExitGroup,
     croppingState,
     cancelCrop,
+    activePaths,
   ]);
 
   // Nudge selected items with arrow keys using a native event listener for reliability


### PR DESCRIPTION
## Summary
- capture the active path list from the app context so global shortcuts can act on the current isolation scope
- bind Ctrl/Cmd+A to gather unlocked path ids and switch to the selection tool

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd03c990188323b728b092bb8f2467