### PR TITLE
feat(interaction): add alt color picker shortcuts

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -1421,7 +1421,16 @@ export const useAppStore = () => {
     onCropManualPointerUp: handleCropManualPointerUp,
     cropManualDraft: appState.cropManualDraft,
   });
-  const pointerInteraction = usePointerInteraction({ tool: toolbarState.tool, viewTransform, drawingInteraction, selectionInteraction });
+  const pointerInteraction = usePointerInteraction({
+    tool: toolbarState.tool,
+    viewTransform,
+    drawingInteraction,
+    selectionInteraction,
+    paths: activePaths,
+    setStrokeColor: toolbarState.setColor,
+    setFillColor: toolbarState.setFill,
+    backgroundColor: uiState.backgroundColor,
+  });
   
   const handleSetTool = useCallback((newTool: Tool) => {
     if (newTool === toolbarState.tool) return;


### PR DESCRIPTION
## Summary
- add Alt and Shift+Alt pointer sampling to the pointer interaction hook so clicks pick stroke or fill colors instead of panning
- provide the hook with active paths and toolbar setters via the app store so sampled colors update the current selection or defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d966cd6483239928e1f51c5c05e7