### PR TITLE
fix: move effects controls above stroke options

### DIFF
--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -227,6 +227,9 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
             disabled={isGradientActive}
           />
 
+          <EffectsPopover {...props} />
+          <StylePropertiesPopover {...props} />
+
           {isDashControlVisible && (
             <DashControl {...props} />
           )}
@@ -244,9 +247,6 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
               endCoalescing={endCoalescing}
             />
           )}
-
-          <EffectsPopover {...props} />
-          <StylePropertiesPopover {...props} />
         </>
       )}
 


### PR DESCRIPTION
## Summary
- move the effects and style property popovers ahead of stroke dash and endpoint controls so the toolbar icons sit higher

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7da1efc083238fe09d1724af2e3a