### PR TITLE
refactor(text): enable inline editing workflow

### DIFF
--- a/src/context/toolbarStore.ts
+++ b/src/context/toolbarStore.ts
@@ -176,7 +176,7 @@ export const useToolbarStore = create<ToolbarState>()(
       drawingDisableMultiStrokeFill: DEFAULT_DISABLE_MULTI_STROKE_FILL,
       setDrawingDisableMultiStrokeFill: (v) => set({ drawingDisableMultiStrokeFill: v }),
 
-      drawingText: '文本',
+      drawingText: '',
       setDrawingText: (v) => set({ drawingText: v }),
 
       drawingFontFamily: 'Excalifont',

--- a/src/hooks/useToolbarState.ts
+++ b/src/hooks/useToolbarState.ts
@@ -3,7 +3,7 @@ import type { AnyPath, ImageData, RectangleData, PolygonData, GroupData, VectorP
 import { useToolManagement } from './toolbar-state/useToolManagement';
 import { usePathActions } from './toolbar-state/usePathActions';
 import * as P from './toolbar-state/property-hooks';
-import { measureText } from '../lib/drawing';
+import { measureTextBounds } from '../lib/drawing';
 import { COLORS, DEFAULT_ROUGHNESS, DEFAULT_BOWING, DEFAULT_CURVE_TIGHTNESS, DEFAULT_FILL_WEIGHT, DEFAULT_HACHURE_ANGLE, DEFAULT_HACHURE_GAP, DEFAULT_CURVE_STEP_COUNT, DEFAULT_PRESERVE_VERTICES, DEFAULT_DISABLE_MULTI_STROKE, DEFAULT_DISABLE_MULTI_STROKE_FILL } from '../constants';
 
 /**
@@ -174,7 +174,7 @@ export const useToolbarState = (
     if (firstSelectedPath?.tool === 'text') {
         updateSelectedPaths((p) => {
             if (p.tool === 'text') {
-                const { width, height } = measureText(newText, p.fontSize, p.fontFamily);
+                const { width, height } = measureTextBounds(newText, p.fontSize, p.fontFamily);
                 return { text: newText, width, height };
             }
             return {};
@@ -188,7 +188,7 @@ export const useToolbarState = (
     if (firstSelectedPath?.tool === 'text') {
         updateSelectedPaths((p) => {
             if (p.tool === 'text') {
-                const { width, height } = measureText(p.text, p.fontSize, newFamily);
+                const { width, height } = measureTextBounds(p.text, p.fontSize, newFamily);
                 return { fontFamily: newFamily, width, height };
             }
             return {};
@@ -202,7 +202,7 @@ export const useToolbarState = (
     if (firstSelectedPath?.tool === 'text') {
         updateSelectedPaths((p) => {
             if (p.tool === 'text') {
-                const { width, height } = measureText(p.text, newSize, p.fontFamily);
+                const { width, height } = measureTextBounds(p.text, newSize, p.fontFamily);
                 return { fontSize: newSize, width, height };
             }
             return {};
@@ -310,7 +310,7 @@ export const useToolbarState = (
     setDrawingPreserveVertices(DEFAULT_PRESERVE_VERTICES);
     setDrawingDisableMultiStroke(DEFAULT_DISABLE_MULTI_STROKE);
     setDrawingDisableMultiStrokeFill(DEFAULT_DISABLE_MULTI_STROKE_FILL);
-    setDrawingText('文本');
+    setDrawingText('');
     setDrawingFontFamily('Excalifont');
     setDrawingFontSize(24);
     setDrawingTextAlign('left');

--- a/src/lib/drawing/text.ts
+++ b/src/lib/drawing/text.ts
@@ -17,7 +17,7 @@ export function measureText(text: string, fontSize: number, fontFamily: string):
     ctx.font = `${fontSize}px ${family}`;
     const lines = text.split('\n');
     let maxWidth = 0;
-    
+
     // 测量宽度
     for (const line of lines) {
         const metrics = ctx.measureText(line);
@@ -25,11 +25,30 @@ export function measureText(text: string, fontSize: number, fontFamily: string):
             maxWidth = metrics.width;
         }
     }
-    
+
     // 高度是根据字体大小、行数和行高乘数估算的
     // 对于 Excalifont，1.25 是一个合适的行高
     const lineHeight = fontSize * 1.25;
     const height = lines.length * lineHeight;
 
     return { width: maxWidth, height };
+}
+
+/**
+ * 计算文本在画布中的边界框。
+ *
+ * 与 `measureText` 不同的是，当文本为空字符串时，此函数仍然会返回一个合理的宽度，
+ * 以便在创建文本时为编辑器提供可点击的空间。
+ */
+export function measureTextBounds(
+    text: string,
+    fontSize: number,
+    fontFamily: string,
+): { width: number; height: number } {
+    const target = text === '' ? 'M' : text;
+    const { width, height } = measureText(target, fontSize, fontFamily);
+    return {
+        width: text === '' ? Math.max(width, fontSize) : width,
+        height,
+    };
 }


### PR DESCRIPTION
## Summary
- create `measureTextBounds` to ensure text metrics stay usable when no characters are entered and reuse it across toolbar updates
- start coalesced text editing immediately when placing text, removing empty results and wiring drawing state through the app store
- resolve text editor lookups through group hierarchies and default new text to a blank value for clean inline editing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce0b7555208323b7a1ecafeb1a4d06