### PR TITLE
fix: align magic wand toolbar controls

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -147,7 +147,7 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
       
       {cropTool === 'magic-wand' && (
         <div className="flex w-full flex-col gap-3">
-          <div className="flex flex-wrap items-center gap-3">
+          <div className="flex flex-wrap items-start gap-3">
             <div className={PANEL_CLASSES.segmentGroup}>
               <PanelButton
               type="button"
@@ -236,7 +236,7 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
             </div>
           )}
 
-          <div className={PANEL_CLASSES.segmentGroup}>
+          <div className={`${PANEL_CLASSES.segmentGroup} self-start`}>
             <PanelButton
               type="button"
               variant="unstyled"


### PR DESCRIPTION
## Summary
- align the magic wand crop toolbar control groups to the top so the two columns sit higher in the panel

## Testing
- npm run build

## Screenshots
![crop toolbar alignment](browser:/invocations/emvozdly/artifacts/artifacts/crop-toolbar.png)

------
https://chatgpt.com/codex/tasks/task_e_68db7da1efc083238fe09d1724af2e3a