### PR TITLE
feat(image): move hsv adjustments to selection toolbar

### DIFF
--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -6,11 +6,13 @@
 import React, { Fragment, useState } from 'react';
 import { Popover, Transition, RadioGroup } from '@headlessui/react';
 import PanelButton from '@/components/PanelButton';
+import type { ImageHsvPreviewController } from '@/hooks/useImageHsvPreview';
 import { PANEL_CLASSES } from './panelStyles';
 import { ICONS } from '../constants';
 import type { SelectionMode, Alignment, DistributeMode } from '../types';
 import { Slider } from './side-toolbar';
 import { TraceImagePopover } from './TraceImagePopover';
+import { ImageHsvPopover } from './side-toolbar/ImageHsvPopover';
 import type { TraceOptions } from '../types';
 import { useTranslation } from 'react-i18next';
 
@@ -30,6 +32,8 @@ interface SelectionToolbarProps {
   onMask: () => void;
   isTraceable: boolean;
   onTraceImage: (options: TraceOptions) => void;
+  isImageEditable: boolean;
+  imageHsvPreview: ImageHsvPreviewController;
 }
 
 
@@ -47,6 +51,8 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
   onMask,
   isTraceable,
   onTraceImage,
+  isImageEditable,
+  imageHsvPreview,
 }) => {
   const { t } = useTranslation();
   const [simplifyValue, setSimplifyValue] = useState(0);
@@ -141,6 +147,15 @@ export const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
       )}
 
       {isTraceable && <TraceImagePopover onTrace={onTraceImage} />}
