### PR TITLE
fix(toolbar): sync fill gradient display

### DIFF
--- a/src/hooks/useToolbarState.ts
+++ b/src/hooks/useToolbarState.ts
@@ -214,7 +214,9 @@ export const useToolbarState = (
   const color = displayValue('color', drawingColor);
   const fill = displayValue('fill', drawingFill);
   const fillStyle = displayValue('fillStyle', drawingFillStyle);
-  const fillGradient = displayValue('fillGradient', drawingFillGradient);
+  const fillGradient = firstSelectedPath
+    ? firstSelectedPath.fillGradient ?? null
+    : drawingFillGradient;
   const strokeWidth = displayValue('strokeWidth', drawingStrokeWidth);
   const strokeLineDash = displayValue('strokeLineDash', drawingStrokeLineDash);
   const strokeLineCapStart = displayValue('strokeLineCapStart', drawingStrokeLineCapStart);


### PR DESCRIPTION
## Summary
- ensure the toolbar falls back to a solid fill mode when the selected shape does not define a gradient

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de2aa8481083239cdeea16027f4bf4