### PR TITLE
refactor: remove border radius control from side toolbar

### DIFF
--- a/src/components/SideToolbar.tsx
+++ b/src/components/SideToolbar.tsx
@@ -91,7 +91,6 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
   const {
     tool,
     sides, setSides,
-    borderRadius, setBorderRadius,
     opacity, setOpacity,
     strokeWidth, setStrokeWidth,
     color, setColor,
@@ -107,7 +106,6 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
   const { t } = useTranslation();
   const opacityLabel = t('opacity');
   const sidesLabel = t('sideToolbar.sides');
-  const borderRadiusLabel = t('sideToolbar.borderRadius');
   const strokeWidthLabel = t('sideToolbar.strokeWidth');
   const strokeColorLabel = t('sideToolbar.strokeColor');
   const fillColorLabel = t('sideToolbar.fillColor');
@@ -164,19 +162,6 @@ export const SideToolbar: React.FC<SideToolbarProps> = (props) => {
               max={50}
               step={1}
               unit=""
-              beginCoalescing={beginCoalescing}
-              endCoalescing={endCoalescing}
-            />
-          )}
-          {borderRadius !== null && (
-            <NumericInput
-              label={borderRadiusLabel}
-              value={borderRadius}
-              setValue={setBorderRadius}
-              min={0}
-              max={500}
-              step={1}
-              unit="px"
               beginCoalescing={beginCoalescing}
               endCoalescing={endCoalescing}
             />


### PR DESCRIPTION
## Summary
- remove the border radius numeric input from the side toolbar so the property panel no longer exposes that setting

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcefd6cb2c832392ff69bad40bbd42