### PR TITLE
feat(paths): persist frame ids

### DIFF
--- a/src/components/TimelinePanel.tsx
+++ b/src/components/TimelinePanel.tsx
@@ -335,7 +335,7 @@ export const TimelinePanel: React.FC = () => {
                         <div className="flex items-center gap-1.5">
                             {frames.map((frame, index) => (
                                 <div
-                                    key={index}
+                                    key={frame.id}
                                     className="relative group flex-shrink-0 w-[4.5rem] h-[4.5rem]"
                                     draggable={!isPlaying}
                                     onDragStart={(e) => handleDragStart(e, index)}

--- a/src/hooks/actions/useAppActions.ts
+++ b/src/hooks/actions/useAppActions.ts
@@ -9,7 +9,7 @@ import { useExportActions } from './useExportActions';
 import { useFileActions } from './useFileActions';
 import { useLibraryActions } from './useLibraryActions';
 import { useObjectActions } from './useObjectActions';
-import type { AnyPath, Point, Tool, WhiteboardData, StyleClipboardData, MaterialData, LibraryData, Alignment, DistributeMode, PngExportOptions, Frame, AnimationExportOptions } from '@/types';
+import type { AnyPath, Point, Tool, WhiteboardData, StyleClipboardData, MaterialData, LibraryData, Alignment, DistributeMode, PngExportOptions, Frame, FrameInput, AnimationExportOptions } from '@/types';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 
 // The props type is a combination of all props needed by the sub-hooks.
@@ -25,7 +25,7 @@ export interface AppActionsProps {
   pathState: {
     setPaths: (updater: React.SetStateAction<AnyPath[]>) => void;
     setSelectedPathIds: React.Dispatch<React.SetStateAction<string[]>>;
-    handleLoadFile: (newFrames: Frame[], newFrameIndex?: number) => void;
+    handleLoadFile: (newFrames: FrameInput[], newFrameIndex?: number) => void;
     handleReorder: (direction: 'forward' | 'backward' | 'front' | 'back') => void;
     beginCoalescing: () => void;
     endCoalescing: () => void;

--- a/src/hooks/actions/useFileActions.ts
+++ b/src/hooks/actions/useFileActions.ts
@@ -11,6 +11,7 @@ import { createDocumentSignature } from '@/lib/document';
 import type { AppActionsProps } from './useAppActions';
 import { getImageDataUrl } from '@/lib/imageCache';
 import { useFilesStore } from '@/context/filesStore';
+import { normalizeFrames } from '@/context/pathsStore';
 
 type FileWithHandle = File & { handle: FileSystemFileHandle };
 
@@ -173,7 +174,8 @@ export const useFileActions = ({
                     })
                 );
             }
-            const framesToLoad = data.frames || [{ paths: data.paths ?? [] }];
+            const rawFrames = data.frames || [{ paths: data.paths ?? [] }];
+            const framesToLoad = normalizeFrames(rawFrames);
             const nextBackgroundColor = data.backgroundColor ?? '#212529';
             const nextFps = data.fps ?? fps;
             pathState.handleLoadFile(framesToLoad);

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -18,8 +18,9 @@ import { useGroupIsolation } from './useGroupIsolation';
 import { getLocalStorageItem } from '../lib/utils';
 import * as idb from '../lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
-import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, PngExportOptions, ImageData as PathImageData, BBox, Frame, Point, GroupData } from '../types';
+import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, PngExportOptions, ImageData as PathImageData, BBox, Point, GroupData } from '../types';
 import { rotatePoint, dist } from '@/lib/drawing';
+import { normalizeFrames, createFrame } from '@/context/pathsStore';
 
 import {
   removeBackground,
@@ -1067,7 +1068,7 @@ export const useAppStore = () => {
       '清空数据',
       '确定要清空所有动画帧中的数据吗？此操作无法撤销。',
       () => {
-        const resetFrames = [{ paths: [] } as Frame];
+        const resetFrames = [createFrame()];
         // Reset the timeline to a single empty frame so no leftover thumbnails remain
         handleLoadFile(resetFrames, 0);
         setSelectedPathIds([]);
@@ -1600,7 +1601,8 @@ export const useAppStore = () => {
 
         const data: WhiteboardData = JSON.parse(contents);
         if (data?.type === 'whiteboard/shapes' && (data.frames || data.paths)) {
-          const framesToLoad = data.frames || [{ paths: data.paths ?? [] }];
+          const rawFrames = data.frames || [{ paths: data.paths ?? [] }];
+          const framesToLoad = normalizeFrames(rawFrames);
           const nextBackground = data.backgroundColor ?? '#212529';
           const nextFps = data.fps ?? initialFpsRef.current;
           handleLoadFile(framesToLoad);

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,8 +269,11 @@ export interface GroupData extends ShapeBase {
 export type AnyPath = VectorPathData | RectangleData | EllipseData | ImageData | BrushPathData | PolygonData | ArcData | GroupData | FrameData;
 
 export interface Frame {
+  id: string;
   paths: AnyPath[];
 }
+
+export type FrameInput = Omit<Frame, 'id'> & { id?: string };
 
 export interface WhiteboardData {
   type: 'whiteboard/shapes';

--- a/tests/context/pathsStore.test.ts
+++ b/tests/context/pathsStore.test.ts
@@ -1,0 +1,83 @@
+/**
+ * 覆盖路径存储中的帧重排逻辑，确保缩略图内容与帧对应关系保持一致。
+ */
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import type { RectangleData } from '@/types';
+
+type PathsStoreModule = typeof import('@/context/pathsStore');
+
+let usePathsStore: PathsStoreModule['usePathsStore'];
+let createFrame: PathsStoreModule['createFrame'];
+
+const createMockStorage = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  } as Storage;
+};
+
+const createRectangle = (id: string, x: number): RectangleData => ({
+  id,
+  tool: 'rectangle',
+  x,
+  y: 0,
+  width: 100,
+  height: 100,
+  color: '#000000',
+  fill: 'none',
+  fillStyle: 'solid',
+  strokeWidth: 1,
+});
+
+beforeAll(async () => {
+  (globalThis as any).window = globalThis;
+  (globalThis as any).localStorage = createMockStorage();
+  const module = await import('@/context/pathsStore');
+  usePathsStore = module.usePathsStore;
+  createFrame = module.createFrame;
+});
+
+beforeEach(() => {
+  usePathsStore.setState((state) => ({
+    ...state,
+    frames: [createFrame()],
+    currentFrameIndex: 0,
+    past: [],
+    future: [],
+  }));
+});
+
+describe('pathsStore frame reordering', () => {
+  it('keeps frame ids and content aligned after reordering', () => {
+    const frameAPath = createRectangle('shape-a', 10);
+    const frameBPath = createRectangle('shape-b', 20);
+
+    const initialFrames = [
+      createFrame([frameAPath], 'frame-a'),
+      createFrame([frameBPath], 'frame-b'),
+    ];
+
+    usePathsStore.getState().handleLoadFile(initialFrames);
+
+    expect(usePathsStore.getState().frames.map((frame) => frame.id)).toEqual([
+      'frame-a',
+      'frame-b',
+    ]);
+
+    usePathsStore.getState().reorderFrames(0, 1);
+
+    const reordered = usePathsStore.getState().frames;
+    expect(reordered.map((frame) => frame.id)).toEqual(['frame-b', 'frame-a']);
+    expect(reordered[0].paths[0]).toBe(frameBPath);
+    expect(reordered[1].paths[0]).toBe(frameAPath);
+  });
+});


### PR DESCRIPTION
## Summary
- add persistent identifiers to Frame records and normalize persisted data
- propagate frame ids through file loading, frame creation, and timeline rendering
- add a regression test to ensure reordering keeps frame content aligned with thumbnails

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db3840250883238fa3715998c161b9