### PR TITLE
fix: keep numeric input display in sync during wheel adjustments

### DIFF
--- a/src/components/side-toolbar/NumericInput.tsx
+++ b/src/components/side-toolbar/NumericInput.tsx
@@ -65,6 +65,7 @@ export const NumericInput: React.FC<NumericInputProps> = React.memo(({
 
     const newValue = Math.max(displayMin, Math.min(displayMax, currentValue + (increment * step)));
     setValue(valueTransformer.fromDisplay(newValue));
+    setLocalValue(Math.round(newValue).toString());
   };
 
   const handleWheel = useWheelCoalescer(beginCoalescing, endCoalescing);


### PR DESCRIPTION
## Summary
- update the numeric input component to update its local display state when scrolling to change values
- ensure wheel-based adjustments remain visible even while the field retains focus

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dcc209bb108323987654dd8759f707