### PR TITLE
fix: inherit text editor typography

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -101,9 +101,9 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
   };
 
   const segmentedButtonBase =
-    'flex items-center gap-2 h-9 px-3 rounded-md text-sm font-medium transition-colors';
+    'flex items-center justify-center gap-2 h-[34px] px-3 rounded-lg text-sm font-medium transition-colors';
   const textButtonBase =
-    'flex items-center gap-2 h-9 px-3 rounded-md text-sm font-medium transition-colors disabled:opacity-60 disabled:cursor-not-allowed';
+    'flex items-center justify-center gap-2 h-[34px] px-3 rounded-lg text-sm font-medium transition-colors disabled:opacity-60 disabled:cursor-not-allowed';
 
   return (
     <div

--- a/src/index.css
+++ b/src/index.css
@@ -115,7 +115,9 @@ textarea {
   -moz-user-select: auto;
   -ms-user-select: auto;
   user-select: auto;
-  font-size: 85%;
+  font: inherit;
+  line-height: inherit;
+  color: inherit;
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- let text-editing controls inherit font, line height, and color so the input matches rendered text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8944bb3b0832380ed1d76e5561c3e