### PR TITLE
perf: optimize image path rendering

### DIFF
--- a/src/components/whiteboard/PathsRenderer.tsx
+++ b/src/components/whiteboard/PathsRenderer.tsx
@@ -3,7 +3,7 @@
  * 它使用 RoughJS 库来创建手绘风格的 SVG 图形。
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import type { RoughSVG } from 'roughjs/bin/svg';
 import type { AnyPath, FrameData, GroupData, ImageData } from '@/types';
 import { renderPathNode } from '@/lib/export';
@@ -32,27 +32,166 @@ const getAllFrames = (paths: AnyPath[]): AnyPath[] => {
  * @description 对常规组进行递归渲染，以利用 React 的 diffing 算法，
  * 仅更新组内已更改的元素。遮罩组则被视为原子单元进行渲染。
  */
-const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.memo(({ rc, data }) => {
-    const [imageSrc, setImageSrc] = useState<string | null>(null);
+const EffectsFilter: React.FC<{ id: string; data: ImageData }> = ({ id, data }) => {
+    const hasBlur = (data.blur ?? 0) > 0;
+    const hasShadow = data.shadowEnabled === true;
+
+    if (!hasBlur && !hasShadow) {
+        return null;
+    }
+
+    const commonProps = {
+        id,
+        x: '-50%',
+        y: '-50%',
+        width: '200%',
+        height: '200%',
+    } as const;
+
+    if (hasBlur && hasShadow) {
+        return (
+            <filter {...commonProps}>
+                <feGaussianBlur in="SourceAlpha" stdDeviation={data.shadowBlur ?? 2} result="shadowBlur" />
+                <feOffset in="shadowBlur" dx={data.shadowOffsetX ?? 2} dy={data.shadowOffsetY ?? 2} result="shadowOffset" />
+                <feFlood floodColor={data.shadowColor ?? 'rgba(0,0,0,0.5)'} result="shadowColor" />
+                <feComposite in="shadowColor" in2="shadowOffset" operator="in" result="shadow" />
+                <feGaussianBlur in="SourceGraphic" stdDeviation={data.blur ?? 0} result="mainBlur" />
+                <feMerge>
+                    <feMergeNode in="shadow" />
+                    <feMergeNode in="mainBlur" />
+                </feMerge>
+            </filter>
+        );
+    }
+
+    if (hasShadow) {
+        return (
+            <filter {...commonProps}>
+                <feDropShadow
+                    dx={data.shadowOffsetX ?? 2}
+                    dy={data.shadowOffsetY ?? 2}
+                    stdDeviation={data.shadowBlur ?? 2}
+                    floodColor={data.shadowColor ?? 'rgba(0,0,0,0.5)'}
+                />
+            </filter>
+        );
+    }
+
+    return (
+        <filter {...commonProps}>
+            <feGaussianBlur stdDeviation={data.blur ?? 0} />
+        </filter>
+    );
+};
+
+const ImagePath: React.FC<{ data: ImageData }> = React.memo(({ data }) => {
+    const [imageSrc, setImageSrc] = useState<string | null>(() => data.src ?? null);
+    const latestDataRef = useRef(data);
+    latestDataRef.current = data;
+
+    const identity = data.fileId ?? data.src ?? data.id;
 
     useEffect(() => {
-        let cancelled = false;
-        if (data.tool !== 'image') {
+        if (!identity) {
             setImageSrc(null);
+            return;
+        }
+
+        let cancelled = false;
+        const current = latestDataRef.current;
+
+        if (current.src && current.src.startsWith('data:')) {
+            setImageSrc(current.src);
             return () => {
                 cancelled = true;
             };
         }
+
         setImageSrc(null);
-        void getImageDataUrl(data as ImageData)
+        void getImageDataUrl(current)
             .then((src) => {
                 if (!cancelled) setImageSrc(src);
             })
-            .catch((err) => console.error('Failed to resolve image for rendering', err));
+            .catch((err) => {
+                console.error('Failed to resolve image for rendering', err);
+            });
+
         return () => {
             cancelled = true;
         };
-    }, [data]);
+    }, [identity]);
+
+    useEffect(() => {
+        if (data.src && data.src.startsWith('data:')) {
+            setImageSrc(data.src);
+        }
+    }, [data.src]);
+
+    if (!imageSrc) {
+        return <g className="pointer-events-none" />;
+    }
+
+    const matrix = getShapeTransformMatrix(data);
+    const transform = isIdentityMatrix(matrix) ? undefined : matrixToString(matrix);
+    const opacity = data.opacity !== undefined && data.opacity < 1 ? data.opacity : undefined;
+    const clipPathId = data.borderRadius && data.borderRadius > 0 ? `clip-${data.id}` : undefined;
+    const hasBlur = (data.blur ?? 0) > 0;
+    const hasShadow = data.shadowEnabled === true;
+    const filterId = hasBlur || hasShadow ? `effects-${data.id}` : undefined;
+
+    const defsChildren: React.ReactNode[] = [];
+    if (clipPathId) {
+        defsChildren.push(
+            <clipPath id={clipPathId} key="clip">
+                <rect
+                    x={data.x}
+                    y={data.y}
+                    width={data.width}
+                    height={data.height}
+                    rx={data.borderRadius}
+                    ry={data.borderRadius}
+                />
+            </clipPath>
+        );
+    }
+
+    if (filterId) {
+        defsChildren.push(<EffectsFilter id={filterId} data={data} key="filter" />);
+    }
+
+    const imageProps: React.SVGProps<SVGImageElement> = {
+        href: imageSrc,
+        x: data.x,
+        y: data.y,
+        width: data.width,
+        height: data.height,
+        preserveAspectRatio: 'none',
+    };
+
+    if (clipPathId) {
+        imageProps.clipPath = `url(#${clipPathId})`;
+    }
+
+    if (filterId) {
+        imageProps.filter = `url(#${filterId})`;
+    }
+
+    (imageProps as any).xlinkHref = imageSrc;
+
+    return (
+        <g className="pointer-events-none">
+            <g transform={transform} opacity={opacity}>
+                {defsChildren.length > 0 && <defs>{defsChildren}</defs>}
+                <image {...imageProps} />
+            </g>
+        </g>
+    );
+});
+
+const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.memo(({ rc, data }) => {
+    if (data.tool === 'image') {
+        return <ImagePath data={data as ImageData} />;
+    }
 
     // 如果路径是常规（非遮罩）组，则递归渲染其子项以获得性能优势。
     if (data.tool === 'group' && !(data as GroupData).mask) {
@@ -69,16 +208,10 @@ const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.m
     // 遮罩组需要作为一个整体进行渲染，以正确生成 <clipPath> 和相关结构。
     const nodeString = useMemo(() => {
         if (!rc) return '';
-        if (data.tool === 'image') {
-            if (!imageSrc) return '';
-            const prepared = { ...(data as ImageData), src: imageSrc };
-            const node = renderPathNode(rc, prepared);
-            return node ? node.outerHTML : '';
-        }
         const node = renderPathNode(rc, data);
         // 使用 outerHTML 确保整个节点都被正确序列化。
         return node ? node.outerHTML : '';
-    }, [rc, data, imageSrc]);
+    }, [rc, data]);
 
     // 使用 dangerouslySetInnerHTML 来渲染预先计算好的 SVG 字符串。
     return <g className="pointer-events-none" dangerouslySetInnerHTML={{ __html: nodeString }} />;
@@ -89,38 +222,15 @@ const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.m
  * This is optimized for live previews where we don't need group recursion or frame logic.
  */
 export const RoughPath: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.memo(({ rc, data }) => {
-    const [imageSrc, setImageSrc] = useState<string | null>(null);
-
-    useEffect(() => {
-        let cancelled = false;
-        if (data.tool !== 'image') {
-            setImageSrc(null);
-            return () => {
-                cancelled = true;
-            };
-        }
-        setImageSrc(null);
-        void getImageDataUrl(data as ImageData)
-            .then((src) => {
-                if (!cancelled) setImageSrc(src);
-            })
-            .catch((err) => console.error('Failed to resolve image for rough path', err));
-        return () => {
-            cancelled = true;
-        };
-    }, [data]);
+    if (data.tool === 'image') {
+        return <ImagePath data={data as ImageData} />;
+    }
 
     const nodeString = useMemo(() => {
         if (!rc || data.tool === 'group') return '';
-        if (data.tool === 'image') {
-            if (!imageSrc) return '';
-            const prepared = { ...(data as ImageData), src: imageSrc };
-            const node = renderPathNode(rc, prepared);
-            return node ? node.outerHTML : '';
-        }
         const node = renderPathNode(rc, data);
         return node ? node.outerHTML : '';
-    }, [rc, data, imageSrc]);
+    }, [rc, data]);
 
     // Use dangerouslySetInnerHTML to render the pre-computed SVG string.
     return <g className="pointer-events-none" dangerouslySetInnerHTML={{ __html: nodeString }} />;


### PR DESCRIPTION
## Summary
- render image paths with a dedicated React component so image data URLs remain stable during transforms
- recreate the SVG filter/clip-path structure in JSX to keep blur and rounded corner support without innerHTML churn
- reuse the new renderer from RoughPath to remove duplicate image-loading logic

## Testing
- `npm run build` *(fails: existing duplicate declaration error in src/lib/hit-testing.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1ff3eafc8323a3b33d173746be59