### PR TITLE
fix: stabilize layers provider context updates

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -7,7 +7,7 @@ import React, { useCallback, useMemo } from 'react';
 import { useAppContext } from '../context/AppContext';
 import useGlobalEventHandlers from '../hooks/useGlobalEventHandlers';
 import { Whiteboard } from './Whiteboard';
-import { LayersProvider } from '../lib/layers-context';
+import { LayersProvider, type LayersContextValue } from '../lib/layers-context';
 import { ICONS, CONTROL_BUTTON_CLASS } from '../constants';
 import PanelButton from '@/components/PanelButton';
 import type { MaterialData, AnyPath } from '../types';
@@ -68,6 +68,8 @@ export const MainLayout: React.FC = () => {
         handleFinishPenPath,
         handleFinishLinePath,
     } = store;
+
+    const layersValue = useMemo<LayersContextValue>(() => store.activePathState, [store.activePathState]);
 
     const onionSkinPaths = useMemo(() => {
         if (!isOnionSkinEnabled || frames.length <= 1) {
@@ -180,7 +182,7 @@ export const MainLayout: React.FC = () => {
 
     return (
         <div className="h-full w-full max-w-full font-sans bg-transparent flex overflow-hidden">
-            <LayersProvider {...store}>
+            <LayersProvider value={layersValue}>
                 <MainMenuPanel />
 
                 <main className="flex-grow h-full relative flex flex-col min-w-0">

--- a/src/lib/layers-context.tsx
+++ b/src/lib/layers-context.tsx
@@ -3,17 +3,17 @@
  * 通过提供一个全局的 LayersContext，避免了在组件树中深层传递 props 的问题。
  */
 import React, { createContext, useContext, useMemo } from 'react';
-import type { AnyPath } from '../types';
 import { usePaths } from '../hooks/usePaths';
 
 // 从 usePaths hook 的返回类型推断 Context 的状态类型
-type LayersContextState = ReturnType<typeof usePaths>;
+export type LayersContextValue = ReturnType<typeof usePaths>;
 
 // 创建一个具有未定义初始值的 Context
-const LayersContext = createContext<LayersContextState | undefined>(undefined);
+const LayersContext = createContext<LayersContextValue | undefined>(undefined);
 
-interface LayersProviderProps extends LayersContextState {
+interface LayersProviderProps {
   children: React.ReactNode;
+  value?: LayersContextValue;
 }
 
 /**
@@ -21,15 +21,176 @@ interface LayersProviderProps extends LayersContextState {
  * @description 这个组件接收 usePaths hook 返回的所有状态和函数，并通过 Context 提供给其所有子组件。
  * @param props - 包含图层状态、操作函数以及子组件。
  */
-export const LayersProvider: React.FC<LayersProviderProps> = ({ children, ...pathState }) => {
-  // 使用 useMemo 来记忆 context 的值，仅当 pathState 中的任何值发生变化时才重新创建。
-  // 这可以防止不必要的子组件重渲染。
-  const contextValue = useMemo(() => ({
-    ...pathState
-  }), [pathState]);
+export const LayersProvider: React.FC<LayersProviderProps> = ({ children, value }) => {
+  if (value) {
+    const valueRef = React.useRef<LayersContextValue>({ ...value });
+    const snapshotRef = React.useRef<{
+      frames: LayersContextValue['frames'];
+      currentFrameIndex: LayersContextValue['currentFrameIndex'];
+      paths: LayersContextValue['paths'];
+      selectedPathIds: LayersContextValue['selectedPathIds'];
+      currentBrushPath: LayersContextValue['currentBrushPath'];
+      currentPenPath: LayersContextValue['currentPenPath'];
+      currentLinePath: LayersContextValue['currentLinePath'];
+      canUndo: LayersContextValue['canUndo'];
+      canRedo: LayersContextValue['canRedo'];
+    } | null>(null);
+
+    const snapshot = {
+      frames: value.frames,
+      currentFrameIndex: value.currentFrameIndex,
+      paths: value.paths,
+      selectedPathIds: value.selectedPathIds,
+      currentBrushPath: value.currentBrushPath,
+      currentPenPath: value.currentPenPath,
+      currentLinePath: value.currentLinePath,
+      canUndo: value.canUndo,
+      canRedo: value.canRedo,
+    } as const;
+
+    const snapshotChanged =
+      snapshotRef.current === null ||
+      snapshotRef.current.frames !== snapshot.frames ||
+      snapshotRef.current.currentFrameIndex !== snapshot.currentFrameIndex ||
+      snapshotRef.current.paths !== snapshot.paths ||
+      snapshotRef.current.selectedPathIds !== snapshot.selectedPathIds ||
+      snapshotRef.current.currentBrushPath !== snapshot.currentBrushPath ||
+      snapshotRef.current.currentPenPath !== snapshot.currentPenPath ||
+      snapshotRef.current.currentLinePath !== snapshot.currentLinePath ||
+      snapshotRef.current.canUndo !== snapshot.canUndo ||
+      snapshotRef.current.canRedo !== snapshot.canRedo;
+
+    if (snapshotChanged) {
+      snapshotRef.current = snapshot;
+      valueRef.current = { ...value };
+    }
+
+    return (
+      <LayersContext.Provider value={valueRef.current}>
+        {children}
+      </LayersContext.Provider>
+    );
+  }
+
+  const fallbackSource = usePaths();
+
+  const {
+    frames,
+    currentFrameIndex,
+    setCurrentFrameIndex,
+    paths,
+    setPaths,
+    handleLoadFile,
+    handleDeletePaths,
+    togglePathsProperty,
+    toggleGroupCollapse,
+    setPathName,
+    reorderPaths,
+    addFrame,
+    copyFrame,
+    deleteFrame,
+    reorderFrames,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    beginCoalescing,
+    endCoalescing,
+    currentBrushPath,
+    setCurrentBrushPath,
+    currentPenPath,
+    setCurrentPenPath,
+    currentLinePath,
+    setCurrentLinePath,
+    selectedPathIds,
+    setSelectedPathIds,
+    finishBrushPath,
+    handleFinishPenPath,
+    handleCancelPenPath,
+    handleFinishLinePath,
+    handleCancelLinePath,
+    handleReorder,
+    handleDeleteSelected,
+  } = fallbackSource;
+
+  const contextValue = useMemo<LayersContextValue>(() => ({
+    frames,
+    currentFrameIndex,
+    setCurrentFrameIndex,
+    paths,
+    setPaths,
+    handleLoadFile,
+    handleDeletePaths,
+    togglePathsProperty,
+    toggleGroupCollapse,
+    setPathName,
+    reorderPaths,
+    addFrame,
+    copyFrame,
+    deleteFrame,
+    reorderFrames,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    beginCoalescing,
+    endCoalescing,
+    currentBrushPath,
+    setCurrentBrushPath,
+    currentPenPath,
+    setCurrentPenPath,
+    currentLinePath,
+    setCurrentLinePath,
+    selectedPathIds,
+    setSelectedPathIds,
+    finishBrushPath,
+    handleFinishPenPath,
+    handleCancelPenPath,
+    handleFinishLinePath,
+    handleCancelLinePath,
+    handleReorder,
+    handleDeleteSelected,
+  }), [
+    frames,
+    currentFrameIndex,
+    setCurrentFrameIndex,
+    paths,
+    setPaths,
+    handleLoadFile,
+    handleDeletePaths,
+    togglePathsProperty,
+    toggleGroupCollapse,
+    setPathName,
+    reorderPaths,
+    addFrame,
+    copyFrame,
+    deleteFrame,
+    reorderFrames,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    beginCoalescing,
+    endCoalescing,
+    currentBrushPath,
+    setCurrentBrushPath,
+    currentPenPath,
+    setCurrentPenPath,
+    currentLinePath,
+    setCurrentLinePath,
+    selectedPathIds,
+    setSelectedPathIds,
+    finishBrushPath,
+    handleFinishPenPath,
+    handleCancelPenPath,
+    handleFinishLinePath,
+    handleCancelLinePath,
+    handleReorder,
+    handleDeleteSelected,
+  ]);
 
   return (
-    <LayersContext.Provider value={contextValue as LayersContextState}>
+    <LayersContext.Provider value={contextValue}>
       {children}
     </LayersContext.Provider>
   );
@@ -42,7 +203,7 @@ export const LayersProvider: React.FC<LayersProviderProps> = ({ children, ...pat
  * @throws 如果在 LayersProvider 外部使用，将抛出错误。
  * @returns 返回 LayersContext 的值。
  */
-export const useLayers = (): LayersContextState => {
+export const useLayers = (): LayersContextValue => {
   const context = useContext(LayersContext);
   if (context === undefined) {
     throw new Error('useLayers must be used within a LayersProvider');

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -27,3 +27,19 @@ Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
   }),
 });
 
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: () => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addListener: () => undefined,
+      removeListener: () => undefined,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => false,
+    }),
+  });
+}
+

--- a/tests/lib/layers-context.test.tsx
+++ b/tests/lib/layers-context.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * 验证 LayersProvider 在非路径状态更新时不会触发使用 useLayers 的组件重新渲染。
+ */
+import React, { useMemo } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppProvider, useAppContext } from '@/context/AppContext';
+import { LayersProvider, useLayers, type LayersContextValue } from '@/lib/layers-context';
+
+describe('layers-context', () => {
+  it('keeps useLayers consumers stable when toggling non-path UI state', async () => {
+    const observedValues: LayersContextValue[] = [];
+
+    const TestConsumer = React.memo(() => {
+      const value = useLayers();
+      observedValues.push(value);
+      return null;
+    });
+
+    const Harness: React.FC = () => {
+      const store = useAppContext();
+      const layersValue = useMemo<LayersContextValue>(() => ({
+        frames: store.frames,
+        currentFrameIndex: store.currentFrameIndex,
+        setCurrentFrameIndex: store.setCurrentFrameIndex,
+        paths: store.paths,
+        setPaths: store.setPaths,
+        handleLoadFile: store.handleLoadFile,
+        handleDeletePaths: store.handleDeletePaths,
+        togglePathsProperty: store.togglePathsProperty,
+        toggleGroupCollapse: store.toggleGroupCollapse,
+        setPathName: store.setPathName,
+        reorderPaths: store.reorderPaths,
+        addFrame: store.addFrame,
+        copyFrame: store.copyFrame,
+        deleteFrame: store.deleteFrame,
+        reorderFrames: store.reorderFrames,
+        undo: store.undo,
+        redo: store.redo,
+        canUndo: store.canUndo,
+        canRedo: store.canRedo,
+        beginCoalescing: store.beginCoalescing,
+        endCoalescing: store.endCoalescing,
+        currentBrushPath: store.currentBrushPath,
+        setCurrentBrushPath: store.setCurrentBrushPath,
+        currentPenPath: store.currentPenPath,
+        setCurrentPenPath: store.setCurrentPenPath,
+        currentLinePath: store.currentLinePath,
+        setCurrentLinePath: store.setCurrentLinePath,
+        selectedPathIds: store.selectedPathIds,
+        setSelectedPathIds: store.setSelectedPathIds,
+        finishBrushPath: store.finishBrushPath,
+        handleFinishPenPath: store.handleFinishPenPath,
+        handleCancelPenPath: store.handleCancelPenPath,
+        handleFinishLinePath: store.handleFinishLinePath,
+        handleCancelLinePath: store.handleCancelLinePath,
+        handleReorder: store.handleReorder,
+        handleDeleteSelected: store.handleDeleteSelected,
+      }), [
+        store.frames,
+        store.currentFrameIndex,
+        store.setCurrentFrameIndex,
+        store.paths,
+        store.setPaths,
+        store.handleLoadFile,
+        store.handleDeletePaths,
+        store.togglePathsProperty,
+        store.toggleGroupCollapse,
+        store.setPathName,
+        store.reorderPaths,
+        store.addFrame,
+        store.copyFrame,
+        store.deleteFrame,
+        store.reorderFrames,
+        store.undo,
+        store.redo,
+        store.canUndo,
+        store.canRedo,
+        store.beginCoalescing,
+        store.endCoalescing,
+        store.currentBrushPath,
+        store.setCurrentBrushPath,
+        store.currentPenPath,
+        store.setCurrentPenPath,
+        store.currentLinePath,
+        store.setCurrentLinePath,
+        store.selectedPathIds,
+        store.setSelectedPathIds,
+        store.finishBrushPath,
+        store.handleFinishPenPath,
+        store.handleCancelPenPath,
+        store.handleFinishLinePath,
+        store.handleCancelLinePath,
+        store.handleReorder,
+        store.handleDeleteSelected,
+      ]);
+
+      return (
+        <LayersProvider value={layersValue}>
+          <TestConsumer />
+          <button
+            type="button"
+            data-testid="toggle-menu"
+            onClick={() => store.setIsMainMenuCollapsed(prev => !prev)}
+          >
+            Toggle menu
+          </button>
+        </LayersProvider>
+      );
+    };
+
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn(() => ({
+          matches: false,
+          media: '',
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+
+    const user = userEvent.setup();
+
+    render(
+      <AppProvider>
+        <Harness />
+      </AppProvider>
+    );
+
+    await waitFor(() => expect(observedValues.length).toBeGreaterThan(0));
+    const initialLength = observedValues.length;
+    const initialDistinct = new Set(observedValues).size;
+
+    const toggleButton = await screen.findByTestId('toggle-menu');
+    await user.click(toggleButton);
+    await user.click(toggleButton);
+
+    await waitFor(() => expect(observedValues.length).toBeGreaterThanOrEqual(initialLength));
+
+    const baseline = observedValues[initialLength - 1];
+    const latest = observedValues[observedValues.length - 1];
+    expect(latest).toBe(baseline);
+    expect(new Set(observedValues).size).toBe(initialDistinct);
+  });
+});


### PR DESCRIPTION
## Summary
- derive the active path state in `MainLayout` and pass it to `LayersProvider` through the `value` prop so context consumers reuse the same data when UI-only state changes
- teach `LayersProvider` to cache provided values via a snapshot check and add a `matchMedia` stub plus a regression test that toggling the main menu leaves `useLayers` consumers untouched

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d35c4fb20c832384977543d4271783