### PR TITLE
feat(text): enable inline canvas editing

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -10,7 +10,7 @@ import { Whiteboard } from './Whiteboard';
 import { LayersProvider } from '../lib/layers-context';
 import { ICONS, CONTROL_BUTTON_CLASS } from '../constants';
 import PanelButton from '@/components/PanelButton';
-import type { MaterialData, AnyPath } from '../types';
+import type { MaterialData, AnyPath, TextData } from '../types';
 
 // Import new layout components
 import { MainMenuPanel } from './layout/MainMenuPanel';
@@ -55,6 +55,9 @@ export const MainLayout: React.FC = () => {
         gridSubdivisions,
         gridOpacity,
         editingTextPathId,
+        handleTextChange,
+        handleTextEditCommit,
+        handleTextEditCancel,
         croppingState,
         currentCropRect,
         cropTool,
@@ -106,6 +109,12 @@ export const MainLayout: React.FC = () => {
 
         return skinPaths;
     }, [isOnionSkinEnabled, frames, currentFrameIndex, onionSkinPrevFrames, onionSkinNextFrames, onionSkinOpacity]);
+
+    const editingTextPath = useMemo(() => {
+        if (!editingTextPathId) { return null; }
+        const target = activePaths.find(path => path.id === editingTextPathId && path.tool === 'text');
+        return (target as TextData | undefined) ?? null;
+    }, [activePaths, editingTextPathId]);
 
     /**
      * 创建一个处理画布右键菜单的函数。
@@ -232,10 +241,14 @@ export const MainLayout: React.FC = () => {
                             gridOpacity={gridOpacity}
                             dragState={selectionInteraction.dragState}
                             editingTextPathId={editingTextPathId}
+                            editingTextPath={editingTextPath}
                             croppingState={croppingState}
                             currentCropRect={currentCropRect}
                             cropTool={cropTool}
                             cropSelectionContours={cropSelectionContours}
+                            onTextChange={handleTextChange}
+                            onTextCommit={handleTextEditCommit}
+                            onTextCancel={handleTextEditCancel}
                         />
                     </div>
                     <TimelinePanel />

--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -7,10 +7,11 @@
 import React, { useRef, useEffect, useState, useMemo, useLayoutEffect } from 'react';
 import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
-import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '../types';
+import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox, TextData } from '../types';
 import { getPointerPosition } from '../lib/utils';
 import { useViewTransformStore } from '@/context/viewTransformStore';
 import { getPathsBoundingBox } from '@/lib/drawing';
+import { TextEditor } from './TextEditor';
 
 // Import new sub-components
 import { Grid } from './whiteboard/Grid';
@@ -51,10 +52,14 @@ interface WhiteboardProps {
   gridOpacity: number;
   dragState: DragState | null;
   editingTextPathId: string | null;
+  editingTextPath: TextData | null;
   croppingState: { pathId: string; originalPath: ImageData; } | null;
   currentCropRect: BBox | null;
   cropTool: 'crop' | 'magic-wand';
   cropSelectionContours: Array<{ d: string; inner: boolean }> | null;
+  onTextChange: (pathId: string, newText: string) => void;
+  onTextCommit: () => void;
+  onTextCancel: () => void;
 }
 
 /**
@@ -91,10 +96,14 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   gridOpacity,
   dragState,
   editingTextPathId,
+  editingTextPath,
   croppingState,
   currentCropRect,
   cropTool,
   cropSelectionContours,
+  onTextChange,
+  onTextCommit,
+  onTextCancel,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -283,7 +292,16 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
           
           <Marquee marquee={marquee} viewTransform={viewTransform} />
           <Lasso lassoPath={lassoPath} viewTransform={viewTransform} />
-          
+
+          {editingTextPath && (
+            <TextEditor
+              path={editingTextPath}
+              onUpdate={(newText) => onTextChange(editingTextPath.id, newText)}
+              onCommit={onTextCommit}
+              onCancel={onTextCancel}
+            />
+          )}
+
         </g>
       </svg>
     </div>

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -10,13 +10,12 @@ import { CONTROL_BUTTON_CLASS, getTimelinePanelBottomOffset } from '@/constants'
 import { Toolbar } from '../Toolbar';
 import { SelectionToolbar } from '../SelectionToolbar';
 import { ContextMenu } from '../ContextMenu';
-import { TextEditor } from '../TextEditor';
 import { StyleLibraryPopover } from '../side-toolbar';
 import { ConfirmationDialog } from '../ConfirmationDialog';
 import { Breadcrumbs } from '../Breadcrumbs';
 import { AboutButton } from './AboutButton';
 import { CropToolbar } from '../CropToolbar';
-import type { AnyPath, TextData, MaterialData } from '@/types';
+import type { AnyPath, MaterialData } from '@/types';
 import { ICONS } from '@/constants';
 import { getPathsBoundingBox, getPathBoundingBox } from '@/lib/drawing';
 
@@ -88,9 +87,6 @@ export const CanvasOverlays: React.FC = () => {
         handleTraceImage,
         confirmationDialog,
         hideConfirmation,
-        editingTextPathId: activeEditingTextPathId, // rename to avoid conflict
-        handleTextChange,
-        handleTextEditCommit,
         croppingState,
         cropTool,
         setCropTool,
@@ -109,11 +105,6 @@ export const CanvasOverlays: React.FC = () => {
         isTimelineCollapsed,
         setIsTimelineCollapsed,
     } = store;
-
-    const editingPath = useMemo(() => 
-        paths.find((p: AnyPath) => p.id === activeEditingTextPathId && p.tool === 'text') as TextData | undefined,
-        [paths, activeEditingTextPathId]
-    );
 
     const canGroup = useMemo(() => selectedPathIds.length > 1, [selectedPathIds]);
     const canUngroup = useMemo(() => paths.some((p: AnyPath) => selectedPathIds.includes(p.id) && p.tool === 'group'), [paths, selectedPathIds]);
@@ -210,13 +201,6 @@ export const CanvasOverlays: React.FC = () => {
                 />
             )}
 
-            {editingPath && (
-                <TextEditor
-                    path={editingPath} viewTransform={store.viewTransform}
-                    onUpdate={(newText) => handleTextChange(editingPath.id, newText)} onCommit={handleTextEditCommit}
-                />
-            )}
-            
             <StyleLibraryPopover
                 isOpen={isStyleLibraryOpen} onClose={() => setIsStyleLibraryOpen(false)}
                 position={styleLibraryPosition} onPositionChange={setStyleLibraryPosition}

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -17,6 +17,7 @@ interface DrawingInteractionProps {
   isGridVisible: boolean;
   gridSize: number;
   gridSubdivisions: number;
+  beginTextEditing: (pathId: string, options?: { select?: boolean; initialText?: string }) => void;
 }
 
 /**
@@ -31,6 +32,7 @@ export const useDrawing = ({
   isGridVisible,
   gridSize,
   gridSubdivisions,
+  beginTextEditing,
 }: DrawingInteractionProps) => {
   const [drawingShape, setDrawingShape] = useState<DrawingShape | null>(null);
   const [previewD, setPreviewD] = useState<string | null>(null);
@@ -177,7 +179,7 @@ export const useDrawing = ({
         };
         setPaths((prev: AnyPath[]) => [...prev, newText]);
         toolbarState.setTool('selection');
-        pathState.setSelectedPathIds([id]);
+        beginTextEditing(id, { initialText: defaultText });
         break;
       }
       case 'arc': {


### PR DESCRIPTION
## Summary
- 在白板内部通过 `foreignObject` 嵌入文本编辑器，实现文本直接在画布中编辑的效果，并清理旧的覆盖层实现。
- 扩展应用状态，加入文本编辑会话管理（自动选中、快照还原、提交/取消），并在创建新文本时立即进入编辑。
- 调整主布局和白板渲染逻辑以传递新的文本编辑回调，保证编辑过程中路径尺寸实时同步。

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce0b7555208323b7a1ecafeb1a4d06