### PR TITLE
fix: hide frame outlines in animation exports

### DIFF
--- a/src/lib/hit-testing.ts
+++ b/src/lib/hit-testing.ts
@@ -57,8 +57,14 @@ function hasVisibleFill(path: AnyPath): boolean {
         return true;
     }
 
+    if (path.fillGradient) {
+        return gradientHasVisibleColor(path.fillGradient);
+    }
+
     const fill = (path.fill ?? '').trim();
-    if (!fill) return false;
+    if (!fill) {
+        return false;
+    }
 
     const normalized = fill.toLowerCase();
     if (normalized === 'transparent' || normalized === 'none') {
@@ -470,12 +476,3 @@ export function isPathIntersectingLasso(path: AnyPath, lassoPoints: Point[]): bo
     // The core logic: check if EVERY point of the shape is inside the lasso polygon for full containment.
     return pointsToCheck.every(p => isPointInPolygon(p, lassoPoints));
 }
-const hasVisibleFill = (path: AnyPath): boolean => {
-    if (path.fillGradient) {
-        return gradientHasVisibleColor(path.fillGradient);
-    }
-    if (!path.fill || path.fill === 'transparent') {
-        return false;
-    }
-    return parseColor(path.fill).a > 0.01;
-};


### PR DESCRIPTION
## Summary
- strip frame tool paths before generating animation exports so sequence frames no longer show the frame outline
- reuse the sanitized paths for global bounding boxes and spritesheet rendering
- unify the hasVisibleFill helper to keep gradient support while removing the duplicate declaration that broke builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfeab6452083238492470384f894c7