### PR TITLE
feat: enable inline text editing on creation

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -237,6 +237,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
       onContextMenu={onContextMenu}
     >
       <svg
+        data-whiteboard-canvas="true"
         ref={svgRef}
         className="w-full h-full touch-none"
         onPointerDown={onPointerDown}

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -163,6 +163,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
       onContextMenu={onContextMenu}
     >
       <svg
+        data-whiteboard-canvas="true"
         ref={svgRef}
         className="w-full h-full touch-none"
         onPointerDown={onPointerDown}

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -519,8 +519,9 @@ export const useAppStore = () => {
 
   const startTextEditing = useCallback((pathId: string) => {
     setEditingTextPathId(pathId);
+    setSelectedPathIds([pathId]);
     beginPathsCoalescing();
-  }, [setEditingTextPathId, beginPathsCoalescing]);
+  }, [setEditingTextPathId, beginPathsCoalescing, setSelectedPathIds]);
 
   const viewTransform = useViewTransform();
   const requestFitToContent = useViewTransformStore(s => s.requestFitToContent);
@@ -675,7 +676,7 @@ export const useAppStore = () => {
 
   const onDoubleClick = useCallback((path: AnyPath) => {
       if (toolbarState.selectionMode !== 'move') return;
-      if (path.tool === 'text') { setEditingTextPathId(path.id); beginPathsCoalescing(); }
+      if (path.tool === 'text') { startTextEditing(path.id); }
       else if (path.tool === 'group') { groupIsolation.handleGroupDoubleClick(path.id); }
       else if (path.tool === 'image') {
           beginPathsCoalescing();
@@ -687,7 +688,7 @@ export const useAppStore = () => {
           setCropHistory({ past: [], future: [] });
           setSelectedPathIds([path.id]);
       }
-  }, [toolbarState.selectionMode, beginPathsCoalescing, groupIsolation, setEditingTextPathId, setCroppingState, setCurrentCropRect, clearCropSelection, setCropTool, setCropEditedSrc, setSelectedPathIds]);
+  }, [toolbarState.selectionMode, startTextEditing, groupIsolation, beginPathsCoalescing, setCroppingState, setCurrentCropRect, clearCropSelection, setCropTool, setCropEditedSrc, setSelectedPathIds]);
 
   const drawingInteraction = useDrawing({ pathState: activePathState, toolbarState, viewTransform, ...uiState, startTextEditing });
   const selectionInteraction = useSelection({ pathState: activePathState, toolbarState, viewTransform, ...uiState, onDoubleClick, croppingState: appState.croppingState, currentCropRect: appState.currentCropRect, setCurrentCropRect, pushCropHistory, cropTool: appState.cropTool, onMagicWandSample: selectMagicWandAt });

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -179,7 +179,6 @@ export const useDrawing = ({
         };
         setPaths((prev: AnyPath[]) => [...prev, newText]);
         toolbarState.setTool('selection');
-        pathState.setSelectedPathIds([id]);
         startTextEditing(id);
         break;
       }

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -17,6 +17,7 @@ interface DrawingInteractionProps {
   isGridVisible: boolean;
   gridSize: number;
   gridSubdivisions: number;
+  startTextEditing: (pathId: string) => void;
 }
 
 /**
@@ -31,6 +32,7 @@ export const useDrawing = ({
   isGridVisible,
   gridSize,
   gridSubdivisions,
+  startTextEditing,
 }: DrawingInteractionProps) => {
   const [drawingShape, setDrawingShape] = useState<DrawingShape | null>(null);
   const [previewD, setPreviewD] = useState<string | null>(null);
@@ -178,6 +180,7 @@ export const useDrawing = ({
         setPaths((prev: AnyPath[]) => [...prev, newText]);
         toolbarState.setTool('selection');
         pathState.setSelectedPathIds([id]);
+        startTextEditing(id);
         break;
       }
       case 'arc': {


### PR DESCRIPTION
## Summary
- start in-canvas text editing immediately after creating a text element
- refactor app store editing helpers to reuse coalescing utilities across text and crop workflows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2161b8948323a92899fd4c3e0dba