### PR TITLE
feat: add selection dimension label overlay

### DIFF
--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -485,6 +485,200 @@ const GradientHandles: React.FC<{ path: AnyPath; scale: number }> = React.memo((
   );
 });
 
+const LABEL_FONT_SIZE = 12;
+const LABEL_FONT_WEIGHT = 600;
+const LABEL_FONT_FAMILY = 'Inter, system-ui, sans-serif';
+const LABEL_FONT = `${LABEL_FONT_WEIGHT} ${LABEL_FONT_SIZE}px ${LABEL_FONT_FAMILY}`;
+const LABEL_PADDING_X = 10;
+const LABEL_PADDING_Y = 4;
+const LABEL_OFFSET_PX = 12;
+
+type DimensionGuide = {
+  text: string;
+  anchor: Point;
+  normal: Point;
+  angle: number;
+};
+
+const measureTextWidth = (() => {
+  let canvas: HTMLCanvasElement | null = null;
+  let context: CanvasRenderingContext2D | null = null;
+  return (text: string, font: string) => {
+    if (typeof document === 'undefined') {
+      return text.length * 7;
+    }
+    if (!canvas) {
+      canvas = document.createElement('canvas');
+      context = canvas.getContext('2d');
+    }
+    if (!context) {
+      return text.length * 7;
+    }
+    context.font = font;
+    return context.measureText(text).width;
+  };
+})();
+
+const formatDimensionValue = (value: number) => {
+  if (!isFinite(value)) {
+    return '0';
+  }
+  const absolute = Math.abs(value);
+  const rounded = Math.round(absolute * 100) / 100;
+  if (rounded < 0.01) {
+    return '0';
+  }
+  const fixed = rounded.toFixed(2);
+  return fixed.replace(/\.00$/, '').replace(/(\.\d*[1-9])0$/, '$1');
+};
+
+const createDimensionGuide = (width: number, height: number, anchor: Point, normal: Point, angle: number): DimensionGuide => ({
+  text: `${formatDimensionValue(Math.max(0, width))} × ${formatDimensionValue(Math.max(0, height))}`,
+  anchor,
+  normal,
+  angle,
+});
+
+const averageNonZero = (values: number[]) => {
+  const positives = values.map(Math.abs).filter(v => v > 0.0001);
+  if (positives.length === 0) {
+    return 0;
+  }
+  const sum = positives.reduce((acc, curr) => acc + curr, 0);
+  return sum / positives.length;
+};
+
+const getGuideForTransformableShape = (
+  path: RectangleData | EllipseData | ImageData | PolygonData | TextData | FrameData,
+): DimensionGuide => {
+  const { x, y, width, height } = path;
+  const matrix = getShapeTransformMatrix(path);
+  const corners = [
+    { x, y },
+    { x: x + width, y },
+    { x: x + width, y: y + height },
+    { x, y: y + height },
+  ].map(point => applyMatrixToPoint(matrix, point));
+
+  const [topLeft, topRight, bottomRight, bottomLeft] = corners;
+
+  const topEdgeVec = { x: topRight.x - topLeft.x, y: topRight.y - topLeft.y };
+  const bottomEdgeVec = { x: bottomRight.x - bottomLeft.x, y: bottomRight.y - bottomLeft.y };
+  const leftEdgeVec = { x: bottomLeft.x - topLeft.x, y: bottomLeft.y - topLeft.y };
+  const rightEdgeVec = { x: bottomRight.x - topRight.x, y: bottomRight.y - topRight.y };
+
+  const widthValue = averageNonZero([
+    Math.hypot(topEdgeVec.x, topEdgeVec.y),
+    Math.hypot(bottomEdgeVec.x, bottomEdgeVec.y),
+  ]);
+
+  const heightValue = averageNonZero([
+    Math.hypot(leftEdgeVec.x, leftEdgeVec.y),
+    Math.hypot(rightEdgeVec.x, rightEdgeVec.y),
+  ]);
+
+  const edgeForOrientation = Math.hypot(bottomEdgeVec.x, bottomEdgeVec.y) > 0.0001 ? bottomEdgeVec : topEdgeVec;
+  const edgeLength = Math.hypot(edgeForOrientation.x, edgeForOrientation.y);
+  const angle = edgeLength > 0.0001 ? Math.atan2(edgeForOrientation.y, edgeForOrientation.x) : 0;
+  const normal = edgeLength > 0.0001
+    ? { x: -edgeForOrientation.y / edgeLength, y: edgeForOrientation.x / edgeLength }
+    : { x: 0, y: 1 };
+
+  const anchor = {
+    x: (bottomLeft.x + bottomRight.x) / 2,
+    y: (bottomLeft.y + bottomRight.y) / 2,
+  };
+
+  return createDimensionGuide(widthValue, heightValue, anchor, normal, angle);
+};
+
+const getGuideFromBBox = (bbox: BBox | null): DimensionGuide | null => {
+  if (!bbox) {
+    return null;
+  }
+  const anchor = { x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height };
+  const normal = { x: 0, y: 1 };
+  return createDimensionGuide(bbox.width, bbox.height, anchor, normal, 0);
+};
+
+const getGuideForPath = (path: AnyPath): DimensionGuide | null => {
+  switch (path.tool) {
+    case 'rectangle':
+    case 'ellipse':
+    case 'image':
+    case 'polygon':
+    case 'text':
+    case 'frame':
+      return getGuideForTransformableShape(path);
+    default:
+      return getGuideFromBBox(getPathBoundingBox(path, false));
+  }
+};
+
+const getDimensionGuide = (paths: AnyPath[]): DimensionGuide | null => {
+  if (!paths || paths.length === 0) {
+    return null;
+  }
+  if (paths.length === 1) {
+    return getGuideForPath(paths[0]);
+  }
+  return getGuideFromBBox(getPathsBoundingBox(paths, false));
+};
+
+const DimensionLabel: React.FC<{ guide: DimensionGuide; scale: number }> = React.memo(({ guide, scale }) => {
+  const textWidth = React.useMemo(() => measureTextWidth(guide.text, LABEL_FONT), [guide.text]);
+  const labelWidth = textWidth + LABEL_PADDING_X * 2;
+  const labelHeight = LABEL_FONT_SIZE + LABEL_PADDING_Y * 2;
+  const safeScale = Math.max(scale, 0.0001);
+
+  const normalLength = Math.hypot(guide.normal.x, guide.normal.y);
+  let normal = normalLength > 0.0001
+    ? { x: guide.normal.x / normalLength, y: guide.normal.y / normalLength }
+    : { x: 0, y: 1 };
+
+  let rotationRad = guide.angle;
+  if (Math.abs(rotationRad) > Math.PI / 2) {
+    rotationRad = rotationRad > 0 ? rotationRad - Math.PI : rotationRad + Math.PI;
+    normal = { x: -normal.x, y: -normal.y };
+  }
+
+  const offsetWorld = (LABEL_OFFSET_PX + labelHeight / 2) / safeScale;
+  const anchorX = guide.anchor.x + normal.x * offsetWorld;
+  const anchorY = guide.anchor.y + normal.y * offsetWorld;
+  const rotationDeg = (rotationRad * 180) / Math.PI;
+
+  return (
+    <g
+      transform={`translate(${anchorX} ${anchorY}) rotate(${rotationDeg}) scale(${1 / safeScale})`}
+      className="pointer-events-none select-none"
+    >
+      <rect
+        x={-labelWidth / 2}
+        y={-labelHeight / 2}
+        width={labelWidth}
+        height={labelHeight}
+        rx={labelHeight / 2}
+        ry={labelHeight / 2}
+        fill="var(--accent-primary)"
+        stroke="var(--text-primary)"
+        strokeOpacity={0.25}
+      />
+      <text
+        x={0}
+        y={0}
+        textAnchor="middle"
+        dominantBaseline="central"
+        fontSize={LABEL_FONT_SIZE}
+        fontFamily={LABEL_FONT_FAMILY}
+        fontWeight={LABEL_FONT_WEIGHT}
+        fill="var(--text-on-accent-solid)"
+      >
+        {guide.text}
+      </text>
+    </g>
+  );
+});
+
 const MultiSelectionControls: React.FC<{ paths: AnyPath[], scale: number }> = React.memo(({ paths, scale }) => {
     const bbox = getPathsBoundingBox(paths, false);
     if (!bbox) return null;
@@ -590,6 +784,11 @@ export const ControlsRenderer: React.FC<ControlsRendererProps> = React.memo(({
 
   // Move/transform mode logic
   if (selectionMode === 'move') {
+    const dimensionGuide = getDimensionGuide(selectedPaths);
+    const dimensionLabel = dimensionGuide ? (
+      <DimensionLabel guide={dimensionGuide} scale={scale} />
+    ) : null;
+
     if (selectedPaths.length === 1) {
         const selectedPath = selectedPaths[0];
         const gradientHandles = selectedPath.fillGradient ? (
@@ -607,6 +806,7 @@ export const ControlsRenderer: React.FC<ControlsRendererProps> = React.memo(({
                         allowSkew={true}
                     />
                     {gradientHandles}
+                    {dimensionLabel}
                 </>
             );
         }
@@ -615,10 +815,16 @@ export const ControlsRenderer: React.FC<ControlsRendererProps> = React.memo(({
             <>
                 <MultiSelectionControls paths={selectedPaths} scale={scale} />
                 {gradientHandles}
+                {dimensionLabel}
             </>
         );
     }
-    return <MultiSelectionControls paths={selectedPaths} scale={scale} />;
+    return (
+      <>
+        <MultiSelectionControls paths={selectedPaths} scale={scale} />
+        {dimensionLabel}
+      </>
+    );
   }
 
   return null;


### PR DESCRIPTION
## Summary
- add a dimension label helper that measures shapes and builds a rotated badge based on selection data
- format width × height strings and render a pill that keeps a constant screen size regardless of zoom
- show the badge for single and multi-selection move mode so it follows the target during transforms

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0af4c97a08323ab565f1566717c68