### PR TITLE
fix: enhance remove background selection visibility

### DIFF
--- a/src/hooks/actions/useObjectActions.ts
+++ b/src/hooks/actions/useObjectActions.ts
@@ -317,9 +317,12 @@ export const useObjectActions = ({
         rect.setAttribute('y', String(sy));
         rect.setAttribute('width', String(sw));
         rect.setAttribute('height', String(sh));
-        rect.setAttribute('fill', 'none');
-        rect.setAttribute('stroke-width', '1');
-        rect.setAttribute('class', 'marching-ants');
+        rect.setAttribute('fill', 'var(--accent-primary)');
+        rect.setAttribute('fill-opacity', '0.12');
+        rect.setAttribute('stroke', 'var(--accent-primary)');
+        rect.setAttribute('stroke-opacity', '0.95');
+        rect.setAttribute('stroke-width', '1.5');
+        rect.setAttribute('class', 'marching-ants selection-highlight');
         rect.setAttribute('vector-effect', 'non-scaling-stroke');
         rect.setAttribute('pointer-events', 'none');
         svg.appendChild(rect);

--- a/src/index.css
+++ b/src/index.css
@@ -272,9 +272,16 @@ input[type='range'].themed-slider::-moz-range-thumb {
 }
 
 .marching-ants {
-  stroke: var(--text-primary);
-  stroke-dasharray: 4 2;
+  stroke: var(--accent-primary);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 3;
+  stroke-linecap: round;
   animation: marching-ants 0.5s linear infinite;
+}
+
+.selection-highlight {
+  fill: var(--accent-primary);
+  fill-opacity: 0.12;
 }
 
 .magic-wand-ants {


### PR DESCRIPTION
## Summary
- tint the remove-background preview overlay and strengthen its marching-ants outline
- update the shared marching-ants styling to use accent coloring with a thicker dash pattern for clarity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d39e16e27c83239e94c0eb0bb63cb4