### PR TITLE
fix: improve magic wand selection visibility

### DIFF
--- a/src/components/whiteboard/MagicWandOverlay.tsx
+++ b/src/components/whiteboard/MagicWandOverlay.tsx
@@ -50,6 +50,7 @@ export const MagicWandOverlay: React.FC<MagicWandOverlayProps> = ({ contours, dr
   const hasDraft = Boolean(draft && draft.points.length > 0);
   if (!contours.length && !hasDraft) return null;
 
+  const overlayPathD = contours.length > 0 ? contours.map(contour => contour.d).join(' ') : null;
   let draftPath: string | null = null;
   let draftShouldClose = false;
   let draftFill = 'none';
@@ -66,6 +67,9 @@ export const MagicWandOverlay: React.FC<MagicWandOverlayProps> = ({ contours, dr
   const markerInnerRadius = 3 / safeScale;
   const markerOuterStroke = 1.5;
   const markerInnerStroke = 0.75;
+  const antsStrokeWidth = 1.5;
+  const antsDash = '6 3';
+  const antsDashOffset = antsStrokeWidth * 2;
 
   if (hasDraft && draft) {
     if (draft.mode === 'brush') {
@@ -116,26 +120,38 @@ export const MagicWandOverlay: React.FC<MagicWandOverlayProps> = ({ contours, dr
 
   return (
     <g className="pointer-events-none">
+      {overlayPathD && (
+        <path
+          d={overlayPathD}
+          fill="var(--magic-wand-selection-fill)"
+          fillRule="evenodd"
+          vectorEffect="non-scaling-stroke"
+          pointerEvents="none"
+        />
+      )}
+
       {contours.map((contour, index) => (
         <g key={`${index}-${contour.inner ? 'inner' : 'outer'}`}>
           <path
             d={contour.d}
             fill="none"
-            stroke="rgba(0,0,0,0.85)"
-            strokeWidth={1}
-            strokeDasharray="4 4"
+            stroke="var(--magic-wand-ants-dark)"
+            strokeWidth={antsStrokeWidth}
+            strokeDasharray={antsDash}
             className="magic-wand-ants"
             vectorEffect="non-scaling-stroke"
+            strokeLinecap="square"
           />
           <path
             d={contour.d}
             fill="none"
-            stroke="rgba(255,255,255,0.95)"
-            strokeWidth={1}
-            strokeDasharray="4 4"
-            strokeDashoffset={2}
+            stroke="var(--magic-wand-ants-light)"
+            strokeWidth={antsStrokeWidth}
+            strokeDasharray={antsDash}
+            strokeDashoffset={antsDashOffset}
             className="magic-wand-ants"
             vectorEffect="non-scaling-stroke"
+            strokeLinecap="square"
           />
         </g>
       ))}

--- a/src/index.css
+++ b/src/index.css
@@ -68,10 +68,13 @@
   /* Canvas Specific */
   --grid-line: rgba(var(--oc-gray-7-rgb), 0.5);
   --subgrid-line: rgba(var(--oc-gray-6-rgb), 0.7);
-  --accent-highlight-fill: rgba(var(--oc-blue-6-rgb), 0.1);
-  --accent-highlight-stroke: rgba(var(--oc-blue-6-rgb), 0.7);
+  --accent-highlight-fill: rgba(var(--oc-blue-6-rgb), 0.24);
+  --accent-highlight-stroke: rgba(var(--oc-blue-6-rgb), 0.85);
   --accent-primary-muted: var(--oc-blue-8);
   --accent-primary-highlight: rgba(var(--oc-blue-6-rgb), 0.2);
+  --magic-wand-selection-fill: rgba(var(--oc-blue-6-rgb), 0.32);
+  --magic-wand-ants-dark: rgba(0, 0, 0, 0.92);
+  --magic-wand-ants-light: rgba(255, 255, 255, 0.98);
 
   /* Custom Scrollbar for Style Library */
   --scrollbar-bg: transparent;


### PR DESCRIPTION
## Summary
- add a filled overlay and thicker marching ants to the magic wand selection render
- raise the contrast of marquee and lasso highlights by tweaking shared accent tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4a09a96508323a9eae087e5ab9e55