### PR TITLE
feat(paths): track frame revision for document signatures

### DIFF
--- a/src/hooks/actions/useAppActions.ts
+++ b/src/hooks/actions/useAppActions.ts
@@ -17,6 +17,7 @@ import type { FileSystemFileHandle } from 'wicg-file-system-access';
 export interface AppActionsProps {
   paths: AnyPath[];
   frames: Frame[];
+  revision: number;
   fps: number;
   setFps: (val: number | ((prev: number) => number)) => void;
   backgroundColor: string;

--- a/src/hooks/usePathsStore.ts
+++ b/src/hooks/usePathsStore.ts
@@ -17,6 +17,7 @@ type PathsState = ReturnType<typeof usePathsStoreBase.getState>;
 const selector = (state: PathsState) => ({
   frames: state.frames,
   currentFrameIndex: state.currentFrameIndex,
+  revision: state.revision,
   setCurrentFrameIndex: state.setCurrentFrameIndex,
   setPaths: state.setPaths,
   handleLoadFile: state.handleLoadFile,
@@ -43,6 +44,7 @@ export const usePathsStore = () => {
   const {
     frames,
     currentFrameIndex,
+    revision,
     setCurrentFrameIndex,
     setPaths: setPathsFromStore,
     handleLoadFile,
@@ -175,6 +177,7 @@ export const usePathsStore = () => {
     () => ({
       frames,
       currentFrameIndex,
+      revision,
       setCurrentFrameIndex,
       paths,
       setPaths,

--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -1,13 +1,11 @@
-import type { Frame } from '@/types';
-
 /**
  * Create a stable signature representing the current whiteboard document.
  *
- * @param frames - All frames in the document.
+ * @param revision - Incrementing revision number for frame mutations.
  * @param backgroundColor - Current canvas background color.
  * @param fps - Current playback speed.
  * @returns Serialized signature string for change detection.
  */
-export const createDocumentSignature = (frames: Frame[], backgroundColor: string, fps: number): string => {
-  return JSON.stringify({ frames, backgroundColor, fps });
+export const createDocumentSignature = (revision: number, backgroundColor: string, fps: number): string => {
+  return `${revision}:${backgroundColor}:${fps}`;
 };


### PR DESCRIPTION
## Summary
- add a revision counter to the paths store and expose it via the hooks
- switch document signatures to use revision/background/fps instead of serializing frames
- update save/load flows to refresh the saved signature with the latest revision

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3faddde08323a5b1e0c952b0249a