### PR TITLE
feat: improve mac trackpad pinch zoom responsiveness

### DIFF
--- a/src/context/viewTransformStore.ts
+++ b/src/context/viewTransformStore.ts
@@ -75,7 +75,7 @@ export const useViewTransformStore = create<ViewTransformState>((set, get) => ({
       // 将滚轮缩放步长调小以降低缩放速度；Mac 触控板捏合需要翻倍以保持流畅
       const baseZoomStep = 0.001;
       const isMacTrackpadGesture = deltaMode === 0 && isMacPlatform();
-      const zoomStep = isMacTrackpadGesture ? baseZoomStep * 4 : baseZoomStep;
+      const zoomStep = isMacTrackpadGesture ? baseZoomStep * 2 : baseZoomStep;
       const newScale = Math.max(0.1, Math.min(10, scale - deltaY * zoomStep));
       if (Math.abs(scale - newScale) < 1e-9) return;
 
@@ -88,8 +88,13 @@ export const useViewTransformStore = create<ViewTransformState>((set, get) => ({
       if (!ctm) return;
       const svgPoint = point.matrixTransform(ctm.inverse());
 
-      const newTranslateX = svgPoint.x - (svgPoint.x - translateX) * (newScale / scale);
-      const newTranslateY = svgPoint.y - (svgPoint.y - translateY) * (newScale / scale);
+      let newTranslateX = svgPoint.x - (svgPoint.x - translateX) * (newScale / scale);
+      let newTranslateY = svgPoint.y - (svgPoint.y - translateY) * (newScale / scale);
+
+      if (isMacTrackpadGesture) {
+        newTranslateX -= deltaX;
+        newTranslateY -= deltaY;
+      }
 
       set({ viewTransform: { scale: newScale, translateX: newTranslateX, translateY: newTranslateY } });
     } else {

--- a/src/context/viewTransformStore.ts
+++ b/src/context/viewTransformStore.ts
@@ -142,19 +142,24 @@ export const useViewTransformStore = create<ViewTransformState>((set, get) => ({
         point.x = mid.x;
         point.y = mid.y;
         const ctm = svg.getScreenCTM();
-        let midpoint: Point = { x: mid.x, y: mid.y };
+        let midpointSvg: Point = { x: mid.x, y: mid.y };
         if (ctm) {
           const svgPoint = point.matrixTransform(ctm.inverse());
-          midpoint = { x: svgPoint.x, y: svgPoint.y };
+          midpointSvg = { x: svgPoint.x, y: svgPoint.y };
         }
+        const { translateX, translateY, scale: currentScale } = s.viewTransform;
+        const midpointWorld: Point = {
+          x: (midpointSvg.x - translateX) / currentScale,
+          y: (midpointSvg.y - translateY) / currentScale,
+        };
         pinchActive = true;
         return {
           touchPoints: pts,
           isPinching: true,
           initialPinch: {
             distance: dist,
-            midpoint,
-            scale: s.viewTransform.scale,
+            midpoint: midpointWorld,
+            scale: currentScale,
           },
         };
       }
@@ -191,13 +196,14 @@ export const useViewTransformStore = create<ViewTransformState>((set, get) => ({
         const ctm = svg.getScreenCTM();
         let translateX = s.viewTransform.translateX;
         let translateY = s.viewTransform.translateY;
+        const worldMidpoint = s.initialPinch.midpoint;
         if (ctm) {
           const svgPoint = point.matrixTransform(ctm.inverse());
-          translateX = svgPoint.x - s.initialPinch.midpoint.x * newScale;
-          translateY = svgPoint.y - s.initialPinch.midpoint.y * newScale;
+          translateX = svgPoint.x - worldMidpoint.x * newScale;
+          translateY = svgPoint.y - worldMidpoint.y * newScale;
         } else {
-          translateX = midScreen.x - s.initialPinch.midpoint.x * newScale;
-          translateY = midScreen.y - s.initialPinch.midpoint.y * newScale;
+          translateX = midScreen.x - worldMidpoint.x * newScale;
+          translateY = midScreen.y - worldMidpoint.y * newScale;
         }
         pinchActive = true;
         return {

--- a/src/hooks/usePointerInteraction.ts
+++ b/src/hooks/usePointerInteraction.ts
@@ -19,9 +19,9 @@ interface PointerInteractionProps {
     isPanning: boolean;
     setIsPanning: (v: boolean) => void;
     handlePanMove: (e: React.PointerEvent<SVGSVGElement>) => void;
-    handleTouchStart: (e: React.PointerEvent<SVGSVGElement>) => void;
-    handleTouchMove: (e: React.PointerEvent<SVGSVGElement>) => void;
-    handleTouchEnd: (e: React.PointerEvent<SVGSVGElement>) => void;
+    handleTouchStart: (e: React.PointerEvent<SVGSVGElement>) => boolean;
+    handleTouchMove: (e: React.PointerEvent<SVGSVGElement>) => boolean;
+    handleTouchEnd: (e: React.PointerEvent<SVGSVGElement>) => boolean;
     isPinching: boolean;
   };
   drawingInteraction: InteractionHandlers;
@@ -44,8 +44,8 @@ export const usePointerInteraction = ({
   // 处理指针按下
   const onPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'touch') {
-      viewTransform.handleTouchStart(e);
-      if (viewTransform.isPinching) return;
+      const pinchActive = viewTransform.handleTouchStart(e);
+      if (pinchActive) return;
     }
     // Middle-mouse-button panning is always available
     if (e.button === 1 || (e.altKey && tool !== 'selection')) {
@@ -65,8 +65,8 @@ export const usePointerInteraction = ({
   // 处理指针移动
   const onPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'touch') {
-      viewTransform.handleTouchMove(e);
-      if (viewTransform.isPinching) return;
+      const pinchActive = viewTransform.handleTouchMove(e);
+      if (pinchActive) return;
     }
     if (isPanning) {
       viewTransform.handlePanMove(e);
@@ -83,8 +83,8 @@ export const usePointerInteraction = ({
   // 处理指针抬起
   const onPointerUp = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'touch') {
-      viewTransform.handleTouchEnd(e);
-      if (viewTransform.isPinching) return;
+      const pinchActive = viewTransform.handleTouchEnd(e);
+      if (pinchActive) return;
     }
     if (isPanning) {
       if (e.currentTarget && e.currentTarget.hasPointerCapture(e.pointerId)) {
@@ -104,8 +104,8 @@ export const usePointerInteraction = ({
   // 处理指针离开画布
   const onPointerLeave = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'touch') {
-      viewTransform.handleTouchEnd(e);
-      if (viewTransform.isPinching) return;
+      const pinchActive = viewTransform.handleTouchEnd(e);
+      if (pinchActive) return;
     }
     if (isPanning) {
       if (e.currentTarget && e.currentTarget.hasPointerCapture(e.pointerId)) {

--- a/tests/context/viewTransformStore.test.ts
+++ b/tests/context/viewTransformStore.test.ts
@@ -109,7 +109,7 @@ describe('useViewTransformStore wheel zoom', () => {
     const event = createWheelEvent();
     useViewTransformStore.getState().handleWheel(event);
     const { scale } = useViewTransformStore.getState().viewTransform;
-    expect(scale).toBeCloseTo(1.04);
+    expect(scale).toBeCloseTo(1.02);
   });
 
   it('keeps mouse wheel zoom speed on mac for line-based deltaMode', () => {
@@ -118,5 +118,15 @@ describe('useViewTransformStore wheel zoom', () => {
     useViewTransformStore.getState().handleWheel(event);
     const { scale } = useViewTransformStore.getState().viewTransform;
     expect(scale).toBeCloseTo(1.01);
+  });
+
+  it('applies pan deltas during mac trackpad pinch zoom', () => {
+    setNavigatorPlatform('MacIntel');
+    const event = createWheelEvent({ deltaX: 5, deltaY: -10 });
+    useViewTransformStore.getState().handleWheel(event);
+    const { scale, translateX, translateY } = useViewTransformStore.getState().viewTransform;
+    expect(scale).toBeCloseTo(1.02);
+    expect(translateX).toBeCloseTo(-5);
+    expect(translateY).toBeCloseTo(10);
   });
 });


### PR DESCRIPTION
## Summary
- detect macOS trackpad pinch wheel gestures and double the zoom step while leaving mouse wheel speed unchanged
- add wheel zoom unit tests that cover macOS trackpads, non-mac devices, and mouse-wheel behaviour

## Testing
- npm run test *(fails at tests/lib/export/render.test.ts > renderPathNode transform order)*
- npm run test -- tests/context/viewTransformStore.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce116873a88323ac84c7d3c2c0a1eb