### PR TITLE
fix: rotate gradient fills within mask groups

### DIFF
--- a/src/lib/export/smooth/path.ts
+++ b/src/lib/export/smooth/path.ts
@@ -7,7 +7,7 @@ import { anchorsToPathD, pointsToPathD } from '@/lib/path-fitting';
 import { createSvgMarker } from '../markers/svg';
 import { getPolygonPathD, calculateArcPathD } from '@/lib/drawing';
 import { createEffectsFilter } from '../core/effects';
-import { getLinearGradientCoordinates, getRadialGradientAttributes, gradientStopColor } from '@/lib/gradient';
+import { getLinearGradientCoordinates, getRadialGradientAttributes, getGradientTransform, gradientStopColor } from '@/lib/gradient';
 import { parseColor, hslaToHslaString } from '@/lib/color';
 
 const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
@@ -94,6 +94,11 @@ export function createSmoothPathNode(data: AnyPath): SVGElement | null {
           ? document.createElementNS(svgNS, 'linearGradient')
           : document.createElementNS(svgNS, 'radialGradient');
         gradientElement.setAttribute('id', gradientId);
+
+        const gradientTransform = getGradientTransform(data);
+        if (gradientTransform) {
+          gradientElement.setAttribute('gradientTransform', gradientTransform);
+        }
 
         if (gradient.type === 'linear') {
           const { x1, y1, x2, y2 } = getLinearGradientCoordinates(gradient);


### PR DESCRIPTION
## Summary
- compute SVG gradient transforms from shape rotation/scale so fills follow object transforms
- apply the gradient transform when rendering rough and smooth shapes to keep gradients aligned inside mask groups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf69e1f54832395984c7d8e04f9be