### PR TITLE
fix: reposition magic wand brush size control

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -211,31 +211,6 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
             </PanelButton>
           </div>
 
-          {cropSelectionMode === 'brush' && (
-            <div className="flex items-center gap-2">
-              <label
-                className="text-sm text-[var(--text-secondary)]"
-                htmlFor="magic-wand-brush-size"
-              >
-                {t('cropMagicWandBrushSize')}
-              </label>
-              <div className={`${PANEL_CLASSES.inputWrapper} w-20`}>
-                <input
-                  id="magic-wand-brush-size"
-                  type="number"
-                  min={brushSizeMin}
-                  max={brushSizeMax}
-                  value={cropBrushSize}
-                  onChange={(event) => handleBrushSizeChange(Number(event.target.value))}
-                  inputMode="numeric"
-                  aria-label={t('cropMagicWandBrushSize')}
-                  className={`${PANEL_CLASSES.input} hide-spinners`}
-                />
-                <span className={PANEL_CLASSES.inputSuffix}>px</span>
-              </div>
-            </div>
-          )}
-
           <div className={PANEL_CLASSES.segmentGroup}>
             <PanelButton
               type="button"
@@ -283,9 +258,33 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
               <span>{t('cropSelectionSubtract')}</span>
             </PanelButton>
           </div>
-          </div>
+          {cropSelectionMode === 'brush' && (
+            <div className="flex items-center gap-2">
+              <label
+                className="text-sm text-[var(--text-secondary)]"
+                htmlFor="magic-wand-brush-size"
+              >
+                {t('cropMagicWandBrushSize')}
+              </label>
+              <div className={`${PANEL_CLASSES.inputWrapper} w-20`}>
+                <input
+                  id="magic-wand-brush-size"
+                  type="number"
+                  min={brushSizeMin}
+                  max={brushSizeMax}
+                  value={cropBrushSize}
+                  onChange={(event) => handleBrushSizeChange(Number(event.target.value))}
+                  inputMode="numeric"
+                  aria-label={t('cropMagicWandBrushSize')}
+                  className={`${PANEL_CLASSES.input} hide-spinners`}
+                />
+                <span className={PANEL_CLASSES.inputSuffix}>px</span>
+              </div>
+            </div>
+          )}
+        </div>
 
-          <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-wrap items-center gap-3">
             <label
               className="flex items-center gap-2 text-sm text-[var(--text-secondary)]"
               htmlFor="magic-wand-feather-radius"


### PR DESCRIPTION
## Summary
- reposition the magic-wand brush size input below the selection operation buttons for a more intuitive layout when using the brush

## Motivation
- the brush size field should appear lower in the cutout toolbar to match the desired UI layout

## Testing
- npm run build

## Screenshots
- ![Updated crop toolbar](browser:/invocations/hfrwgapn/artifacts/artifacts/crop-toolbar.png)


------
https://chatgpt.com/codex/tasks/task_e_68dc7b3630088323a2183d85eda27b6f