### PR TITLE
Add worker-backed HSV preview controller

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -66,6 +66,7 @@ export const MainLayout: React.FC = () => {
         // Pen/Line tool finishers for context menu
         handleFinishPenPath,
         handleFinishLinePath,
+        handleAdjustImageHsv,
     } = store;
 
     const layersValue = useMemo<LayersContextValue>(() => store.activePathState, [store.activePathState]);
@@ -238,6 +239,7 @@ export const MainLayout: React.FC = () => {
                             cropTool={cropTool}
                             cropSelectionContours={cropSelectionContours}
                             cropManualDraft={cropManualDraft}
+                            previewSrcById={handleAdjustImageHsv.previewSrcById}
                         />
                     </div>
                     <TimelinePanel />

--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -7,7 +7,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Tool, AnyPath, VectorPathData, GradientFill } from '../types';
-import type { HsvAdjustment } from '@/lib/image';
+import type { ImageHsvPreviewController } from '@/hooks/useImageHsvPreview';
 import { ICONS } from '../constants';
 import PanelButton from '@/components/PanelButton';
 
@@ -82,7 +82,7 @@ interface SideToolbarProps {
   setShadowBlur: (sb: number) => void;
   shadowColor: string;
   setShadowColor: (sc: string) => void;
-  onAdjustImageHsv: (adj: HsvAdjustment) => void;
+  imageHsvPreview: Pick<ImageHsvPreviewController, 'beginPreview' | 'updatePreview' | 'commitPreview'>;
 }
 
 /**
@@ -105,7 +105,7 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
     beginCoalescing, endCoalescing,
     onToggleStyleLibrary,
     isStyleLibraryOpen,
-    onAdjustImageHsv,
+    imageHsvPreview,
   } = props;
 
   const { t } = useTranslation();
@@ -237,7 +237,9 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
 
           {firstSelectedPath?.tool === 'image' && (
             <ImageHsvPopover
-              onAdjust={onAdjustImageHsv}
+              beginPreview={imageHsvPreview.beginPreview}
+              updatePreview={imageHsvPreview.updatePreview}
+              commitPreview={imageHsvPreview.commitPreview}
               beginCoalescing={beginCoalescing}
               endCoalescing={endCoalescing}
             />

--- a/src/components/Whiteboard.tsx
+++ b/src/components/Whiteboard.tsx
@@ -61,6 +61,7 @@ interface WhiteboardProps {
     points: Point[];
     previewPoint?: Point;
   } | null;
+  previewSrcById?: Record<string, string>;
 }
 
 /**
@@ -101,6 +102,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   cropTool,
   cropSelectionContours,
   cropManualDraft,
+  previewSrcById,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -240,9 +242,9 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
         
         <g style={{ transform: `translate(${viewTransform.translateX}px, ${viewTransform.translateY}px) scale(${viewTransform.scale})` }}>
           
-          <PathsRenderer paths={backgroundPaths} rc={rc} isBackground />
-          <PathsRenderer paths={onionSkinPaths} rc={rc} />
-          <PathsRenderer paths={visiblePaths} rc={rc} />
+          <PathsRenderer paths={backgroundPaths} rc={rc} isBackground previewSrcById={previewSrcById} />
+          <PathsRenderer paths={onionSkinPaths} rc={rc} previewSrcById={previewSrcById} />
+          <PathsRenderer paths={visiblePaths} rc={rc} previewSrcById={previewSrcById} />
 
           <LivePreviewRenderer
             currentLivePath={currentLivePath}

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -35,7 +35,7 @@ export const SideToolbarPanel: React.FC = () => {
                     transform: `translateY(-50%) ${isSideToolbarCollapsed ? 'translateX(calc(100% + 1rem))' : 'translateX(0)'}`,
                 }}
             >
-                <SideToolbar {...store} onToggleStyleLibrary={handleToggleStyleLibrary} onAdjustImageHsv={handleAdjustImageHsv} />
+                <SideToolbar {...store} onToggleStyleLibrary={handleToggleStyleLibrary} imageHsvPreview={handleAdjustImageHsv} />
             </div>
         </>
     );

--- a/src/components/whiteboard/PathsRenderer.tsx
+++ b/src/components/whiteboard/PathsRenderer.tsx
@@ -98,7 +98,7 @@ const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; previewSrcBy
         return (
             <g>
                 {(data as GroupData).children.map(child => (
-                    <PathComponent key={child.id} rc={rc} data={child} />
+                    <PathComponent key={child.id} rc={rc} data={child} previewSrcById={previewSrcById} />
                 ))}
             </g>
         );

--- a/src/components/whiteboard/PathsRenderer.tsx
+++ b/src/components/whiteboard/PathsRenderer.tsx
@@ -31,14 +31,16 @@ const getAllFrames = (paths: AnyPath[], accumulator: AnyPath[] = []): AnyPath[] 
  * @description 对常规组进行递归渲染，以利用 React 的 diffing 算法，
  * 仅更新组内已更改的元素。遮罩组则被视为原子单元进行渲染。
  */
