### PR TITLE
fix: allow immediate text editing on placement

### DIFF
--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -20,6 +20,7 @@ import { isPointHittingPath, findDeepestHitPath } from '@/lib/hit-testing';
 import { recursivelyUpdatePaths } from './utils';
 
 const HIT_RADIUS = 10; // 点击命中控制点的半径
+export const DOUBLE_CLICK_TIMEOUT_MS = 500;
 
 /**
  * 处理在“移动/变换”模式下的指针按下事件。
@@ -281,7 +282,10 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
 
     if (clickedPath) {
         const now = Date.now();
-        if (lastClickRef.current.pathId === clickedPath.id && now - lastClickRef.current.time < 300) {
+        if (
+            lastClickRef.current.pathId === clickedPath.id &&
+            now - lastClickRef.current.time < DOUBLE_CLICK_TIMEOUT_MS
+        ) {
             // DON'T allow another double-click action if we are already cropping
             if (!croppingState) {
                 onDoubleClick(clickedPath);

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -847,7 +847,13 @@ export const useAppStore = () => {
       }
   }, [toolbarState.selectionMode, pathState, groupIsolation, setEditingTextPathId, setCroppingState, setCurrentCropRect, clearCropSelection, setCropTool, setCropEditedSrc]);
 
-  const drawingInteraction = useDrawing({ pathState: activePathState, toolbarState, viewTransform, ...uiState });
+  const drawingInteraction = useDrawing({
+    pathState: activePathState,
+    toolbarState,
+    viewTransform,
+    ...uiState,
+    setEditingTextPathId,
+  });
   const selectionInteraction = useSelection({
     pathState: activePathState,
     toolbarState,

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -17,6 +17,7 @@ interface DrawingInteractionProps {
   isGridVisible: boolean;
   gridSize: number;
   gridSubdivisions: number;
+  setEditingTextPathId: (value: string | null) => void;
 }
 
 /**
@@ -31,6 +32,7 @@ export const useDrawing = ({
   isGridVisible,
   gridSize,
   gridSubdivisions,
+  setEditingTextPathId,
 }: DrawingInteractionProps) => {
   const [drawingShape, setDrawingShape] = useState<DrawingShape | null>(null);
   const [previewD, setPreviewD] = useState<string | null>(null);
@@ -43,6 +45,7 @@ export const useDrawing = ({
     setCurrentPenPath, currentPenPath,
     setCurrentLinePath, currentLinePath,
     setPaths,
+    beginCoalescing,
   } = pathState;
 
   const { getPointerPosition } = viewTransform;
@@ -180,6 +183,8 @@ export const useDrawing = ({
         setPaths((prev: AnyPath[]) => [...prev, newText]);
         toolbarState.setTool('selection');
         pathState.setSelectedPathIds([id]);
+        setEditingTextPathId(id);
+        beginCoalescing?.();
         break;
       }
       case 'arc': {

--- a/src/lib/hit-testing.ts
+++ b/src/lib/hit-testing.ts
@@ -470,12 +470,3 @@ export function isPathIntersectingLasso(path: AnyPath, lassoPoints: Point[]): bo
     // The core logic: check if EVERY point of the shape is inside the lasso polygon for full containment.
     return pointsToCheck.every(p => isPointInPolygon(p, lassoPoints));
 }
-const hasVisibleFill = (path: AnyPath): boolean => {
-    if (path.fillGradient) {
-        return gradientHasVisibleColor(path.fillGradient);
-    }
-    if (!path.fill || path.fill === 'transparent') {
-        return false;
-    }
-    return parseColor(path.fill).a > 0.01;
-};

--- a/tests/hooks/useDrawing.test.ts
+++ b/tests/hooks/useDrawing.test.ts
@@ -1,0 +1,126 @@
+// useDrawing 钩子文本绘制与编辑行为测试
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDrawing } from '@/hooks/useDrawing';
+import type { AnyPath } from '@/types';
+import type React from 'react';
+
+describe('useDrawing text creation', () => {
+  let dateSpy: ReturnType<typeof vi.spyOn>;
+  let storedPaths: AnyPath[];
+  const beginCoalescing = vi.fn();
+  const setEditingTextPathId = vi.fn();
+  const setSelectedPathIds = vi.fn();
+  const setTool = vi.fn();
+  const getPointerPosition = vi.fn(() => ({ x: 10, y: 20 }));
+  let measureTextSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  const createHook = () => {
+    storedPaths = [];
+
+    const pathState = {
+      setCurrentBrushPath: vi.fn(),
+      currentBrushPath: null,
+      finishBrushPath: vi.fn(),
+      setCurrentPenPath: vi.fn(),
+      currentPenPath: null,
+      setCurrentLinePath: vi.fn(),
+      currentLinePath: null,
+      setPaths: vi.fn((updater) => {
+        storedPaths = typeof updater === 'function' ? (updater as (prev: AnyPath[]) => AnyPath[])(storedPaths) : updater;
+      }),
+      beginCoalescing,
+      setSelectedPathIds,
+    };
+
+    const toolbarState = {
+      tool: 'text',
+      setTool,
+      color: '#000000',
+      fill: 'transparent',
+      fillGradient: null,
+      fillStyle: 'solid',
+      strokeWidth: 0,
+      opacity: 1,
+      strokeLineDash: undefined,
+      strokeLineCapStart: 'round',
+      strokeLineCapEnd: 'round',
+      strokeLineJoin: 'miter',
+      endpointSize: 1,
+      endpointFill: 'hollow',
+      isRough: false,
+      roughness: 0,
+      bowing: 0,
+      fillWeight: 0,
+      hachureAngle: 0,
+      hachureGap: 0,
+      curveTightness: 0,
+      curveStepCount: 0,
+      preserveVertices: false,
+      disableMultiStroke: false,
+      disableMultiStrokeFill: false,
+      fontSize: 24,
+      textAlign: 'left' as const,
+      text: '',
+      fontFamily: 'Excalifont',
+    };
+
+    const viewTransform = {
+      getPointerPosition,
+    };
+
+    return renderHook(() => useDrawing({
+      pathState,
+      toolbarState,
+      viewTransform,
+      isGridVisible: false,
+      gridSize: 10,
+      gridSubdivisions: 1,
+      setEditingTextPathId,
+    }));
+  };
+
+  beforeEach(async () => {
+    dateSpy = vi.spyOn(Date, 'now').mockReturnValue(123);
+    const drawingModule = await import('@/lib/drawing');
+    measureTextSpy = vi.spyOn(drawingModule, 'measureText').mockReturnValue({ width: 42, height: 18 });
+    beginCoalescing.mockClear();
+    setEditingTextPathId.mockClear();
+    setSelectedPathIds.mockClear();
+    setTool.mockClear();
+    getPointerPosition.mockClear();
+  });
+
+  afterEach(() => {
+    dateSpy.mockRestore();
+    measureTextSpy?.mockRestore();
+  });
+
+  it('immediately enters editing mode after placing text', () => {
+    const { result } = createHook();
+
+    const setPointerCapture = vi.fn();
+    const event = {
+      pointerId: 1,
+      currentTarget: { setPointerCapture },
+      clientX: 10,
+      clientY: 20,
+    } as unknown as React.PointerEvent<SVGSVGElement>;
+
+    act(() => {
+      result.current.onPointerDown(event);
+    });
+
+    expect(setPointerCapture).toHaveBeenCalledWith(1);
+    expect(setEditingTextPathId).toHaveBeenCalledWith('123');
+    expect(beginCoalescing).toHaveBeenCalledTimes(1);
+    expect(setSelectedPathIds).toHaveBeenCalledWith(['123']);
+    expect(setTool).toHaveBeenCalledWith('selection');
+    expect(getPointerPosition).toHaveBeenCalled();
+    expect(measureTextSpy).toHaveBeenCalledWith('文本', 24, 'Excalifont');
+    expect(storedPaths).toHaveLength(1);
+    expect(storedPaths[0].id).toBe('123');
+    expect(storedPaths[0].tool).toBe('text');
+    expect(storedPaths[0]).toHaveProperty('text', '文本');
+  });
+});

--- a/tests/hooks/useToolbarState.test.ts
+++ b/tests/hooks/useToolbarState.test.ts
@@ -8,6 +8,7 @@ import type { Dispatch, SetStateAction } from 'react';
 
 const drawingColorSetter = vi.fn();
 const drawingFillSetter = vi.fn();
+const drawingFillGradientSetter = vi.fn();
 const drawingFillStyleSetter = vi.fn();
 const drawingStrokeWidthSetter = vi.fn();
 const drawingOpacitySetter = vi.fn();
@@ -43,6 +44,7 @@ const drawingShadowColorSetter = vi.fn();
 vi.mock('@/hooks/toolbar-state/property-hooks', () => ({
   useDrawingColor: () => ({ drawingColor: '#222222', setDrawingColor: drawingColorSetter }),
   useDrawingFill: () => ({ drawingFill: 'transparent', setDrawingFill: drawingFillSetter }),
+  useDrawingFillGradient: () => ({ drawingFillGradient: null, setDrawingFillGradient: drawingFillGradientSetter }),
   useDrawingFillStyle: () => ({ drawingFillStyle: 'hachure', setDrawingFillStyle: drawingFillStyleSetter }),
   useDrawingStrokeWidth: () => ({ drawingStrokeWidth: 0, setDrawingStrokeWidth: drawingStrokeWidthSetter }),
   useDrawingOpacity: () => ({ drawingOpacity: 1, setDrawingOpacity: drawingOpacitySetter }),


### PR DESCRIPTION
## Summary
- raise the double-click timeout to 500ms via a shared constant in the pointer-down logic
- mark freshly placed text as the active editor target and coalesce its history updates so typing can begin immediately
- add a regression test covering the text placement flow, extend toolbar-state mocks to include fill gradients, and drop a duplicate helper from hit-testing

## Testing
- npm run test *(fails: renderPathNode transform order > applies scale before rotation for flipped images)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce2285df6c8323b469a9e1eca31c08