### PR TITLE
feat(text): enable direct canvas editing

### DIFF
--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -17,6 +17,7 @@ interface DrawingInteractionProps {
   isGridVisible: boolean;
   gridSize: number;
   gridSubdivisions: number;
+  beginTextEditing: (pathId: string) => void;
 }
 
 /**
@@ -31,6 +32,7 @@ export const useDrawing = ({
   isGridVisible,
   gridSize,
   gridSubdivisions,
+  beginTextEditing,
 }: DrawingInteractionProps) => {
   const [drawingShape, setDrawingShape] = useState<DrawingShape | null>(null);
   const [previewD, setPreviewD] = useState<string | null>(null);
@@ -158,22 +160,23 @@ export const useDrawing = ({
         const defaultText = text || '文本';
         const { width, height } = measureText(defaultText, fontSize, fontFamily);
 
+        beginTextEditing(id);
         const newText: TextData = {
-            id,
-            tool: 'text',
-            text: defaultText,
-            x: snappedPoint.x,
-            y: snappedPoint.y,
-            width,
-            height,
-            fontFamily,
-            fontSize,
-            textAlign,
-            ...sharedProps,
-            // Text specific overrides
-            fill: 'transparent',
-            fillStyle: 'solid',
-            strokeWidth: 0,
+          id,
+          tool: 'text',
+          text: defaultText,
+          x: snappedPoint.x,
+          y: snappedPoint.y,
+          width,
+          height,
+          fontFamily,
+          fontSize,
+          textAlign,
+          ...sharedProps,
+          // Text specific overrides
+          fill: 'transparent',
+          fillStyle: 'solid',
+          strokeWidth: 0,
         };
         setPaths((prev: AnyPath[]) => [...prev, newText]);
         toolbarState.setTool('selection');


### PR DESCRIPTION
## Summary
- allow text elements placed via the text tool to enter the canvas editor immediately
- add centralized text-edit lifecycle management so empty edits are cleaned up and history coalesces correctly
- finish active text edits when switching tools to avoid dangling overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce0b7555208323b7a1ecafeb1a4d06