-const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.memo(({ rc, data }) => {
+const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; previewSrcById?: Record<string, string>; }> = React.memo(({ rc, data, previewSrcById }) => {
     const [imageSrc, setImageSrc] = useState<string | null>(null);
     const lastImageKeyRef = useRef<string | null>(null);
     const latestImageDataRef = useRef<ImageData | null>(null);
 
-    const imageKey = data.tool === 'image'
+    const previewSrc = data.tool === 'image' ? previewSrcById?.[data.id] ?? null : null;
+    const baseImageKey = data.tool === 'image'
         ? (data.fileId ?? data.src ?? null)
         : null;
+    const imageKey = previewSrc ?? baseImageKey;
 
     latestImageDataRef.current = data.tool === 'image' ? (data as ImageData) : null;
 
@@ -56,6 +58,14 @@ const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.m
         const imageData = latestImageDataRef.current;
         if (!imageData) {
             lastImageKeyRef.current = null;
+            return () => {
+                cancelled = true;
+            };
+        }
+
+        if (previewSrc) {
+            lastImageKeyRef.current = imageKey;
+            setImageSrc(prev => (prev === previewSrc ? prev : previewSrc));
             return () => {
                 cancelled = true;
             };
@@ -81,7 +91,7 @@ const PathComponent: React.FC<{ rc: RoughSVG | null; data: AnyPath; }> = React.m
         return () => {
             cancelled = true;
         };
-    }, [imageKey]);
+    }, [imageKey, previewSrc]);
 
     // 如果路径是常规（非遮罩）组，则递归渲染其子项以获得性能优势。
     if (data.tool === 'group' && !(data as GroupData).mask) {
@@ -190,6 +200,7 @@ interface PathsRendererProps {
   paths: AnyPath[];
   rc: RoughSVG | null;
   isBackground?: boolean;
+  previewSrcById?: Record<string, string>;
 }
 
 
@@ -198,13 +209,13 @@ interface PathsRendererProps {
  * @description 它遍历顶层路径，并为每个路径渲染一个 `PathComponent`。
  * 递归由 `PathComponent` 内部处理。
  */
-export const PathsRenderer: React.FC<PathsRendererProps> = React.memo(({ paths, rc, isBackground }) => {
+export const PathsRenderer: React.FC<PathsRendererProps> = React.memo(({ paths, rc, isBackground, previewSrcById }) => {
   // 预先计算画框列表，以便在其上方渲染编号。
   const frames = useMemo(() => getAllFrames(paths), [paths]);
   return (
     <g opacity={isBackground ? 0.3 : 1} style={{ pointerEvents: isBackground ? 'none' : 'auto' }}>
       {paths.map((path) => (
-        <PathComponent key={path.id} rc={rc} data={path} />
+        <PathComponent key={path.id} rc={rc} data={path} previewSrcById={previewSrcById} />
       ))}
       {/* 渲染所有路径后，在其上方渲染画框编号 */}
       {frames.map((frame, index) => {

--- a/src/components/whiteboard/Whiteboard.tsx
+++ b/src/components/whiteboard/Whiteboard.tsx
@@ -73,6 +73,7 @@ interface WhiteboardProps {
         brushSize: number;
       }
   ) | null;
+  previewSrcById?: Record<string, string>;
 }
 
 /**
@@ -113,6 +114,7 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
   cropTool,
   cropSelectionContours,
   cropManualDraft,
+  previewSrcById,
 }) => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [rc, setRc] = useState<RoughSVG | null>(null);
@@ -178,9 +180,9 @@ export const Whiteboard: React.FC<WhiteboardProps> = ({
         
         <g style={{ transform: `translate(${viewTransform.translateX}px, ${viewTransform.translateY}px) scale(${viewTransform.scale})` }}>
           
-          <PathsRenderer paths={backgroundPaths} rc={rc} isBackground />
-          <PathsRenderer paths={onionSkinPaths} rc={rc} />
-          <PathsRenderer paths={visiblePaths} rc={rc} />
+          <PathsRenderer paths={backgroundPaths} rc={rc} isBackground previewSrcById={previewSrcById} />
+          <PathsRenderer paths={onionSkinPaths} rc={rc} previewSrcById={previewSrcById} />
+          <PathsRenderer paths={visiblePaths} rc={rc} previewSrcById={previewSrcById} />
 
           <LivePreviewRenderer
             currentLivePath={currentLivePath}

--- a/src/hooks/useImageHsvPreview.ts
+++ b/src/hooks/useImageHsvPreview.ts
@@ -1,0 +1,318 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ImageData as PathImageData } from '@/types';
+import type { HsvAdjustment } from '@/lib/image';
+import { getImagePixelData } from '@/lib/imageCache';
+import { useFilesStore } from '@/context/filesStore';
+import { blobToDataUrl } from '@/lib/fileConversion';
+
+type NormalizedAdjustment = Required<Pick<HsvAdjustment, 'h' | 's' | 'v'>>;
+
+interface ActivePreviewState {
+  pathId: string;
+  ready: Promise<void> | null;
+  objectUrl: string | null;
+  lastImageData: ImageData | null;
+  lastBlob: Blob | null;
+  lastAdjustment: NormalizedAdjustment;
+}
+
+interface WorkerResponse {
+  type: 'init' | 'adjust' | 'reset' | 'error';
+  requestId: number;
+  width?: number;
+  height?: number;
+  buffer?: ArrayBuffer;
+  error?: string;
+}
+
+type WorkerMessage =
+  | Omit<import('@/workers/imageHsvWorker').InitMessage, 'requestId'>
+  | Omit<import('@/workers/imageHsvWorker').AdjustMessage, 'requestId'>
+  | Omit<import('@/workers/imageHsvWorker').ResetMessage, 'requestId'>;
+
+export interface ImageHsvPreviewController {
+  previewSrcById: Record<string, string>;
+  beginPreview: () => Promise<boolean>;
+  updatePreview: (adjustment: HsvAdjustment) => Promise<void>;
+  commitPreview: (adjustment: HsvAdjustment) => Promise<void>;
+  cancelPreview: () => Promise<void>;
+}
+
+interface UseImageHsvPreviewOptions {
+  getActiveImagePath: () => PathImageData | null;
+  applyCommittedFile: (pathId: string, fileId: string) => void;
+}
+
+const normalizeAdjustment = (adjustment: HsvAdjustment): NormalizedAdjustment => ({
+  h: adjustment.h ?? 0,
+  s: adjustment.s ?? 0,
+  v: adjustment.v ?? 0,
+});
+
+const imageDataToBlob = async (imageData: ImageData): Promise<Blob> => {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(imageData.width, imageData.height);
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      throw new Error('Failed to acquire offscreen canvas context');
+    }
+    ctx.putImageData(imageData, 0, 0);
+    return canvas.convertToBlob({ type: 'image/png' });
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = imageData.width;
+  canvas.height = imageData.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to acquire canvas context for preview conversion');
+  }
+  ctx.putImageData(imageData, 0, 0);
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('Canvas failed to produce blob'));
+      }
+    }, 'image/png');
+  });
+};
+
+export const useImageHsvPreview = ({ getActiveImagePath, applyCommittedFile }: UseImageHsvPreviewOptions): ImageHsvPreviewController => {
+  const [previewSrcById, setPreviewSrcById] = useState<Record<string, string>>({});
+  const workerRef = useRef<Worker | null>(null);
+  const requestIdRef = useRef(0);
+  const pendingResponsesRef = useRef(new Map<number, { resolve: (payload: WorkerResponse) => void; reject: (error: Error) => void }>());
+  const activePreviewRef = useRef<ActivePreviewState | null>(null);
+  const latestAdjustRequestRef = useRef<number | null>(null);
+
+  const ensureWorker = useCallback(() => {
+    if (workerRef.current) {
+      return workerRef.current;
+    }
+
+    const worker = new Worker(new URL('../workers/imageHsvWorker.ts', import.meta.url), { type: 'module' });
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const response = event.data;
+      const pending = pendingResponsesRef.current.get(response.requestId);
+      if (!pending) {
+        return;
+      }
+      pendingResponsesRef.current.delete(response.requestId);
+      if (response.type === 'error') {
+        pending.reject(new Error(response.error ?? 'Unknown worker error'));
+      } else {
+        pending.resolve(response);
+      }
+    };
+    worker.onerror = (event) => {
+      const error = event instanceof ErrorEvent ? event.error : new Error('Worker error');
+      pendingResponsesRef.current.forEach(({ reject }) => reject(error as Error));
+      pendingResponsesRef.current.clear();
+    };
+
+    workerRef.current = worker;
+    return worker;
+  }, []);
+
+  const callWorker = useCallback(
+    (message: WorkerMessage, transfer?: Transferable[]) => {
+      const worker = ensureWorker();
+      const requestId = ++requestIdRef.current;
+      const payload = { ...message, requestId } as WorkerMessage & { requestId: number };
+      const promise = new Promise<WorkerResponse>((resolve, reject) => {
+        pendingResponsesRef.current.set(requestId, { resolve, reject });
+      });
+      worker.postMessage(payload, transfer ?? []);
+      return { requestId, promise };
+    },
+    [ensureWorker],
+  );
+
+  const revokePreviewUrl = useCallback((state: ActivePreviewState | null) => {
+    if (state?.objectUrl) {
+      URL.revokeObjectURL(state.objectUrl);
+    }
+  }, []);
+
+  const cancelPreview = useCallback(async () => {
+    const active = activePreviewRef.current;
+    if (!active) {
+      return;
+    }
+
+    revokePreviewUrl(active);
+    setPreviewSrcById(prev => {
+      if (!(active.pathId in prev)) {
+        return prev;
+      }
+      const next = { ...prev };
+      delete next[active.pathId];
+      return next;
+    });
+
+    activePreviewRef.current = null;
+    latestAdjustRequestRef.current = null;
+
+    try {
+      await callWorker({ type: 'reset' }).promise;
+    } catch (error) {
+      console.error('Failed to reset HSV preview worker', error);
+    }
+  }, [callWorker, revokePreviewUrl]);
+
+  const beginPreview = useCallback(async () => {
+    const path = getActiveImagePath();
+    if (!path) {
+      return false;
+    }
+
+    const existing = activePreviewRef.current;
+    if (existing?.pathId && existing.pathId !== path.id) {
+      await cancelPreview();
+    }
+
+    try {
+      const pixelData = await getImagePixelData(path);
+      const buffer = pixelData.data.buffer.slice(0);
+      const { promise } = callWorker({
+        type: 'init',
+        width: pixelData.width,
+        height: pixelData.height,
+        buffer,
+      }, [buffer]);
+
+      const readyPromise = promise.then(() => undefined);
+      activePreviewRef.current = {
+        pathId: path.id,
+        ready: readyPromise,
+        objectUrl: null,
+        lastImageData: null,
+        lastBlob: null,
+        lastAdjustment: { h: 0, s: 0, v: 0 },
+      };
+
+      await readyPromise;
+      return true;
+    } catch (error) {
+      console.error('Failed to prepare HSV preview', error);
+      activePreviewRef.current = null;
+      return false;
+    }
+  }, [callWorker, cancelPreview, getActiveImagePath]);
+
+  const updatePreview = useCallback(async (adjustment: HsvAdjustment) => {
+    const active = activePreviewRef.current;
+    if (!active) {
+      return;
+    }
+
+    try {
+      await active.ready;
+    } catch (error) {
+      console.error('HSV preview worker initialization failed', error);
+      return;
+    }
+
+    const normalized = normalizeAdjustment(adjustment);
+    active.lastAdjustment = normalized;
+
+    const { requestId, promise } = callWorker({ type: 'adjust', adjustment: normalized });
+    latestAdjustRequestRef.current = requestId;
+
+    try {
+      const response = await promise;
+      if (latestAdjustRequestRef.current !== requestId) {
+        return;
+      }
+      if (!response.buffer || typeof response.width !== 'number' || typeof response.height !== 'number') {
+        return;
+      }
+
+      const pixels = new Uint8ClampedArray(response.buffer);
+      const imageData = new ImageData(pixels, response.width, response.height);
+      active.lastImageData = imageData;
+
+      try {
+        const blob = await imageDataToBlob(imageData);
+        active.lastBlob = blob;
+        const nextUrl = URL.createObjectURL(blob);
+        revokePreviewUrl(active);
+        active.objectUrl = nextUrl;
+        setPreviewSrcById(prev => ({ ...prev, [active.pathId]: nextUrl }));
+      } catch (error) {
+        console.error('Failed to materialize HSV preview blob', error);
+      }
+    } catch (error) {
+      console.error('Failed to update HSV preview', error);
+    }
+  }, [callWorker, revokePreviewUrl]);
+
+  const commitPreview = useCallback(async (adjustment: HsvAdjustment) => {
+    const active = activePreviewRef.current;
+    if (!active) {
+      return;
+    }
+
+    try {
+      await active.ready;
+    } catch (error) {
+      console.error('HSV preview worker initialization failed', error);
+      return;
+    }
+
+    const normalized = normalizeAdjustment(adjustment);
+    if (
+      !active.lastImageData ||
+      active.lastAdjustment.h !== normalized.h ||
+      active.lastAdjustment.s !== normalized.s ||
+      active.lastAdjustment.v !== normalized.v
+    ) {
+      await updatePreview(normalized);
+    }
+
+    const imageData = active.lastImageData;
+    if (!imageData) {
+      return;
+    }
+
+    let blob = active.lastBlob;
+    try {
+      if (!blob) {
+        blob = await imageDataToBlob(imageData);
+      }
+    } catch (error) {
+      console.error('Failed to finalize HSV preview blob', error);
+      return;
+    }
+
+    if (!blob) {
+      return;
+    }
+
+    try {
+      const dataUrl = await blobToDataUrl(blob);
+      const { fileId } = await useFilesStore.getState().ingestDataUrl(dataUrl);
+      applyCommittedFile(active.pathId, fileId);
+    } catch (error) {
+      console.error('Failed to commit HSV preview', error);
+    } finally {
+      await cancelPreview();
+    }
+  }, [applyCommittedFile, cancelPreview, updatePreview]);
+
+  useEffect(() => () => {
+    void cancelPreview();
+    workerRef.current?.terminate();
+    workerRef.current = null;
+  }, [cancelPreview]);
+
+  return useMemo(() => ({
+    previewSrcById,
+    beginPreview,
+    updatePreview,
+    commitPreview,
+    cancelPreview,
+  }), [previewSrcById, beginPreview, updatePreview, commitPreview, cancelPreview]);
+};

--- a/src/workers/imageHsvWorker.ts
+++ b/src/workers/imageHsvWorker.ts
@@ -1,0 +1,81 @@
+/// <reference lib="webworker" />
+
+import { adjustHsv, type HsvAdjustment } from '@/lib/image';
+
+export interface BaseMessage {
+  requestId: number;
+}
+
+export interface InitMessage extends BaseMessage {
+  type: 'init';
+  width: number;
+  height: number;
+  buffer: ArrayBuffer;
+}
+
+export interface AdjustMessage extends BaseMessage {
+  type: 'adjust';
+  adjustment: HsvAdjustment;
+}
+
+export interface ResetMessage extends BaseMessage {
+  type: 'reset';
+}
+
+type IncomingMessage = InitMessage | AdjustMessage | ResetMessage;
+
+type OutgoingMessage =
+  | { type: 'init'; requestId: number }
+  | { type: 'adjust'; requestId: number; width: number; height: number; buffer: ArrayBuffer }
+  | { type: 'reset'; requestId: number }
+  | { type: 'error'; requestId: number; error: string };
+
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope;
+
+let baseImage: ImageData | null = null;
+
+ctx.onmessage = (event: MessageEvent<IncomingMessage>) => {
+  const message = event.data;
+
+  try {
+    switch (message.type) {
+      case 'init': {
+        const data = new Uint8ClampedArray(message.buffer);
+        baseImage = new ImageData(data, message.width, message.height);
+        ctx.postMessage({ type: 'init', requestId: message.requestId } satisfies OutgoingMessage);
+        break;
+      }
+
+      case 'adjust': {
+        if (!baseImage) {
+          ctx.postMessage({ type: 'error', requestId: message.requestId, error: 'not-initialized' } satisfies OutgoingMessage);
+          break;
+        }
+
+        const result = adjustHsv(baseImage, message.adjustment ?? {});
+        ctx.postMessage(
+          {
+            type: 'adjust',
+            requestId: message.requestId,
+            width: result.width,
+            height: result.height,
+            buffer: result.data.buffer,
+          } satisfies OutgoingMessage,
+          [result.data.buffer]
+        );
+        break;
+      }
+
+      case 'reset': {
+        baseImage = null;
+        ctx.postMessage({ type: 'reset', requestId: message.requestId } satisfies OutgoingMessage);
+        break;
+      }
+
+      default:
+        ctx.postMessage({ type: 'error', requestId: message.requestId, error: 'unknown-message' } satisfies OutgoingMessage);
+    }
+  } catch (error) {
+    ctx.postMessage({ type: 'error', requestId: message.requestId, error: (error as Error).message } satisfies OutgoingMessage);
+  }
+};


### PR DESCRIPTION
## Summary
- add a dedicated `useImageHsvPreview` hook and worker that cache image pixels, apply HSV adjustments off the main thread, and expose live preview URLs
- integrate the preview controller into the toolbar popover, object actions, and whiteboard rendering so image previews update without mutating stored files until commit
- update path rendering to prefer live preview sources and commit the final bitmap through the files store once adjustments are confirmed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db3ff0105483238ff63182a8eb959a