### PR TITLE
feat(selection): lock movement axis with shift

### DIFF
--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -54,6 +54,7 @@ const handlePointerDownForMove = (
               originalPaths: selectedPaths,
               initialPointerPos: point,
               initialSelectionBbox: selectionGeometricBbox,
+              axisLock: null,
           });
       }
     };

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -148,7 +148,7 @@ export const useSelection = ({
     }
 
     handlePointerMoveLogic({
-      e, movePoint, dragState, marquee, setMarquee, lassoPath, setLassoPath,
+      e, movePoint, dragState, setDragState, marquee, setMarquee, lassoPath, setLassoPath,
       pathState, toolbarState, viewTransform,
       setIsHoveringMovable, setIsHoveringEditable, isClosingPath, snapToGrid,
       setCurrentCropRect,

--- a/src/types.ts
+++ b/src/types.ts
@@ -333,6 +333,7 @@ type MoveDragState = {
   originalPaths: AnyPath[];
   initialPointerPos: Point;
   initialSelectionBbox: BBox;
+  axisLock: 'x' | 'y' | null;
 };
 
 // A drag state for resizing a single shape

--- a/tests/hooks/selection-logic/pointerMove.test.ts
+++ b/tests/hooks/selection-logic/pointerMove.test.ts
@@ -1,0 +1,188 @@
+// handlePointerMoveLogic 轴向锁定行为测试
+import type { MutableRefObject, Dispatch, SetStateAction, PointerEvent as ReactPointerEvent } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { handlePointerMoveLogic } from '@/hooks/selection-logic/pointerMove';
+import * as DrawingLib from '@/lib/drawing';
+import type {
+  AnyPath,
+  DragState,
+  RectangleData,
+  SelectionPathState,
+  SelectionToolbarState,
+  SelectionViewTransform,
+} from '@/types';
+
+const createRectangle = (): RectangleData => ({
+  id: 'rect-1',
+  tool: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 120,
+  height: 80,
+  rotation: 0,
+  color: '#000000',
+  fill: 'transparent',
+  fillStyle: 'hachure',
+  strokeWidth: 2,
+  roughness: 0,
+  bowing: 0,
+  fillWeight: 0,
+  hachureAngle: 0,
+  hachureGap: 0,
+  curveTightness: 0,
+  curveStepCount: 0,
+});
+
+const createPathState = (
+  paths: AnyPath[],
+  setPaths: Dispatch<SetStateAction<AnyPath[]>>
+): SelectionPathState => ({
+  paths,
+  setPaths,
+  selectedPathIds: ['rect-1'],
+  setSelectedPathIds: vi.fn(),
+  beginCoalescing: vi.fn(),
+  endCoalescing: vi.fn(),
+});
+
+const toolbarState: SelectionToolbarState = { selectionMode: 'move' };
+const viewTransform: SelectionViewTransform = {
+  viewTransform: { scale: 1, translateX: 0, translateY: 0 },
+  getPointerPosition: vi.fn(),
+};
+const noop = vi.fn();
+const snapToGrid = (point: { x: number; y: number }) => point;
+const isClosingPath = { current: null } as MutableRefObject<{ pathId: string; anchorIndex: number } | null>;
+
+const createMoveDragState = (paths: AnyPath[]): DragState => ({
+  type: 'move',
+  pathIds: ['rect-1'],
+  originalPaths: paths,
+  initialPointerPos: { x: 0, y: 0 },
+  initialSelectionBbox: { x: 0, y: 0, width: 120, height: 80 },
+  axisLock: null,
+});
+
+describe('handlePointerMoveLogic axis locking', () => {
+  it('locks movement to the dominant axis when Shift is held', () => {
+    let currentPaths: AnyPath[] = [createRectangle()];
+    let latestDragState: DragState = createMoveDragState(currentPaths);
+    let updatedPaths: AnyPath[] | null = null;
+
+    const setPaths: Dispatch<SetStateAction<AnyPath[]>> = updater => {
+      updatedPaths = typeof updater === 'function'
+        ? (updater as (prev: AnyPath[]) => AnyPath[])(currentPaths)
+        : updater;
+      currentPaths = updatedPaths;
+    };
+    const setDragState: Dispatch<SetStateAction<DragState>> = updater => {
+      latestDragState = typeof updater === 'function'
+        ? (updater as (prev: DragState) => DragState)(latestDragState)
+        : updater;
+    };
+
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callback(0);
+      return 1;
+    });
+
+    handlePointerMoveLogic({
+      e: { shiftKey: true } as ReactPointerEvent<SVGSVGElement>,
+      movePoint: { x: 40, y: 12 },
+      dragState: latestDragState,
+      setDragState,
+      marquee: null,
+      setMarquee: noop,
+      lassoPath: null,
+      setLassoPath: noop,
+      pathState: createPathState(currentPaths, setPaths),
+      toolbarState,
+      viewTransform,
+      setIsHoveringMovable: noop,
+      setIsHoveringEditable: noop,
+      isClosingPath,
+      snapToGrid,
+      setCurrentCropRect: noop,
+    });
+
+    rafSpy.mockRestore();
+
+    expect(updatedPaths).not.toBeNull();
+    const movedRect = updatedPaths![0] as RectangleData;
+    expect(movedRect.x).toBe(40);
+    expect(movedRect.y).toBe(0);
+    expect(latestDragState && latestDragState.type === 'move' ? latestDragState.axisLock : null).toBe('x');
+  });
+
+  it('switches axis lock when movement favors the perpendicular direction', () => {
+    let currentPaths: AnyPath[] = [createRectangle()];
+    let latestDragState: DragState = createMoveDragState(currentPaths);
+
+    const setPaths: Dispatch<SetStateAction<AnyPath[]>> = updater => {
+      currentPaths = typeof updater === 'function'
+        ? (updater as (prev: AnyPath[]) => AnyPath[])(currentPaths)
+        : updater;
+    };
+    const setDragState: Dispatch<SetStateAction<DragState>> = updater => {
+      latestDragState = typeof updater === 'function'
+        ? (updater as (prev: DragState) => DragState)(latestDragState)
+        : updater;
+    };
+
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      callback(0);
+      return 1;
+    });
+    const movePathSpy = vi.spyOn(DrawingLib, 'movePath');
+
+    handlePointerMoveLogic({
+      e: { shiftKey: true } as ReactPointerEvent<SVGSVGElement>,
+      movePoint: { x: 50, y: 10 },
+      dragState: latestDragState,
+      setDragState,
+      marquee: null,
+      setMarquee: noop,
+      lassoPath: null,
+      setLassoPath: noop,
+      pathState: createPathState(currentPaths, setPaths),
+      toolbarState,
+      viewTransform,
+      setIsHoveringMovable: noop,
+      setIsHoveringEditable: noop,
+      isClosingPath,
+      snapToGrid,
+      setCurrentCropRect: noop,
+    });
+
+    expect(latestDragState && latestDragState.type === 'move' ? latestDragState.axisLock : null).toBe('x');
+
+    movePathSpy.mockClear();
+
+    handlePointerMoveLogic({
+      e: { shiftKey: true } as ReactPointerEvent<SVGSVGElement>,
+      movePoint: { x: 5, y: 60 },
+      dragState: latestDragState,
+      setDragState,
+      marquee: null,
+      setMarquee: noop,
+      lassoPath: null,
+      setLassoPath: noop,
+      pathState: createPathState(currentPaths, setPaths),
+      toolbarState,
+      viewTransform,
+      setIsHoveringMovable: noop,
+      setIsHoveringEditable: noop,
+      isClosingPath,
+      snapToGrid,
+      setCurrentCropRect: noop,
+    });
+
+    rafSpy.mockRestore();
+    expect(latestDragState && latestDragState.type === 'move' ? latestDragState.axisLock : null).toBe('y');
+    expect(movePathSpy).toHaveBeenCalledTimes(1);
+    const lastCall = movePathSpy.mock.calls[0];
+    expect(lastCall?.[1]).toBe(0);
+    expect(lastCall?.[2]).toBe(60);
+    movePathSpy.mockRestore();
+  });
+});

