### PR TITLE
fix(color-picker): align eyedropper control height

### DIFF
--- a/src/components/ColorPicker.tsx
+++ b/src/components/ColorPicker.tsx
@@ -229,7 +229,7 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ color, onChange, onInt
                 <PanelButton
                     variant="unstyled"
                     onClick={handleEyeDropper}
-                    className="w-9 h-9 flex-shrink-0 flex items-center justify-center rounded-lg text-[var(--text-secondary)] bg-white/10 hover:bg-white/20 transition-colors"
+                    className="w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-md text-[var(--text-secondary)] bg-white/10 hover:bg-white/20 transition-colors"
                     title="Pick color from screen"
                 >
                     {ICONS.EYEDROPPER}


### PR DESCRIPTION
## Summary
- align the color picker eyedropper control size with the adjacent input so the row has a consistent height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc644ac2c832381d1ecf8573d7857