### PR TITLE
fix: reposition crop brush size control

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -211,31 +211,6 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
             </PanelButton>
           </div>
 
-          {cropSelectionMode === 'brush' && (
-            <div className="flex items-center gap-2">
-              <label
-                className="text-sm text-[var(--text-secondary)]"
-                htmlFor="magic-wand-brush-size"
-              >
-                {t('cropMagicWandBrushSize')}
-              </label>
-              <div className={`${PANEL_CLASSES.inputWrapper} w-20`}>
-                <input
-                  id="magic-wand-brush-size"
-                  type="number"
-                  min={brushSizeMin}
-                  max={brushSizeMax}
-                  value={cropBrushSize}
-                  onChange={(event) => handleBrushSizeChange(Number(event.target.value))}
-                  inputMode="numeric"
-                  aria-label={t('cropMagicWandBrushSize')}
-                  className={`${PANEL_CLASSES.input} hide-spinners`}
-                />
-                <span className={PANEL_CLASSES.inputSuffix}>px</span>
-              </div>
-            </div>
-          )}
-
           <div className={PANEL_CLASSES.segmentGroup}>
             <PanelButton
               type="button"
@@ -286,6 +261,29 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
+            {cropSelectionMode === 'brush' && (
+              <label
+                className="flex items-center gap-2 text-sm text-[var(--text-secondary)]"
+                htmlFor="magic-wand-brush-size"
+              >
+                {t('cropMagicWandBrushSize')}
+                <div className={`${PANEL_CLASSES.inputWrapper} w-20`}>
+                  <input
+                    id="magic-wand-brush-size"
+                    type="number"
+                    min={brushSizeMin}
+                    max={brushSizeMax}
+                    value={cropBrushSize}
+                    onChange={(event) => handleBrushSizeChange(Number(event.target.value))}
+                    inputMode="numeric"
+                    aria-label={t('cropMagicWandBrushSize')}
+                    className={`${PANEL_CLASSES.input} hide-spinners`}
+                  />
+                  <span className={PANEL_CLASSES.inputSuffix}>px</span>
+                </div>
+              </label>
+            )}
+
             <label
               className="flex items-center gap-2 text-sm text-[var(--text-secondary)]"
               htmlFor="magic-wand-feather-radius"


### PR DESCRIPTION
## Summary
- move the magic wand brush size control below the mode selectors so it appears with the other numeric options

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dc7b3630088323a2183d85eda27b6f