### PR TITLE
fix: correct grid snapping during transforms

### DIFF
--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -160,6 +160,7 @@ const handlePointerDownForLasso = (
 interface HandlePointerDownProps {
   e: React.PointerEvent<SVGSVGElement>;
   point: Point;
+  snapToGrid: (point: Point) => Point;
   setDragState: Dispatch<SetStateAction<DragState>>;
   setMarquee: Dispatch<SetStateAction<{ start: Point; end: Point } | null>>;
   setLassoPath: Dispatch<SetStateAction<Point[] | null>>;
@@ -179,11 +180,13 @@ interface HandlePointerDownProps {
  * @param props - 包含事件对象、状态和设置器的对象。
  */
 export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
-    const { e, point, setDragState, pathState, toolbarState, viewTransform, onDoubleClick, lastClickRef, croppingState, currentCropRect, cropTool, onMagicWandSample } = props;
+    const { e, point, snapToGrid, setDragState, pathState, toolbarState, viewTransform, onDoubleClick, lastClickRef, croppingState, currentCropRect, cropTool, onMagicWandSample } = props;
     const { paths, setPaths, selectedPathIds, beginCoalescing, endCoalescing, setSelectedPathIds } = pathState;
     const { selectionMode } = toolbarState;
     const { viewTransform: vt } = viewTransform;
     const target = e.target as SVGElement;
+
+    const snappedPoint = snapToGrid(point);
 
     const handle = target.dataset.handle as ResizeHandlePosition | 'rotate' | 'border-radius' | 'arc' | undefined;
     const type = target.dataset.type as 'anchor' | 'handleIn' | 'handleOut' | undefined;
@@ -205,7 +208,7 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
                 handle: handle as ResizeHandlePosition,
                 initialCropRect: currentCropRect,
                 originalImage: croppingState.originalPath,
-                initialPointerPos: point,
+                initialPointerPos: snappedPoint,
             });
         }
         // Any other click (on another shape, empty space, etc.) does nothing.
