### PR TITLE
fix: sync layer panel selection with canvas

### DIFF
--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -9,6 +9,7 @@ import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
 import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '../types';
 import { getPointerPosition } from '../lib/utils';
+import { collectPathsByIds } from '@/lib/pathTree';
 import { useViewTransformStore } from '@/context/viewTransformStore';
 import { getPathsBoundingBox } from '@/lib/drawing';
 
@@ -168,9 +169,10 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   };
 
   // 记忆化计算选中的路径，以避免不必要的重渲染
-  const selectedPaths = useMemo(() => {
-    return paths.filter(p => selectedPathIds.includes(p.id));
-  }, [paths, selectedPathIds]);
+  const selectedPaths = useMemo(
+    () => collectPathsByIds(paths, selectedPathIds),
+    [paths, selectedPathIds],
+  );
   
   // 记忆化计算可见的路径，仅排除显式隐藏的路径
   const visiblePaths = useMemo(() => paths.filter(p => p.isVisible !== false), [paths]);

--- a/src/components/layers-panel/LayersPanel.tsx
+++ b/src/components/layers-panel/LayersPanel.tsx
@@ -11,6 +11,7 @@ import { useAppContext } from '@/context/AppContext';
 import { LayerItem } from './LayerItem';
 import PanelButton from '@/components/PanelButton';
 import { withLayerIconSize } from './constants';
+import { findPathById } from '@/lib/pathTree';
 
 export const LayersPanel: React.FC = () => {
   const { paths, selectedPathIds, reorderPaths, handleDeletePaths, setPaths, setSelectedPathIds } = useLayers();
@@ -98,17 +99,6 @@ export const LayersPanel: React.FC = () => {
     setDraggedId(id);
   };
 
-  const findPath = (paths: AnyPath[], id: string): AnyPath | null => {
-    for (const p of paths) {
-        if (p.id === id) return p;
-        if (p.tool === 'group') {
-            const found = findPath((p as GroupData).children, id);
-            if (found) return found;
-        }
-    }
-    return null;
-  }
-
   const handleItemDragOver = (e: React.DragEvent, targetId: string) => {
     e.preventDefault();
     e.stopPropagation();
@@ -117,7 +107,7 @@ export const LayersPanel: React.FC = () => {
     const rect = (e.currentTarget as HTMLDivElement).getBoundingClientRect();
     const y = e.clientY - rect.top;
     const height = rect.height;
-    const targetPath = findPath(paths, targetId);
+    const targetPath = findPathById(paths, targetId);
     
     let position: 'above' | 'below' | 'inside';
     const threshold = height * 0.4;

--- a/src/components/layout/MainMenuPanel.tsx
+++ b/src/components/layout/MainMenuPanel.tsx
@@ -7,6 +7,7 @@ import { useAppContext } from '@/context/AppContext';
 import { MainMenu } from '../MainMenu';
 import type { AnyPath } from '@/types';
 import { getPathsBoundingBox, getPathBoundingBox } from '@/lib/drawing';
+import { collectPathsByIds } from '@/lib/pathTree';
 
 export const MainMenuPanel: React.FC = () => {
     const {
@@ -74,7 +75,7 @@ export const MainMenuPanel: React.FC = () => {
                 }
             }
         } else if (selectedPathIds.length > 1) {
-            const selectedPaths = paths.filter((p: AnyPath) => selectedPathIds.includes(p.id));
+            const selectedPaths = collectPathsByIds(paths, selectedPathIds);
             const bbox = getPathsBoundingBox(selectedPaths, false);
             if (bbox) {
                 return {

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -9,6 +9,7 @@ import rough from 'roughjs/bin/rough';
 import type { RoughSVG } from 'roughjs/bin/svg';
 import type { AnyPath, VectorPathData, LivePath, Point, DrawingShape, Tool, DragState, SelectionMode, ImageData, BBox } from '@/types';
 import { getPointerPosition } from '@/lib/utils';
+import { collectPathsByIds } from '@/lib/pathTree';
 import { useViewTransformStore } from '@/context/viewTransformStore';
 
 // Import new sub-components
@@ -150,9 +151,10 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   };
 
   // 记忆化计算选中的路径，以避免不必要的重渲染
-  const selectedPaths = useMemo(() => {
-    return paths.filter(p => selectedPathIds.includes(p.id));
-  }, [paths, selectedPathIds]);
+  const selectedPaths = useMemo(
+    () => collectPathsByIds(paths, selectedPathIds),
+    [paths, selectedPathIds],
+  );
   
   // 记忆化计算可见的路径，仅排除显式隐藏的路径
   const visiblePaths = useMemo(() => paths.filter(p => p.isVisible !== false), [paths]);

--- a/src/lib/pathTree.ts
+++ b/src/lib/pathTree.ts
@@ -1,0 +1,45 @@
+import type { AnyPath, GroupData } from '@/types';
+
+const isGroup = (path: AnyPath): path is GroupData => path.tool === 'group';
+
+const traverse = (paths: AnyPath[], visit: (path: AnyPath) => void) => {
+  for (const path of paths) {
+    visit(path);
+    if (isGroup(path)) {
+      traverse(path.children, visit);
+    }
+  }
+};
+
+export const findPathById = (paths: AnyPath[], id: string): AnyPath | null => {
+  let found: AnyPath | null = null;
+
+  traverse(paths, path => {
+    if (!found && path.id === id) {
+      found = path;
+    }
+  });
+
+  return found;
+};
+
+export const collectPathsByIds = (paths: AnyPath[], ids: string[]): AnyPath[] => {
+  if (ids.length === 0) return [];
+
+  const idSet = new Set(ids);
+  const found = new Map<string, AnyPath>();
+
+  traverse(paths, path => {
+    if (idSet.has(path.id)) {
+      found.set(path.id, path);
+    }
+  });
+
+  return ids.reduce<AnyPath[]>((result, id) => {
+    const path = found.get(id);
+    if (path) {
+      result.push(path);
+    }
+    return result;
+  }, []);
+};


### PR DESCRIPTION
## Summary
- add reusable path tree helpers to find nested items
- ensure whiteboard views and menu derive selected paths recursively
- reuse helper in the layers panel drag-over logic for consistency

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8096e2c7c83239ea46ea26b3ba0e3