### PR TITLE
feat: sync toolbar defaults when copying style

### DIFF
--- a/src/hooks/actions/useLibraryActions.ts
+++ b/src/hooks/actions/useLibraryActions.ts
@@ -19,6 +19,102 @@ export const useLibraryActions = ({
 }: AppActionsProps) => {
   const { t } = useTranslation();
 
+  const applyStyleToToolbar = useCallback(
+    (style: StyleClipboardData) => {
+      if (style.color !== undefined && typeof toolbarState.setColor === 'function') {
+        toolbarState.setColor(style.color);
+      }
+      if (style.fill !== undefined && typeof toolbarState.setFill === 'function') {
+        toolbarState.setFill(style.fill);
+      }
+      if (style.fillGradient !== undefined && typeof toolbarState.setFillGradient === 'function') {
+        toolbarState.setFillGradient(style.fillGradient ?? null);
+      }
+      if (style.fillStyle !== undefined && typeof toolbarState.setFillStyle === 'function') {
+        toolbarState.setFillStyle(style.fillStyle);
+      }
+      if (style.strokeWidth !== undefined && typeof toolbarState.setStrokeWidth === 'function') {
+        toolbarState.setStrokeWidth(style.strokeWidth);
+      }
+      if (typeof toolbarState.setStrokeLineDash === 'function') {
+        toolbarState.setStrokeLineDash(style.strokeLineDash ?? undefined);
+      }
+      if (style.strokeLineCapStart !== undefined && typeof toolbarState.setStrokeLineCapStart === 'function') {
+        toolbarState.setStrokeLineCapStart(style.strokeLineCapStart);
+      }
+      if (style.strokeLineCapEnd !== undefined && typeof toolbarState.setStrokeLineCapEnd === 'function') {
+        toolbarState.setStrokeLineCapEnd(style.strokeLineCapEnd);
+      }
+      if (style.endpointSize !== undefined && typeof toolbarState.setEndpointSize === 'function') {
+        toolbarState.setEndpointSize(style.endpointSize);
+      }
+      if (style.endpointFill !== undefined && typeof toolbarState.setEndpointFill === 'function') {
+        toolbarState.setEndpointFill(style.endpointFill);
+      }
+      if (style.opacity !== undefined && typeof toolbarState.setOpacity === 'function') {
+        toolbarState.setOpacity(style.opacity);
+      }
+      if (style.isRough !== undefined && typeof toolbarState.setIsRough === 'function') {
+        toolbarState.setIsRough(style.isRough);
+      }
+      if (style.roughness !== undefined && typeof toolbarState.setRoughness === 'function') {
+        toolbarState.setRoughness(style.roughness);
+      }
+      if (style.bowing !== undefined && typeof toolbarState.setBowing === 'function') {
+        toolbarState.setBowing(style.bowing);
+      }
+      if (style.fillWeight !== undefined && typeof toolbarState.setFillWeight === 'function') {
+        toolbarState.setFillWeight(style.fillWeight);
+      }
+      if (style.hachureAngle !== undefined && typeof toolbarState.setHachureAngle === 'function') {
+        toolbarState.setHachureAngle(style.hachureAngle);
+      }
+      if (style.hachureGap !== undefined && typeof toolbarState.setHachureGap === 'function') {
+        toolbarState.setHachureGap(style.hachureGap);
+      }
+      if (style.curveTightness !== undefined && typeof toolbarState.setCurveTightness === 'function') {
+        toolbarState.setCurveTightness(style.curveTightness);
+      }
+      if (style.curveStepCount !== undefined && typeof toolbarState.setCurveStepCount === 'function') {
+        toolbarState.setCurveStepCount(style.curveStepCount);
+      }
+      if (style.preserveVertices !== undefined && typeof toolbarState.setPreserveVertices === 'function') {
+        toolbarState.setPreserveVertices(style.preserveVertices);
+      }
+      if (style.disableMultiStroke !== undefined && typeof toolbarState.setDisableMultiStroke === 'function') {
+        toolbarState.setDisableMultiStroke(style.disableMultiStroke);
+      }
+      if (style.disableMultiStrokeFill !== undefined && typeof toolbarState.setDisableMultiStrokeFill === 'function') {
+        toolbarState.setDisableMultiStrokeFill(style.disableMultiStrokeFill);
+      }
+      if (typeof style.borderRadius === 'number' && typeof toolbarState.setBorderRadius === 'function') {
+        toolbarState.setBorderRadius(style.borderRadius);
+      }
+      if (typeof style.sides === 'number' && typeof toolbarState.setSides === 'function') {
+        toolbarState.setSides(style.sides);
+      }
+      if (style.blur !== undefined && typeof toolbarState.setBlur === 'function') {
+        toolbarState.setBlur(style.blur);
+      }
+      if (style.shadowEnabled !== undefined && typeof toolbarState.setShadowEnabled === 'function') {
+        toolbarState.setShadowEnabled(style.shadowEnabled);
+      }
+      if (style.shadowOffsetX !== undefined && typeof toolbarState.setShadowOffsetX === 'function') {
+        toolbarState.setShadowOffsetX(style.shadowOffsetX);
+      }
+      if (style.shadowOffsetY !== undefined && typeof toolbarState.setShadowOffsetY === 'function') {
+        toolbarState.setShadowOffsetY(style.shadowOffsetY);
+      }
+      if (style.shadowBlur !== undefined && typeof toolbarState.setShadowBlur === 'function') {
+        toolbarState.setShadowBlur(style.shadowBlur);
+      }
+      if (style.shadowColor !== undefined && typeof toolbarState.setShadowColor === 'function') {
+        toolbarState.setShadowColor(style.shadowColor);
+      }
+    },
+    [toolbarState]
+  );
+
   /**
    * 从选中的单个图形复制样式。
    */
@@ -26,7 +122,7 @@ export const useLibraryActions = ({
     if (selectedPathIds.length !== 1) return;
     const path = paths.find(p => p.id === selectedPathIds[0]);
     if (!path) return;
-    setStyleClipboard({
+    const copiedStyle: StyleClipboardData = {
         color: path.color,
         fill: path.fill,
         fillGradient: path.fillGradient,
@@ -52,8 +148,17 @@ export const useLibraryActions = ({
         disableMultiStrokeFill: path.disableMultiStrokeFill,
         borderRadius: (path.tool === 'rectangle' || path.tool === 'image' || path.tool === 'polygon') ? (path as RectangleData | ImageData | PolygonData).borderRadius : undefined,
         sides: path.tool === 'polygon' ? (path as PolygonData).sides : undefined,
-    });
-  }, [paths, selectedPathIds, setStyleClipboard]);
+        blur: path.blur,
+        shadowEnabled: path.shadowEnabled,
+        shadowOffsetX: path.shadowOffsetX,
+        shadowOffsetY: path.shadowOffsetY,
+        shadowBlur: path.shadowBlur,
+        shadowColor: path.shadowColor,
+    };
+
+    setStyleClipboard(copiedStyle);
+    applyStyleToToolbar(copiedStyle);
+  }, [paths, selectedPathIds, setStyleClipboard, applyStyleToToolbar]);
   
   /**
    * 将复制的样式粘贴到选中的图形上。


### PR DESCRIPTION
## Summary
- update the copy-style action to push the copied style into the toolbar defaults
- include blur and shadow fields in the copied style payload for reuse

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8099ad7988323b829af6683f3b76c