@@ -247,13 +250,13 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
 
                 if (isSimpleShape) {
                     if (e.ctrlKey || e.metaKey) {
-                        setDragState({ type: 'skew', pathId: path.id, handle, originalPath: path as any, initialPointerPos: point });
+                        setDragState({ type: 'skew', pathId: path.id, handle, originalPath: path as any, initialPointerPos: snappedPoint });
                     } else {
-                        setDragState({ type: 'resize', pathId: path.id, handle, originalPath: path as any, initialPointerPos: point });
+                        setDragState({ type: 'resize', pathId: path.id, handle, originalPath: path as any, initialPointerPos: snappedPoint });
                     }
                 } else {
                     if (!bbox) { endCoalescing(); return; }
-                    setDragState({ type: 'scale', pathIds: selectedPathIds, handle, originalPaths: selected, initialPointerPos: point, initialSelectionBbox: bbox });
+                    setDragState({ type: 'scale', pathIds: selectedPathIds, handle, originalPaths: selected, initialPointerPos: snappedPoint, initialSelectionBbox: bbox });
                 }
             }
         } else if (selectionMode === 'edit') {

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -131,7 +131,7 @@ export const useSelection = ({
   const onPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
     e.currentTarget.setPointerCapture(e.pointerId);
     const point = getPointerPosition(e, e.currentTarget);
-    
+
     if (croppingState && cropTool === 'magic-wand' && (cropSelectionMode && cropSelectionMode !== 'magic-wand')) {
       onCropManualPointerDown?.(point, e);
       return;
@@ -143,6 +143,7 @@ export const useSelection = ({
 
     handlePointerDownLogic({
       e, point, setDragState, setMarquee, setLassoPath,
+      snapToGrid,
       pathState, toolbarState, viewTransform,
       onDoubleClick, lastClickRef, croppingState,
       currentCropRect, cropTool, onMagicWandSample,

--- a/tests/hooks/selection-logic/pointerDown.test.ts
+++ b/tests/hooks/selection-logic/pointerDown.test.ts
@@ -1,0 +1,144 @@
+// handlePointerDownLogic 网格吸附测试
+import { describe, expect, it, vi } from 'vitest';
+import type { PointerEvent as ReactPointerEvent } from 'react';
+import { handlePointerDownLogic } from '@/hooks/selection-logic/pointerDown';
+import type {
+  AnyPath,
+  RectangleData,
+  SelectionPathState,
+  SelectionToolbarState,
+  SelectionViewTransform,
+  DragState,
+  Point,
+} from '@/types';
+
+const createRectangle = (id: string): RectangleData => ({
+  id,
+  tool: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 40,
+  rotation: 0,
+  color: '#000000',
+  fill: 'transparent',
+  fillStyle: 'hachure',
+  strokeWidth: 1,
+  roughness: 0,
+  bowing: 0,
+  fillWeight: 0,
+  hachureAngle: 0,
+  hachureGap: 0,
+  curveTightness: 0,
+  curveStepCount: 0,
+});
+
+const baseViewTransform: SelectionViewTransform = {
+  viewTransform: { scale: 1, translateX: 0, translateY: 0 },
+  getPointerPosition: vi.fn(),
+};
+
+const baseToolbarState: SelectionToolbarState = { selectionMode: 'move' };
+const snap = (point: Point): Point => ({
+  x: Math.round(point.x / 10) * 10,
+  y: Math.round(point.y / 10) * 10,
+});
+
+const createPathState = (paths: AnyPath[]): SelectionPathState => ({
+  paths,
+  setPaths: vi.fn(),
+  selectedPathIds: paths.map(p => p.id),
+  setSelectedPathIds: vi.fn(),
+  beginCoalescing: vi.fn(),
+  endCoalescing: vi.fn(),
+});
+
+const sharedArgs = {
+  setMarquee: vi.fn(),
+  setLassoPath: vi.fn(),
+  onDoubleClick: vi.fn(),
+  lastClickRef: { current: { time: 0, pathId: null } },
+  croppingState: null,
+  currentCropRect: null,
+  cropTool: 'crop' as const,
+  onMagicWandSample: vi.fn(),
+};
+
+describe('handlePointerDownLogic grid snapping', () => {
+  it('snaps the initial pointer for resize handles', () => {
+    const rectangle = createRectangle('rect-1');
+    const pathState = createPathState([rectangle]);
+    const setDragState = vi.fn();
+
+    const event = {
+      button: 0,
+      shiftKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      target: {
+        dataset: {
+          handle: 'right',
+          pathId: 'rect-1',
+        } as DOMStringMap,
+      },
+    } as unknown as ReactPointerEvent<SVGSVGElement>;
+
+    handlePointerDownLogic({
+      e: event,
+      point: { x: 12.6, y: 18.4 },
+      snapToGrid: snap,
+      setDragState,
+      pathState,
+      toolbarState: baseToolbarState,
+      viewTransform: baseViewTransform,
+      ...sharedArgs,
+    });
+
+    expect(setDragState).toHaveBeenCalled();
+    const [arg] = setDragState.mock.calls[0] ?? [];
+    const dragState = (typeof arg === 'function' ? arg(null) : arg) as DragState;
+    expect(dragState && dragState.type).toBe('resize');
+    if (dragState && dragState.type === 'resize') {
+      expect(dragState.initialPointerPos).toEqual({ x: 10, y: 20 });
+    }
+  });
+
+  it('snaps the initial pointer for scale handles on groups', () => {
+    const rectA = createRectangle('rect-1');
+    const rectB = { ...createRectangle('rect-2'), x: 120 };
+    const pathState = createPathState([rectA, rectB]);
+    const setDragState = vi.fn();
+
+    const event = {
+      button: 0,
+      shiftKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      target: {
+        dataset: {
+          handle: 'bottom-right',
+          pathId: 'rect-1',
+        } as DOMStringMap,
+      },
+    } as unknown as ReactPointerEvent<SVGSVGElement>;
+
+    handlePointerDownLogic({
+      e: event,
+      point: { x: 199.2, y: 81.5 },
+      snapToGrid: snap,
+      setDragState,
+      pathState,
+      toolbarState: baseToolbarState,
+      viewTransform: baseViewTransform,
+      ...sharedArgs,
+    });
+
+    expect(setDragState).toHaveBeenCalled();
+    const [arg] = setDragState.mock.calls[0] ?? [];
+    const dragState = (typeof arg === 'function' ? arg(null) : arg) as DragState;
+    expect(dragState && dragState.type).toBe('scale');
+    if (dragState && dragState.type === 'scale') {
+      expect(dragState.initialPointerPos).toEqual({ x: 200, y: 80 });
+    }
+  });
+});

--- a/tests/hooks/useSelection.test.ts
+++ b/tests/hooks/useSelection.test.ts
@@ -160,6 +160,7 @@ describe('useSelection', () => {
       expect.objectContaining({
         e: event,
         point: { x: 16, y: 27 },
+        snapToGrid: expect.any(Function),
         pathState: expect.objectContaining({ paths: currentPaths }),
       })
     );


### PR DESCRIPTION
## Summary
- snap selection drag start positions to the grid before starting crop, resize, scale and skew operations
- pass the grid snapping helper through the selection hook so pointer down logic can access it
- add regression tests covering snapped drag state initialization for resize and scale handles

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68d809ec2edc8323b0002baffb8eacc3