### PR TITLE
feat: require Ctrl+Shift for free transform

### DIFF
--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -159,7 +159,8 @@ const ShapeControls: React.FC<{
         }
 
         const handleKeyChange = (event: KeyboardEvent) => {
-            const next = event.ctrlKey || event.metaKey;
+            const hasPrimaryModifier = event.ctrlKey || event.metaKey;
+            const next = hasPrimaryModifier && event.shiftKey;
             setIsSkewModifierActive(prev => (prev === next ? prev : next));
         };
 

--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -254,7 +254,8 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
                 const isSimpleShape = selected.length === 1 && (path.tool === 'rectangle' || path.tool === 'ellipse' || path.tool === 'image' || path.tool === 'polygon' || path.tool === 'frame');
 
                 if (isSimpleShape) {
-                    if (e.ctrlKey || e.metaKey) {
+                    const hasPrimaryModifier = e.ctrlKey || e.metaKey;
+                    if (hasPrimaryModifier && e.shiftKey) {
                         setDragState({ type: 'skew', pathId: path.id, handle, originalPath: path as any, initialPointerPos: point });
                     } else {
                         setDragState({ type: 'resize', pathId: path.id, handle, originalPath: path as any, initialPointerPos: point });


### PR DESCRIPTION
## Summary
- require holding Ctrl/Cmd together with Shift to activate free transform/skew mode on shape bounding boxes
- update keyboard modifier tracking so skew cursors only appear when both modifiers are pressed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dccad1d5748323bc2f87d38508e22f