### PR TITLE
fix: keep frame stroke width constant

### DIFF
--- a/src/lib/export/rough/shapes.ts
+++ b/src/lib/export/rough/shapes.ts
@@ -1,6 +1,7 @@
 import type { RoughSVG } from 'roughjs/bin/svg';
 import type { RectangleData, EllipseData, ImageData, PolygonData, FrameData } from '@/types';
 import { getPolygonPathD, getRoundedRectPathD } from '@/lib/drawing';
+import { applyNonScalingStroke } from '@/lib/export/utils/svg';
 
 export function renderImage(data: ImageData): SVGElement {
     const imgData = data as ImageData;
@@ -73,18 +74,6 @@ export function renderRoughShape(rc: RoughSVG, data: RectangleData | EllipseData
         };
         const d = getRoundedRectPathD(x, y, width, height, 0);
         const frameNode = rc.path(d, frameOptions);
-
-        const applyNonScalingStroke = (element: SVGElement) => {
-            if (element.tagName === 'path') {
-                element.setAttribute('vector-effect', 'non-scaling-stroke');
-            }
-            Array.from(element.children).forEach((child) => {
-                if (child instanceof SVGElement) {
-                    applyNonScalingStroke(child);
-                }
-            });
-        };
-
         applyNonScalingStroke(frameNode);
         return frameNode;
     } else if (data.tool === 'polygon') {

--- a/src/lib/export/smooth/path.ts
+++ b/src/lib/export/smooth/path.ts
@@ -7,6 +7,7 @@ import { anchorsToPathD, pointsToPathD } from '@/lib/path-fitting';
 import { createSvgMarker } from '../markers/svg';
 import { getPolygonPathD, calculateArcPathD } from '@/lib/drawing';
 import { createEffectsFilter } from '../core/effects';
+import { applyNonScalingStroke } from '@/lib/export/utils/svg';
 import { getLinearGradientCoordinates, getRadialGradientAttributes, gradientStopColor } from '@/lib/gradient';
 import { parseColor, hslaToHslaString } from '@/lib/color';
 
@@ -81,6 +82,7 @@ export function createSmoothPathNode(data: AnyPath): SVGElement | null {
       pathEl.setAttribute('stroke-width', '2');
       pathEl.setAttribute('stroke-dasharray', '8 4');
       pathEl.setAttribute('fill', 'none');
+      applyNonScalingStroke(pathEl);
     } else {
       pathEl.setAttribute('stroke', data.color);
       pathEl.setAttribute('stroke-width', String(data.strokeWidth));
@@ -184,6 +186,9 @@ export function createSmoothPathNode(data: AnyPath): SVGElement | null {
         if (data.opacity !== undefined && data.opacity < 1) {
             pathEl.setAttribute('opacity', String(data.opacity));
         }
+        if (data.tool === 'frame') {
+            applyNonScalingStroke(pathEl);
+        }
         return pathEl;
     } else {
         if (hasRotation) {
@@ -198,6 +203,9 @@ export function createSmoothPathNode(data: AnyPath): SVGElement | null {
         }
         if (!defs.hasChildNodes()) {
             g.removeChild(defs);
+        }
+        if (data.tool === 'frame') {
+            applyNonScalingStroke(g);
         }
         return g;
     }

--- a/src/lib/export/utils/svg.ts
+++ b/src/lib/export/utils/svg.ts
@@ -1,0 +1,28 @@
+const geometryTags = new Set([
+  'path',
+  'line',
+  'polyline',
+  'polygon',
+  'rect',
+  'circle',
+  'ellipse'
+]);
+
+const hasVisibleStroke = (element: SVGElement): boolean => {
+  const stroke = element.getAttribute('stroke');
+  return !!stroke && stroke !== 'none' && stroke !== 'transparent';
+};
+
+export const applyNonScalingStroke = (element: SVGElement): void => {
+  if (element.tagName === 'defs') return;
+
+  if (geometryTags.has(element.tagName.toLowerCase()) && hasVisibleStroke(element)) {
+    element.setAttribute('vector-effect', 'non-scaling-stroke');
+  }
+
+  element.childNodes.forEach((child) => {
+    if (child instanceof SVGElement) {
+      applyNonScalingStroke(child);
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- ensure frame shapes use non-scaling strokes so borders remain visually consistent

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf1815d8c83239d4dd8dd60d001af