### PR TITLE
fix(color): sample background with alt shift

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -8,6 +8,7 @@ import { HSLA, parseColor, hslaToHslaString, hslaToHex } from '../lib/color';
 import { ICONS } from '../constants';
 import PanelButton from '@/components/PanelButton';
 import { PANEL_CLASSES } from './panelStyles';
+import { isEyeDropperSupported, openEyeDropper } from '@/lib/eyeDropper';
 
 // 预设颜色数组
 const PRESET_COLORS = [
@@ -128,16 +129,22 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, onInt
    * 使用浏览器的 EyeDropper API 从屏幕取色。
    */
   const handleEyeDropper = async () => {
-    if (!('EyeDropper' in window)) {
-        alert("Your browser does not support the EyeDropper API.");
-        return;
+    if (!isEyeDropperSupported()) {
+      alert('Your browser does not support the EyeDropper API.');
+      return;
     }
+
     try {
-        const eyeDropper = new (window as any).EyeDropper();
-        const result = await eyeDropper.open();
-        onChange(result.sRGBHex);
-    } catch (e) {
-      // 用户取消了取色器
+      const pickedColor = await openEyeDropper();
+      if (pickedColor) {
+        const sampled = parseColor(pickedColor);
+        const finalHsla = { ...sampled, a: hsla.a };
+        setHsla(finalHsla);
+        setHexInput(hslaToHex(finalHsla));
+        onChange(hslaToHslaString(finalHsla));
+      }
+    } catch (error) {
+      console.error('EyeDropper failed to open', error);
     }
   };
   
@@ -215,7 +222,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, onInt
                <span className={PANEL_CLASSES.inputSuffix}>%</span>
            </div>
            
-            {'EyeDropper' in window && (
+            {isEyeDropperSupported() && (
                 <PanelButton
                     variant="unstyled"
                     onClick={handleEyeDropper}

--- a/src/lib/eyeDropper.ts
+++ b/src/lib/eyeDropper.ts
@@ -1,0 +1,55 @@
+/**
+ * Provides a thin wrapper around the browser EyeDropper API so multiple callers
+ * can share the same capability checks and cancellation handling.
+ */
+
+interface EyeDropperResult {
+  sRGBHex: string;
+}
+
+interface EyeDropperOpenOptions {
+  signal?: AbortSignal;
+}
+
+interface EyeDropper {
+  open: (options?: EyeDropperOpenOptions) => Promise<EyeDropperResult>;
+}
+
+interface EyeDropperConstructor {
+  new (): EyeDropper;
+}
+
+interface EyeDropperWindow extends Window {
+  EyeDropper?: EyeDropperConstructor;
+}
+
+/**
+ * Determines whether the current runtime supports the EyeDropper API.
+ */
+export const isEyeDropperSupported = (): boolean =>
+  typeof window !== 'undefined' && Boolean((window as EyeDropperWindow).EyeDropper);
+
+/**
+ * Opens the EyeDropper and resolves with the picked color.
+ *
+ * Returns `null` when the API is unsupported or the user cancels the picker.
+ * Any other thrown errors are propagated to the caller so they can handle them.
+ */
+export const openEyeDropper = async ({
+  signal,
+}: EyeDropperOpenOptions = {}): Promise<string | null> => {
+  if (!isEyeDropperSupported()) {
+    return null;
+  }
+
+  try {
+    const eyeDropper = new (window as EyeDropperWindow).EyeDropper!();
+    const result = await eyeDropper.open(signal ? { signal } : undefined);
+    return result.sRGBHex;
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      return null;
+    }
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- generalize sampling helpers so the EyeDropper and cached image reads can target either the foreground color or the canvas background
- track Alt/Shift state globally so holding Shift+Alt applies the sampled color to the background while the existing Alt flow continues to set the stroke color
- reuse the new foreground sampler for pointer Alt-clicks so behavior stays consistent across interaction paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce677a1434832387e82afc1931d35d