### PR TITLE
feat(color): allow alt sampling of stroke color

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -19,6 +19,7 @@ import * as idb from '../lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, TextData, PngExportOptions, ImageData as PathImageData, BBox, Frame, Point } from '../types';
 import { measureText, rotatePoint } from '@/lib/drawing';
+import { findDeepestHitPath } from '@/lib/hit-testing';
 import { removeBackground } from '@/lib/image';
 import { getImageDataUrl } from '@/lib/imageCache';
 import { useFilesStore } from '@/context/filesStore';
@@ -513,6 +514,24 @@ export const useAppStore = () => {
   const viewTransform = useViewTransform();
   const requestFitToContent = useViewTransformStore(s => s.requestFitToContent);
   const toolbarState = useToolsStore(activePaths, pathState.selectedPathIds, activePathState.setPaths, pathState.setSelectedPathIds, pathState.beginCoalescing, pathState.endCoalescing);
+  const { setColor } = toolbarState;
+
+  const sampleStrokeColor = useCallback((point: Point) => {
+    const paths = pathState.paths;
+    if (!paths || paths.length === 0) {
+      return false;
+    }
+    const hitPath = findDeepestHitPath(point, paths, viewTransform.viewTransform.scale);
+    if (!hitPath) {
+      return false;
+    }
+    const { color } = hitPath;
+    if (!color) {
+      return false;
+    }
+    setColor(color);
+    return true;
+  }, [pathState.paths, viewTransform.viewTransform, setColor]);
   
   const handleResetPreferences = useCallback(() => {
     showConfirmation(
@@ -679,7 +698,7 @@ export const useAppStore = () => {
 
   const drawingInteraction = useDrawing({ pathState: activePathState, toolbarState, viewTransform, ...uiState });
   const selectionInteraction = useSelection({ pathState: activePathState, toolbarState, viewTransform, ...uiState, onDoubleClick, croppingState: appState.croppingState, currentCropRect: appState.currentCropRect, setCurrentCropRect, pushCropHistory, cropTool: appState.cropTool, onMagicWandSample: selectMagicWandAt });
-  const pointerInteraction = usePointerInteraction({ tool: toolbarState.tool, viewTransform, drawingInteraction, selectionInteraction });
+  const pointerInteraction = usePointerInteraction({ tool: toolbarState.tool, viewTransform, drawingInteraction, selectionInteraction, sampleStrokeColor });
   
   const handleSetTool = useCallback((newTool: Tool) => {
     if (newTool === toolbarState.tool) return;


### PR DESCRIPTION
## Summary
- allow pointer interactions to invoke a stroke color sampler when Alt+click is pressed
- find the topmost path under the cursor and update the toolbar color so Alt picks the stroke color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce0b3ea96483239849297f81f6345e