### PR TITLE
fix: hide trim transparent button when not cropping

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -271,16 +271,18 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
       )}
 
       <div className="flex flex-wrap items-center justify-end gap-2">
-        <PanelButton
-          type="button"
-          title={t('trimTransparent')}
-          onClick={trimTransparentEdges}
-          variant="unstyled"
-          className={`${textButtonBase} text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]`}
-        >
-          {ICONS.CROP_TRIM}
-          <span>{t('trimTransparent')}</span>
-        </PanelButton>
+        {cropTool === 'crop' && (
+          <PanelButton
+            type="button"
+            title={t('trimTransparent')}
+            onClick={trimTransparentEdges}
+            variant="unstyled"
+            className={`${textButtonBase} text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]`}
+          >
+            {ICONS.CROP_TRIM}
+            <span>{t('trimTransparent')}</span>
+          </PanelButton>
+        )}
         <PanelButton
           type="button"
           title={t('cancel')}


### PR DESCRIPTION
## Summary
- conditionally render the trim-transparent-edges control only while the crop tool is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce660519fc8323bef0144bc45571c8