+
+      {isImageEditable && (
+        <ImageHsvPopover
+          beginPreview={imageHsvPreview.beginPreview}
+          updatePreview={imageHsvPreview.updatePreview}
+          commitPreview={imageHsvPreview.commitPreview}
+          cancelPreview={imageHsvPreview.cancelPreview}
+        />
+      )}
 
       {canAlignOrDistribute && (
           <Popover className="relative">

--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -7,12 +7,10 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Tool, AnyPath, VectorPathData, GradientFill } from '../types';
-import type { ImageHsvPreviewController } from '@/hooks/useImageHsvPreview';
 import { ICONS } from '../constants';
 import PanelButton from '@/components/PanelButton';
 
 import { NumericInput, ColorControl, FillStyleControl, EndpointPopover, DashControl, StylePropertiesPopover, EffectsPopover, GradientFillPopover } from './side-toolbar';
-import { ImageHsvPopover } from './side-toolbar/ImageHsvPopover';
 
 interface SideToolbarProps {
   tool: Tool;
@@ -82,7 +80,6 @@ interface SideToolbarProps {
   setShadowBlur: (sb: number) => void;
   shadowColor: string;
   setShadowColor: (sc: string) => void;
-  imageHsvPreview: Pick<ImageHsvPreviewController, 'beginPreview' | 'updatePreview' | 'commitPreview'>;
 }
 
 /**
@@ -105,7 +102,6 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
     beginCoalescing, endCoalescing,
     onToggleStyleLibrary,
     isStyleLibraryOpen,
-    imageHsvPreview,
   } = props;
 
   const { t } = useTranslation();
@@ -233,16 +229,6 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
 
           {isEndpointControlVisible && (
             <EndpointPopover {...props} />
-          )}
-
-          {firstSelectedPath?.tool === 'image' && (
-            <ImageHsvPopover
-              beginPreview={imageHsvPreview.beginPreview}
-              updatePreview={imageHsvPreview.updatePreview}
-              commitPreview={imageHsvPreview.commitPreview}
-              beginCoalescing={beginCoalescing}
-              endCoalescing={endCoalescing}
-            />
           )}
 
           <EffectsPopover {...props} />

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -85,6 +85,7 @@ export const CanvasOverlays: React.FC = () => {
         handleDistribute,
         handleBooleanOperation,
         handleTraceImage,
+        handleAdjustImageHsv,
         confirmationDialog,
         hideConfirmation,
         croppingState,
@@ -124,6 +125,11 @@ export const CanvasOverlays: React.FC = () => {
         const path = paths.find((p: AnyPath) => p.id === selectedPathIds[0]);
         return path?.tool === 'image';
     }, [paths, selectedPathIds]);
+
+    const isImageEditable = useMemo(
+        () => selectedPathIds.length === 1 && paths.some((p: AnyPath) => p.id === selectedPathIds[0] && p.tool === 'image'),
+        [paths, selectedPathIds]
+    );
 
     /**
      * 构建上下文菜单的操作列表。
@@ -188,6 +194,8 @@ export const CanvasOverlays: React.FC = () => {
                         onMask={handleMask}
                         isTraceable={isTraceable}
                         onTraceImage={handleTraceImage}
+                        isImageEditable={isImageEditable}
+                        imageHsvPreview={handleAdjustImageHsv}
                     />
                 </div>
             )}

--- a/src/components/layout/SideToolbarPanel.tsx
+++ b/src/components/layout/SideToolbarPanel.tsx
@@ -13,7 +13,7 @@ import PanelButton from '@/components/PanelButton';
  */
 export const SideToolbarPanel: React.FC = () => {
     const store = useAppContext();
-    const { isSideToolbarCollapsed, setIsSideToolbarCollapsed, handleToggleStyleLibrary, handleAdjustImageHsv } = store;
+    const { isSideToolbarCollapsed, setIsSideToolbarCollapsed, handleToggleStyleLibrary } = store;
     
     return (
         <>
@@ -35,7 +35,7 @@ export const SideToolbarPanel: React.FC = () => {
                     transform: `translateY(-50%) ${isSideToolbarCollapsed ? 'translateX(calc(100% + 1rem))' : 'translateX(0)'}`,
                 }}
             >
-                <SideToolbar {...store} onToggleStyleLibrary={handleToggleStyleLibrary} imageHsvPreview={handleAdjustImageHsv} />
+                <SideToolbar {...store} onToggleStyleLibrary={handleToggleStyleLibrary} />
             </div>
         </>
     );

--- a/src/components/side-toolbar/ImageHsvPopover.tsx
+++ b/src/components/side-toolbar/ImageHsvPopover.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useRef, useState } from 'react';
+import React, { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Popover, Transition } from '@headlessui/react';
 import { ICONS } from '@/constants';
@@ -9,92 +9,166 @@ interface ImageHsvPopoverProps {
   beginPreview: () => Promise<boolean>;
   updatePreview: (adj: HsvAdjustment) => Promise<void>;
   commitPreview: (adj: HsvAdjustment) => Promise<void>;
-  beginCoalescing: () => void;
-  endCoalescing: () => void;
+  cancelPreview: () => Promise<void>;
+  disabled?: boolean;
 }
 
-export const ImageHsvPopover: React.FC<ImageHsvPopoverProps> = ({ beginPreview, updatePreview, commitPreview, beginCoalescing, endCoalescing }) => {
+const DEFAULT_ADJUSTMENT: HsvAdjustment = { h: 0, s: 0, v: 0 };
+
+interface PopoverContentProps extends ImageHsvPopoverProps {
+  open: boolean;
+  close: () => void;
+  title: string;
+  hueLabel: string;
+  saturationLabel: string;
+  valueLabel: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
+const ImageHsvPopoverContent: React.FC<PopoverContentProps> = ({
+  open,
+  close,
+  beginPreview,
+  updatePreview,
+  commitPreview,
+  cancelPreview,
+  title,
+  hueLabel,
+  saturationLabel,
+  valueLabel,
+  confirmLabel,
+  cancelLabel,
+}) => {
   const [h, setH] = useState(0);
   const [s, setS] = useState(0);
   const [v, setV] = useState(0);
-  const latestAdjustmentRef = useRef<HsvAdjustment>({ h: 0, s: 0, v: 0 });
-  const { t } = useTranslation();
-  const title = t('sideToolbar.imageHsv.title');
-  const hueLabel = t('sideToolbar.imageHsv.hue');
-  const saturationLabel = t('sideToolbar.imageHsv.saturation');
-  const valueLabel = t('sideToolbar.imageHsv.value');
+  const beginPromiseRef = useRef<Promise<boolean> | null>(null);
+  const latestAdjustmentRef = useRef<HsvAdjustment>({ ...DEFAULT_ADJUSTMENT });
+  const committedRef = useRef(false);
+
+  const ensurePreviewReady = useCallback(() => {
+    if (!beginPromiseRef.current) {
+      beginPromiseRef.current = beginPreview().catch(error => {
+        console.error('Failed to begin HSV preview', error);
+        return false;
+      });
+    }
+    return beginPromiseRef.current;
+  }, [beginPreview]);
+
+  const resetState = useCallback(() => {
+    setH(0);
+    setS(0);
+    setV(0);
+    latestAdjustmentRef.current = { ...DEFAULT_ADJUSTMENT };
+  }, []);
 
   useEffect(() => {
-    latestAdjustmentRef.current = { h, s, v };
-  }, [h, s, v]);
+    if (open) {
+      committedRef.current = false;
+      beginPromiseRef.current = null;
+      resetState();
+      void ensurePreviewReady();
+      return;
+    }
 
-  const createSliderHandler = (applyFraction: (fraction: number, current: { h: number; s: number; v: number }) => { h: number; s: number; v: number }) => (e: React.PointerEvent<HTMLDivElement>) => {
-    if (e.button !== 0) return;
-    beginCoalescing();
-    const slider = e.currentTarget;
-    slider.setPointerCapture(e.pointerId);
-    const rect = slider.getBoundingClientRect();
+    beginPromiseRef.current = null;
+    if (!committedRef.current) {
+      void cancelPreview();
+    }
+    committedRef.current = false;
+    resetState();
+  }, [open, cancelPreview, ensurePreviewReady, resetState]);
 
-    const beginPromise = beginPreview().catch((error) => {
-      console.error('Failed to begin HSV preview', error);
-      return false;
-    });
-
-    const updateFromEvent = (clientX: number) => {
-      const clamped = Math.max(0, Math.min(clientX - rect.left, rect.width));
-      const fraction = rect.width === 0 ? 0 : clamped / rect.width;
-      const next = applyFraction(fraction, {
-        h: typeof latestAdjustmentRef.current.h === 'number' ? latestAdjustmentRef.current.h : h,
-        s: typeof latestAdjustmentRef.current.s === 'number' ? latestAdjustmentRef.current.s : s,
-        v: typeof latestAdjustmentRef.current.v === 'number' ? latestAdjustmentRef.current.v : v,
-      });
-      setH(next.h);
-      setS(next.s);
-      setV(next.v);
-      latestAdjustmentRef.current = next;
-
-      void (async () => {
-        const ready = await beginPromise;
-        if (!ready) return;
-        try {
-          await updatePreview(next);
-        } catch (error) {
-          console.error('Failed to update HSV preview', error);
-        }
-      })();
+  const applyAdjustment = useCallback((next: HsvAdjustment) => {
+    setH(next.h ?? 0);
+    setS(next.s ?? 0);
+    setV(next.v ?? 0);
+    latestAdjustmentRef.current = {
+      h: typeof next.h === 'number' ? next.h : 0,
+      s: typeof next.s === 'number' ? next.s : 0,
+      v: typeof next.v === 'number' ? next.v : 0,
     };
 
-    updateFromEvent(e.nativeEvent.clientX);
+    void (async () => {
+      const ready = await ensurePreviewReady();
+      if (!ready) {
+        return;
+      }
+      try {
+        await updatePreview(latestAdjustmentRef.current);
+      } catch (error) {
+        console.error('Failed to update HSV preview', error);
+      }
+    })();
+  }, [ensurePreviewReady, updatePreview]);
 
-    const handleMove = (ev: PointerEvent) => updateFromEvent(ev.clientX);
+  const createSliderHandler = useCallback((
+    applyFraction: (
+      fraction: number,
+      current: { h: number; s: number; v: number },
+    ) => { h: number; s: number; v: number },
+  ) => (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) {
+      return;
+    }
+    const slider = event.currentTarget;
+    slider.setPointerCapture(event.pointerId);
+    const rect = slider.getBoundingClientRect();
+
+    const updateFromClientX = (clientX: number) => {
+      const clamped = Math.max(0, Math.min(clientX - rect.left, rect.width));
+      const fraction = rect.width === 0 ? 0 : clamped / rect.width;
+      const current = latestAdjustmentRef.current;
+      const next = applyFraction(fraction, {
+        h: typeof current.h === 'number' ? current.h : h,
+        s: typeof current.s === 'number' ? current.s : s,
+        v: typeof current.v === 'number' ? current.v : v,
+      });
+      applyAdjustment(next);
+    };
+
+    updateFromClientX(event.nativeEvent.clientX);
+
+    const handleMove = (ev: PointerEvent) => updateFromClientX(ev.clientX);
     const handleUp = () => {
-      slider.releasePointerCapture(e.pointerId);
+      slider.releasePointerCapture(event.pointerId);
       document.removeEventListener('pointermove', handleMove);
       document.removeEventListener('pointerup', handleUp);
       document.removeEventListener('pointercancel', handleUp);
-      const finalAdjustment = latestAdjustmentRef.current;
-      void (async () => {
-        try {
-          const ready = await beginPromise;
-          if (ready) {
-            await commitPreview({
-              h: typeof finalAdjustment.h === 'number' ? finalAdjustment.h : h,
-              s: typeof finalAdjustment.s === 'number' ? finalAdjustment.s : s,
-              v: typeof finalAdjustment.v === 'number' ? finalAdjustment.v : v,
-            });
-          }
-        } catch (error) {
-          console.error('Failed to commit HSV preview', error);
-        } finally {
-          endCoalescing();
-        }
-      })();
     };
 
     document.addEventListener('pointermove', handleMove);
     document.addEventListener('pointerup', handleUp);
     document.addEventListener('pointercancel', handleUp);
-  };
+  }, [applyAdjustment, h, s, v]);
+
+  const handleCancel = useCallback(() => {
+    committedRef.current = false;
+    void cancelPreview();
+    close();
+  }, [cancelPreview, close]);
+
+  const handleConfirm = useCallback(async () => {
+    const hasChanges = h !== 0 || s !== 0 || v !== 0;
+    if (!hasChanges) {
+      close();
+      return;
+    }
+
+    try {
+      const ready = await ensurePreviewReady();
+      if (!ready) {
+        return;
+      }
+      await commitPreview(latestAdjustmentRef.current);
+      committedRef.current = true;
+      close();
+    } catch (error) {
+      console.error('Failed to commit HSV preview', error);
+    }
+  }, [close, commitPreview, ensurePreviewReady, h, s, v]);
 
   const hPos = ((h + 180) / 360) * 100;
   const sPos = ((s + 100) / 200) * 100;
@@ -102,70 +176,149 @@ export const ImageHsvPopover: React.FC<ImageHsvPopoverProps> = ({ beginPreview, 
   const baseHue = (h + 360) % 360;
   const baseS = Math.min(Math.max(0, 100 + s), 200) / 2;
   const baseV = Math.min(Math.max(0, 100 + v), 200) / 2;
+
   const hueBg = 'linear-gradient(to right, hsl(0,100%,50%), hsl(60,100%,50%), hsl(120,100%,50%), hsl(180,100%,50%), hsl(240,100%,50%), hsl(300,100%,50%), hsl(360,100%,50%))';
   const satBg = `linear-gradient(to right, hsl(${baseHue},0%,${baseV}%), hsl(${baseHue},100%,${baseV}%))`;
   const valBg = `linear-gradient(to right, hsl(${baseHue},${baseS}%,0%), hsl(${baseHue},${baseS}%,50%), hsl(${baseHue},${baseS}%,100%))`;
+  const hasChanges = h !== 0 || s !== 0 || v !== 0;
 
   return (
-    <div className="flex flex-col items-center w-14" title={title}>
-      <Popover className="relative">
-        <Popover.Button
-          as={PanelButton}
-          variant="unstyled"
-          className="p-2 h-9 w-9 rounded-lg flex items-center justify-center transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]"
-          title={title}
-        >
-          {ICONS.HSV}
-        </Popover.Button>
-        <Transition as={Fragment} enter="transition ease-out duration-200" enterFrom="opacity-0 translate-y-1" enterTo="opacity-100 translate-y-0" leave="transition ease-in duration-150" leaveFrom="opacity-100 translate-y-0" leaveTo="opacity-0 translate-y-1">
-          <Popover.Panel className="absolute bottom-0 mb-0 right-full mr-2 w-64 bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] z-20 p-4">
-            <div className="space-y-4">
-              <h3 className="text-sm font-bold text-center text-[var(--text-primary)]">{title}</h3>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-primary)]">{hueLabel}</label>
-                <div
-                  className="relative h-4 cursor-pointer"
-                  onPointerDown={createSliderHandler((fraction, current) => ({
-                    h: Math.round(fraction * 360) - 180,
-                    s: current.s,
-                    v: current.v,
-                  }))}
-                >
-                  <div className="w-full h-2 rounded-lg absolute top-1/2 -translate-y-1/2" style={{ background: hueBg }} />
-                  <div className="absolute w-4 h-4 -translate-y-1/2 -translate-x-1/2 top-1/2 rounded-full bg-white shadow-md ring-1 ring-white/20" style={{ left: `${hPos}%` }} />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-primary)]">{saturationLabel}</label>
-                <div
-                  className="relative h-4 cursor-pointer"
-                  onPointerDown={createSliderHandler((fraction, current) => ({
-                    h: current.h,
-                    s: Math.round(fraction * 200) - 100,
-                    v: current.v,
-                  }))}
-                >
-                  <div className="w-full h-2 rounded-lg absolute top-1/2 -translate-y-1/2" style={{ background: satBg }} />
-                  <div className="absolute w-4 h-4 -translate-y-1/2 -translate-x-1/2 top-1/2 rounded-full shadow-md ring-1 ring-white/20" style={{ left: `${sPos}%`, backgroundColor: `hsl(${baseHue}, ${sPos}%, ${baseV}%)` }} />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <label className="text-sm font-medium text-[var(--text-primary)]">{valueLabel}</label>
-                <div
-                  className="relative h-4 cursor-pointer"
-                  onPointerDown={createSliderHandler((fraction, current) => ({
-                    h: current.h,
-                    s: current.s,
-                    v: Math.round(fraction * 200) - 100,
-                  }))}
-                >
-                  <div className="w-full h-2 rounded-lg absolute top-1/2 -translate-y-1/2" style={{ background: valBg }} />
-                  <div className="absolute w-4 h-4 -translate-y-1/2 -translate-x-1/2 top-1/2 rounded-full shadow-md ring-1 ring-white/20" style={{ left: `${vPos}%`, backgroundColor: `hsl(${baseHue}, ${baseS}%, ${vPos}%)` }} />
-                </div>
-              </div>
+    <div className="space-y-5">
+      <div className="space-y-4">
+        <h3 className="text-sm font-bold text-center text-[var(--text-primary)]">{title}</h3>
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-[var(--text-primary)]">{hueLabel}</label>
+            <div
+              className="relative h-4 cursor-pointer"
+              onPointerDown={createSliderHandler((fraction, current) => ({
+                h: Math.round(fraction * 360) - 180,
+                s: current.s,
+                v: current.v,
+              }))}
+            >
+              <div className="w-full h-2 rounded-lg absolute top-1/2 -translate-y-1/2" style={{ background: hueBg }} />
+              <div
+                className="absolute w-4 h-4 -translate-y-1/2 -translate-x-1/2 top-1/2 rounded-full bg-white shadow-md ring-1 ring-white/20"
+                style={{ left: `${hPos}%` }}
+              />
             </div>
-          </Popover.Panel>
-        </Transition>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-[var(--text-primary)]">{saturationLabel}</label>
+            <div
+              className="relative h-4 cursor-pointer"
+              onPointerDown={createSliderHandler((fraction, current) => ({
+                h: current.h,
+                s: Math.round(fraction * 200) - 100,
+                v: current.v,
+              }))}
+            >
+              <div className="w-full h-2 rounded-lg absolute top-1/2 -translate-y-1/2" style={{ background: satBg }} />
+              <div
+                className="absolute w-4 h-4 -translate-y-1/2 -translate-x-1/2 top-1/2 rounded-full shadow-md ring-1 ring-white/20"
+                style={{ left: `${sPos}%`, backgroundColor: `hsl(${baseHue}, ${sPos}%, ${baseV}%)` }}
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-[var(--text-primary)]">{valueLabel}</label>
+            <div
+              className="relative h-4 cursor-pointer"
+              onPointerDown={createSliderHandler((fraction, current) => ({
+                h: current.h,
+                s: current.s,
+                v: Math.round(fraction * 200) - 100,
+              }))}
+            >
+              <div className="w-full h-2 rounded-lg absolute top-1/2 -translate-y-1/2" style={{ background: valBg }} />
+              <div
+                className="absolute w-4 h-4 -translate-y-1/2 -translate-x-1/2 top-1/2 rounded-full shadow-md ring-1 ring-white/20"
+                style={{ left: `${vPos}%`, backgroundColor: `hsl(${baseHue}, ${baseS}%, ${vPos}%)` }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="flex-1 h-9 rounded-md bg-[var(--ui-element-bg)] text-sm font-medium text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)] transition-colors"
+        >
+          {cancelLabel}
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!hasChanges}
+          className="flex-1 h-9 rounded-md text-sm font-medium transition-colors bg-[var(--accent-bg)] text-[var(--accent-primary)] hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const ImageHsvPopover: React.FC<ImageHsvPopoverProps> = (props) => {
+  const { disabled } = props;
+  const { t } = useTranslation();
+  const title = t('sideToolbar.imageHsv.title');
+  const hueLabel = t('sideToolbar.imageHsv.hue');
+  const saturationLabel = t('sideToolbar.imageHsv.saturation');
+  const valueLabel = t('sideToolbar.imageHsv.value');
+  const confirmLabel = t('confirm');
+  const cancelLabel = t('cancel');
+
+  const panelWidthClass = 'w-72';
+
+  return (
+    <div className="flex flex-col items-center w-[34px]" title={title}>
+      <Popover className="relative">
+        {({ open, close }) => (
+          <>
+            <Popover.Button
+              as={PanelButton}
+              variant="unstyled"
+              disabled={disabled}
+              className={`flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors ${
+                disabled
+                  ? 'opacity-40 cursor-not-allowed'
+                  : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
+              }`}
+              title={title}
+            >
+              {ICONS.HSV}
+            </Popover.Button>
+            <Transition
+              as={Fragment}
+              enter="transition ease-out duration-200"
+              enterFrom="opacity-0 translate-y-1"
+              enterTo="opacity-100 translate-y-0"
+              leave="transition ease-in duration-150"
+              leaveFrom="opacity-100 translate-y-0"
+              leaveTo="opacity-0 translate-y-1"
+            >
+              {open && (
+                <Popover.Panel className={`absolute bottom-full mb-3 left-1/2 -translate-x-1/2 ${panelWidthClass} bg-[var(--ui-popover-bg)] backdrop-blur-lg rounded-xl shadow-lg border border-[var(--ui-panel-border)] z-30 p-5`}>
+                  <ImageHsvPopoverContent
+                    {...props}
+                    open={open}
+                    close={close}
+                    title={title}
+                    hueLabel={hueLabel}
+                    saturationLabel={saturationLabel}
+                    valueLabel={valueLabel}
+                    confirmLabel={confirmLabel}
+                    cancelLabel={cancelLabel}
+                  />
+                </Popover.Panel>
+              )}
+            </Transition>
+          </>
+        )}
       </Popover>
     </div>
   );


### PR DESCRIPTION
## Summary
- move the HSV adjustment control from the side toolbar into the selection toolbar shown for images
- gate HSV tweaks behind an explicit preview/confirm flow so the original image is untouched until confirmation
- remove the unused side-toolbar wiring and pass the preview controller through the selection toolbar instead

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc8413ee8083239ed3dcf2a7b2fe98