### PR TITLE
fix: reorder single selection button in crop toolbar

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -423,21 +423,6 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
                   type="button"
                   variant="unstyled"
                   className={`${segmentedButtonBase} ${
-                    cropSelectionOperation === 'add'
-                      ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
-                      : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
-                  }`}
-                  onClick={() => setCropSelectionOperation('add')}
-                  aria-pressed={cropSelectionOperation === 'add'}
-                  title={t('cropSelectionAdd')}
-                >
-                  <span className="font-semibold">＋</span>
-                  <span>{t('cropSelectionAdd')}</span>
-                </PanelButton>
-                <PanelButton
-                  type="button"
-                  variant="unstyled"
-                  className={`${segmentedButtonBase} ${
                     cropSelectionOperation === 'replace'
                       ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
                       : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
@@ -448,6 +433,21 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
                 >
                   <span className="font-semibold">⟳</span>
                   <span>{t('cropSelectionReset')}</span>
+                </PanelButton>
+                <PanelButton
+                  type="button"
+                  variant="unstyled"
+                  className={`${segmentedButtonBase} ${
+                    cropSelectionOperation === 'add'
+                      ? 'bg-[var(--accent-bg)] text-[var(--accent-primary)]'
+                      : 'text-[var(--text-secondary)] hover:bg-[var(--ui-element-bg-hover)]'
+                  }`}
+                  onClick={() => setCropSelectionOperation('add')}
+                  aria-pressed={cropSelectionOperation === 'add'}
+                  title={t('cropSelectionAdd')}
+                >
+                  <span className="font-semibold">＋</span>
+                  <span>{t('cropSelectionAdd')}</span>
                 </PanelButton>
                 <PanelButton
                   type="button"


### PR DESCRIPTION
## Summary
- reorder the crop selection reset button to appear before the add option in the magic wand toolbar
- keep the segmented control grouping unchanged otherwise

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcec330d188323bbb878001e972fe6