### PR TITLE
fix: allow selecting filled shapes by clicking interior

### DIFF
--- a/src/lib/hit-testing.ts
+++ b/src/lib/hit-testing.ts
@@ -51,6 +51,22 @@ export function isPointInPolygon(point: Point, vs: Point[]): boolean {
     return inside;
 }
 
+function hasVisibleFill(path: AnyPath): boolean {
+    if (path.tool === 'image') {
+        return true;
+    }
+
+    const fill = (path.fill ?? '').trim();
+    if (!fill) return false;
+
+    const normalized = fill.toLowerCase();
+    if (normalized === 'transparent' || normalized === 'none') {
+        return false;
+    }
+
+    return parseColor(fill).a > 0.01;
+}
+
 /**
  * Checks if a point is hitting the stroke of a given path with a tolerance.
  * @param point The point to check.
@@ -119,8 +135,8 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
                 const center = { x: x + width / 2, y: y + height / 2 };
                 testPoint = rotatePoint(point, center, -rotation);
             }
-            
-            const isFillVisible = path.fill !== 'transparent' && parseColor(path.fill).a > 0.01;
+
+            const isFillVisible = hasVisibleFill(path);
 
             // Check for hit on the fill area first.
             const isInside = testPoint.x >= x && testPoint.x <= x + width && testPoint.y >= y && testPoint.y <= y + height;
@@ -146,8 +162,8 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
                 const center = { x: x + width / 2, y: y + height / 2 };
                 testPoint = rotatePoint(point, center, -rotation);
             }
-            
-            const isFillVisible = path.fill !== 'transparent' && parseColor(path.fill).a > 0.01;
+
+            const isFillVisible = hasVisibleFill(path);
             const vertices = getPolygonVertices(x, y, width, height, sides);
 
             // Check for hit on fill area first.
@@ -181,7 +197,7 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
                 testPoint = rotatePoint(point, center, -rotation);
             }
 
-            const isFillVisible = path.fill !== 'transparent' && parseColor(path.fill).a > 0.01;
+            const isFillVisible = hasVisibleFill(path);
 
             // Check for hit on fill using ellipse equation
             if (isFillVisible && rx > 0 && ry > 0) {
@@ -209,12 +225,12 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
             if (vectorPath.anchors.length === 1) {
                 return dist(point, vectorPath.anchors[0].point) < threshold;
             }
-            
+
             const pathPoints = samplePath(vectorPath.anchors, 20, vectorPath.isClosed);
             if (pathPoints.length < 2) return false;
 
             if (vectorPath.isClosed) {
-                const isFillVisible = path.fill !== 'transparent' && parseColor(path.fill).a > 0.01;
+                const isFillVisible = hasVisibleFill(path);
                 if (isFillVisible && isPointInPolygon(point, pathPoints)) {
                     return true;
                 }


### PR DESCRIPTION
## Summary
- add a reusable helper to detect whether a path exposes a visible fill
- allow hit testing to treat fills (including images) as clickable areas when selecting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd21f707b483238f7dcc5a3f57b988