### PR TITLE
fix: preserve feathering on magic wand cutouts

### DIFF
--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -405,11 +405,19 @@ export function applyMaskToImage(
   imageData: ImageData,
   mask: MagicWandMask | null,
   featherRadius = 0
-): { image: ImageData; contours: Array<{ points: Array<{ x: number; y: number }>; inner: boolean }> } {
+): {
+  image: ImageData;
+  contours: Array<{ points: Array<{ x: number; y: number }>; inner: boolean }>;
+  featherData: Float32Array | null;
+} {
   const result = new Uint8ClampedArray(imageData.data);
 
   if (!mask) {
-    return { image: new ImageData(result, imageData.width, imageData.height), contours: [] };
+    return {
+      image: new ImageData(result, imageData.width, imageData.height),
+      contours: [],
+      featherData: null,
+    };
   }
 
   const effectiveRadius = Math.max(0, Math.floor(featherRadius));
@@ -433,7 +441,7 @@ export function applyMaskToImage(
     console.warn('Failed to trace magic wand contours', error);
   }
 
-  return { image: new ImageData(result, imageData.width, imageData.height), contours };
+  return { image: new ImageData(result, imageData.width, imageData.height), contours, featherData };
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose feather data from the magic wand mask processing so it can be reused during cuts
- expand the extracted selection bounds and apply feather weights when creating the cutout image
- keep cut layers aligned with the feathered area to avoid hard edges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce8fef0408323aff8eb422a1dd4b1