--- a/tests/hooks/useSelection.test.ts
+++ b/tests/hooks/useSelection.test.ts
@@ -136,6 +136,7 @@ describe('useSelection', () => {
         originalPaths: currentPaths,
         initialPointerPos: { x: 0, y: 0 },
         initialSelectionBbox: { x: 0, y: 0, width: 0, height: 0 },
+        axisLock: null,
       });
     });
 
@@ -217,6 +218,7 @@ describe('useSelection', () => {
         originalPaths: currentPaths,
         initialPointerPos: { x: 0, y: 0 },
         initialSelectionBbox: { x: 0, y: 0, width: 0, height: 0 },
+        axisLock: null,
       });
     });
 

--- a/tests/hooks/useToolbarState.test.ts
+++ b/tests/hooks/useToolbarState.test.ts
@@ -8,6 +8,7 @@ import type { Dispatch, SetStateAction } from 'react';
 
 const drawingColorSetter = vi.fn();
 const drawingFillSetter = vi.fn();
+const drawingFillGradientSetter = vi.fn();
 const drawingFillStyleSetter = vi.fn();
 const drawingStrokeWidthSetter = vi.fn();
 const drawingOpacitySetter = vi.fn();
@@ -43,6 +44,7 @@ const drawingShadowColorSetter = vi.fn();
 vi.mock('@/hooks/toolbar-state/property-hooks', () => ({
   useDrawingColor: () => ({ drawingColor: '#222222', setDrawingColor: drawingColorSetter }),
   useDrawingFill: () => ({ drawingFill: 'transparent', setDrawingFill: drawingFillSetter }),
+  useDrawingFillGradient: () => ({ drawingFillGradient: null, setDrawingFillGradient: drawingFillGradientSetter }),
   useDrawingFillStyle: () => ({ drawingFillStyle: 'hachure', setDrawingFillStyle: drawingFillStyleSetter }),
   useDrawingStrokeWidth: () => ({ drawingStrokeWidth: 0, setDrawingStrokeWidth: drawingStrokeWidthSetter }),
   useDrawingOpacity: () => ({ drawingOpacity: 1, setDrawingOpacity: drawingOpacitySetter }),
@@ -181,6 +183,7 @@ describe('useToolbarState', () => {
   const setterMocks = [
     drawingColorSetter,
     drawingFillSetter,
+    drawingFillGradientSetter,
     drawingFillStyleSetter,
     drawingStrokeWidthSetter,
     drawingOpacitySetter,


### PR DESCRIPTION
## Summary
- lock selection dragging to horizontal or vertical axes when Shift is held and allow switching axes with sufficient directional change
- extend move drag state to track the current axis lock and plumb updates through the selection hook
- adjust toolbar and selection tests and add coverage for the new axis-lock behaviour

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d167977d4c8323b448dfce2ed7a078