### PR TITLE
Fix crop toolbar layout for magic wand controls

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -146,7 +146,7 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
       </div>
       
       {cropTool === 'magic-wand' && (
-        <div className="flex w-full flex-col gap-3">
+        <div className="flex min-w-[420px] flex-col gap-3">
           <div className="flex flex-wrap items-center gap-3">
             <div className={PANEL_CLASSES.segmentGroup}>
               <PanelButton
@@ -345,44 +345,40 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
               </>
             )}
           </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <PanelButton
+              type="button"
+              variant="unstyled"
+              onClick={applyMagicWandSelection}
+              disabled={!hasSelection}
+              className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
+            >
+              {ICONS.CHECK}
+              <span>{t('subtractSelection')}</span>
+            </PanelButton>
+            <PanelButton
+              type="button"
+              variant="unstyled"
+              onClick={cutMagicWandSelection}
+              disabled={!hasSelection}
+              className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
+            >
+              {ICONS.CUT}
+              <span>{t('cutSelection')}</span>
+            </PanelButton>
+            <PanelButton
+              type="button"
+              variant="unstyled"
+              onClick={invertMagicWandSelection}
+              className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
+              title={t('cropSelectionInvert')}
+            >
+              <span className="font-semibold">⇆</span>
+              <span>{t('cropSelectionInvert')}</span>
+            </PanelButton>
+          </div>
         </div>
       )}
-
-      {cropTool === 'magic-wand' && (
-        <div className="flex flex-wrap items-center gap-2">
-          <PanelButton
-            type="button"
-            variant="unstyled"
-            onClick={applyMagicWandSelection}
-            disabled={!hasSelection}
-            className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
-          >
-            {ICONS.CHECK}
-            <span>{t('subtractSelection')}</span>
-          </PanelButton>
-          <PanelButton
-            type="button"
-            variant="unstyled"
-            onClick={cutMagicWandSelection}
-            disabled={!hasSelection}
-            className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
-          >
-            {ICONS.CUT}
-            <span>{t('cutSelection')}</span>
-          </PanelButton>
-          <PanelButton
-            type="button"
-            variant="unstyled"
-            onClick={invertMagicWandSelection}
-            className={`${textButtonBase} bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:opacity-90`}
-            title={t('cropSelectionInvert')}
-          >
-            <span className="font-semibold">⇆</span>
-            <span>{t('cropSelectionInvert')}</span>
-          </PanelButton>
-        </div>
-      )}
-
       <div className="flex flex-wrap items-center justify-end gap-2">
         {cropTool === 'crop' && (
           <PanelButton


### PR DESCRIPTION
## Summary
- keep the magic-wand controls in a fixed-width column so they align with the crop/cut toggles
- integrate the apply/cut/invert actions into the same column instead of rendering in a wrapped row

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db7da1efc083238fe09d1724af2e3a