### PR TITLE
refactor(whiteboard): avoid array reallocation when collecting frames

### DIFF
--- a/src/components/whiteboard/PathsRenderer.tsx
+++ b/src/components/whiteboard/PathsRenderer.tsx
@@ -15,16 +15,15 @@ import { getShapeTransformMatrix, isIdentityMatrix, matrixToString } from '@/lib
  * @param paths - 要搜索的路径数组。
  * @returns 一个包含所有找到的画框对象的数组。
  */
-const getAllFrames = (paths: AnyPath[]): AnyPath[] => {
-  let allFrames: AnyPath[] = [];
+const getAllFrames = (paths: AnyPath[], accumulator: AnyPath[] = []): AnyPath[] => {
   for (const path of paths) {
     if (path.tool === 'frame') {
-      allFrames.push(path);
+      accumulator.push(path);
     } else if (path.tool === 'group') {
-      allFrames = [...allFrames, ...getAllFrames((path as GroupData).children)];
+      getAllFrames((path as GroupData).children, accumulator);
     }
   }
-  return allFrames;
+  return accumulator;
 };
 
 /**


### PR DESCRIPTION
## Summary
- reuse a shared accumulator when collecting frames inside PathsRenderer to avoid repeated array copies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db384fed308323a4e8cb3689fd495f