### PR TITLE
fix: set main menu default width to 200

### DIFF
--- a/src/components/layout/MainMenuPanel.tsx
+++ b/src/components/layout/MainMenuPanel.tsx
@@ -8,6 +8,7 @@ import { MainMenu } from '../MainMenu';
 import type { AnyPath } from '@/types';
 import { getPathsBoundingBox, getPathBoundingBox } from '@/lib/drawing';
 import { collectPathsByIds } from '@/lib/pathTree';
+import { DEFAULT_MAIN_MENU_WIDTH } from '@/constants';
 
 export const MainMenuPanel: React.FC = () => {
     const {
@@ -108,8 +109,8 @@ export const MainMenuPanel: React.FC = () => {
         target.setPointerCapture(e.pointerId);
 
         const startX = e.clientX;
-        const startWidth = mainMenuWidth;
-        const MIN_WIDTH = 200;
+        const startWidth = mainMenuWidth ?? DEFAULT_MAIN_MENU_WIDTH;
+        const MIN_WIDTH = DEFAULT_MAIN_MENU_WIDTH;
         const MAX_WIDTH = 500;
 
         const handlePointerMove = (moveEvent: PointerEvent) => {
@@ -130,17 +131,19 @@ export const MainMenuPanel: React.FC = () => {
         window.addEventListener('pointerup', handlePointerUp);
     };
 
+    const effectiveWidth = mainMenuWidth ?? DEFAULT_MAIN_MENU_WIDTH;
+
     return (
         <div
             className="relative flex-shrink-0 overflow-hidden"
             style={{
-                width: isMainMenuCollapsed ? '0px' : `${mainMenuWidth}px`,
+                width: isMainMenuCollapsed ? '0px' : `${effectiveWidth}px`,
                 transition: isResizing ? 'none' : 'width 300ms ease-in-out'
             }}
         >
             <div
                 className="h-full"
-                style={{ width: `${mainMenuWidth}px` }}
+                style={{ width: `${effectiveWidth}px` }}
             >
                 <MainMenu
                     onSave={handleSaveFile}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -42,6 +42,8 @@ export const COLORS = [
 export const CONTROL_BUTTON_CLASS =
   'flex items-center justify-center h-[34px] w-[34px] rounded-lg transition-colors text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]';
 
+export const DEFAULT_MAIN_MENU_WIDTH = 200;
+
 export const TIMELINE_PANEL_HEIGHT_VAR = 'var(--timeline-panel-height, 0px)';
 export const TIMELINE_PANEL_COLLAPSED_OFFSET = '1rem';
 export const TIMELINE_PANEL_BOTTOM_OFFSET = `calc(${TIMELINE_PANEL_HEIGHT_VAR} + ${TIMELINE_PANEL_COLLAPSED_OFFSET})`;

--- a/src/context/uiStore.ts
+++ b/src/context/uiStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { getLocalStorageItem } from '@/lib/utils';
 import type { PngExportOptions } from '@/types';
+import { DEFAULT_MAIN_MENU_WIDTH } from '@/constants';
 
 export interface UiState {
   isGridVisible: boolean;
@@ -37,7 +38,7 @@ const initialUiState = (): UiState => ({
   isStatusBarCollapsed: getLocalStorageItem('whiteboard_isStatusBarCollapsed', isMobile),
   isSideToolbarCollapsed: getLocalStorageItem('whiteboard_isSideToolbarCollapsed', isMobile),
   isMainMenuCollapsed: getLocalStorageItem('whiteboard_isMainMenuCollapsed', isMobile),
-  mainMenuWidth: getLocalStorageItem('whiteboard_mainMenuWidth', 200),
+  mainMenuWidth: getLocalStorageItem('whiteboard_mainMenuWidth', DEFAULT_MAIN_MENU_WIDTH),
   pngExportOptions: getLocalStorageItem('whiteboard_pngExportOptions', { scale: 1, highQuality: true, transparentBg: true }),
   isStyleLibraryOpen: false,
   styleLibraryPosition: { x: 0, y: 0 },

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -16,6 +16,7 @@ import { usePointerInteraction } from './usePointerInteraction';
 import { useAppActions } from './actions/useAppActions';
 import { useGroupIsolation } from './useGroupIsolation';
 import { getLocalStorageItem } from '../lib/utils';
+import { DEFAULT_MAIN_MENU_WIDTH } from '@/constants';
 import * as idb from '../lib/indexedDB';
 import type { FileSystemFileHandle } from 'wicg-file-system-access';
 import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, PngExportOptions, ImageData as PathImageData, BBox, Point, GroupData } from '../types';
@@ -253,7 +254,7 @@ const getInitialUiState = (): UiState => {
     isStatusBarCollapsed: getLocalStorageItem('whiteboard_isStatusBarCollapsed', isMobile),
     isSideToolbarCollapsed: getLocalStorageItem('whiteboard_isSideToolbarCollapsed', isMobile),
     isMainMenuCollapsed: getLocalStorageItem('whiteboard_isMainMenuCollapsed', isMobile),
-    mainMenuWidth: getLocalStorageItem('whiteboard_mainMenuWidth', 200),
+    mainMenuWidth: getLocalStorageItem('whiteboard_mainMenuWidth', DEFAULT_MAIN_MENU_WIDTH),
     pngExportOptions: getLocalStorageItem('whiteboard_pngExportOptions', { scale: 1, highQuality: true, transparentBg: true }),
     isStyleLibraryOpen: false,
     styleLibraryPosition: { x: 0, y: 0 },


### PR DESCRIPTION
## Summary
- centralize the default main menu width in a shared constant set to 200px
- ensure the UI and app stores fall back to the shared default width value
- apply the default width when rendering and resizing the main menu panel so the sidebar opens at 200px

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcccb64a848323925a2531ff5cdc07