### PR TITLE
fix: ensure manual crop selections include edges

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -76,7 +76,9 @@ const mapWorldPointToImagePixel = (
       return 0;
     }
     if (value >= 1) {
-      return size - 1;
+      // When clamping points we allow coordinates to reach the canvas edge so the
+      // generated mask covers the outermost pixel instead of leaving a 1px gap.
+      return clampToBounds ? size : size - 1;
     }
     return Math.floor(value * size);
   };


### PR DESCRIPTION
## Summary
- allow clamped manual selection points to reach the canvas edge so masks cover the outermost pixels
- document the rationale inline to prevent regressions that leave a 1px border

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3888b1c0c8323a2ce79cf0a51cd25