### PR TITLE
fix: avoid global re-render from pointer tracking

### DIFF
--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -40,7 +40,7 @@ const useGlobalEventHandlers = () => {
     handleCut, handleCopy, handleCopyAsPng, handlePaste, handleImportClick, handleFileImport, handleSaveFile,
     handleBringForward, handleSendBackward, handleBringToFront, handleSendToBack,
     handleGroup, handleUngroup,
-    getPointerPosition, viewTransform: vt, lastPointerPosition,
+    getPointerPosition, viewTransform: vt,
     groupIsolationPath, handleExitGroup, activePathState,
     croppingState, currentCropRect, setCurrentCropRect, pushCropHistory,
     cancelCrop,
@@ -128,7 +128,8 @@ const useGlobalEventHandlers = () => {
 
     const pivot = { x: bbox.x + bbox.width / 2, y: bbox.y + bbox.height / 2 };
     const fallbackRadius = Math.max(bbox.width, bbox.height, 1);
-    const initialPointer = lastPointerPosition ?? { x: pivot.x + fallbackRadius, y: pivot.y };
+    const pointerFromStore = vt.getLastPointerPosition?.();
+    const initialPointer = pointerFromStore ?? { x: pivot.x + fallbackRadius, y: pivot.y };
     let initialDistance = Math.hypot(initialPointer.x - pivot.x, initialPointer.y - pivot.y);
     if (!Number.isFinite(initialDistance) || initialDistance < 1e-6) {
       initialDistance = 1;
@@ -309,7 +310,6 @@ const useGlobalEventHandlers = () => {
     croppingState,
     selectedPathIds,
     activePaths,
-    lastPointerPosition,
     getPointerPosition,
     setActivePaths,
     finishKeyboardScale,
@@ -764,8 +764,9 @@ const useGlobalEventHandlers = () => {
                     const cached = await getCachedImage({ fileId: metadata.id });
 
                     let pasteAt: Point;
-                    if (lastPointerPosition) {
-                      pasteAt = lastPointerPosition;
+                    const pointer = vt.getLastPointerPosition?.();
+                    if (pointer) {
+                      pasteAt = pointer;
                     } else {
                       const svg = document.querySelector('svg');
                       if (!svg) return;
@@ -814,8 +815,9 @@ const useGlobalEventHandlers = () => {
                     event.preventDefault();
                     item.getAsString((str) => {
                         let pasteAt: Point | undefined;
-                        if (lastPointerPosition) {
-                            pasteAt = lastPointerPosition;
+                        const pointer = vt.getLastPointerPosition?.();
+                        if (pointer) {
+                            pasteAt = pointer;
                         } else {
                             const svg = document.querySelector('svg');
                             if (svg) {
@@ -843,8 +845,9 @@ const useGlobalEventHandlers = () => {
              if (!clipboardText) return;
 
              // Paste to the last known mouse position, or fallback to viewport center
-             if (lastPointerPosition) {
-                 void handlePaste({ pasteAt: lastPointerPosition, clipboardText });
+             const pointer = vt.getLastPointerPosition?.();
+             if (pointer) {
+                 void handlePaste({ pasteAt: pointer, clipboardText });
              } else {
                  const svg = document.querySelector('svg');
                  if (svg) {
@@ -864,7 +867,7 @@ const useGlobalEventHandlers = () => {
     return () => {
         document.removeEventListener('paste', handleGlobalPaste);
     };
-  }, [handlePaste, getPointerPosition, setActivePaths, setSelectedPathIds, setTool, vt.scale, lastPointerPosition]);
+  }, [handlePaste, getPointerPosition, setActivePaths, setSelectedPathIds, setTool, vt.scale, vt.getLastPointerPosition]);
 };
 
 export default useGlobalEventHandlers;

--- a/src/hooks/useViewTransform.ts
+++ b/src/hooks/useViewTransform.ts
@@ -19,8 +19,8 @@ export const useViewTransform = () => {
   const handleTouchEnd = useViewTransformStore(s => s.handleTouchEnd);
   const isPinching = useViewTransformStore(s => s.isPinching);
   const getPointerPosition = useViewTransformStore(s => s.getPointerPosition);
-  const lastPointerPosition = useViewTransformStore(s => s.lastPointerPosition);
   const setLastPointerPosition = useViewTransformStore(s => s.setLastPointerPosition);
+  const getLastPointerPosition = React.useCallback(() => useViewTransformStore.getState().lastPointerPosition, []);
 
   return React.useMemo(
     () => ({
@@ -34,8 +34,8 @@ export const useViewTransform = () => {
       handleTouchEnd,
       isPinching,
       getPointerPosition,
-      lastPointerPosition,
       setLastPointerPosition,
+      getLastPointerPosition,
     }),
     [
       viewTransform,
@@ -48,8 +48,8 @@ export const useViewTransform = () => {
       handleTouchEnd,
       isPinching,
       getPointerPosition,
-      lastPointerPosition,
       setLastPointerPosition,
+      getLastPointerPosition,
     ]
   );
 };


### PR DESCRIPTION
## Summary
- expose a stable `getLastPointerPosition` helper from `useViewTransform` instead of returning the live pointer value
- switch global event handlers to read the last pointer position on demand so pointer moves no longer thrash the app context

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d49d83525883238e7b202f8d525249