### PR TITLE
Allow resizing text shapes through transform helpers

### DIFF
--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -251,7 +251,7 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
                     return;
                 }
                 const path = selected[0];
-                const isSimpleShape = selected.length === 1 && (path.tool === 'rectangle' || path.tool === 'ellipse' || path.tool === 'image' || path.tool === 'polygon' || path.tool === 'frame');
+                const isSimpleShape = selected.length === 1 && (path.tool === 'rectangle' || path.tool === 'ellipse' || path.tool === 'image' || path.tool === 'polygon' || path.tool === 'frame' || path.tool === 'text');
 
                 if (isSimpleShape) {
                     if (e.ctrlKey || e.metaKey) {
@@ -296,7 +296,7 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
                 setDragState({ type: 'arc', pathId, pointIndex, initialPoint: arcPoint });
             }
             else if (handle && handle !== 'rotate' && handle !== 'border-radius' && handle !== 'arc') {
-                if (path.tool === 'rectangle' || path.tool === 'ellipse' || path.tool === 'image' || path.tool === 'polygon' || path.tool === 'frame') setDragState({ type: 'resize', pathId, handle, originalPath: path as any, initialPointerPos: point });
+                if (path.tool === 'rectangle' || path.tool === 'ellipse' || path.tool === 'image' || path.tool === 'polygon' || path.tool === 'frame' || path.tool === 'text') setDragState({ type: 'resize', pathId, handle, originalPath: path as any, initialPointerPos: point });
             }
         } return;
     }

--- a/src/lib/drawing/transform/resize.ts
+++ b/src/lib/drawing/transform/resize.ts
@@ -1,4 +1,4 @@
-import type { Point, RectangleData, EllipseData, ImageData, PolygonData, FrameData, ResizeHandlePosition } from '@/types';
+import type { Point, RectangleData, EllipseData, ImageData, PolygonData, FrameData, TextData, ResizeHandlePosition } from '@/types';
 import { rotatePoint } from '../geom';
 import { scalePath } from './scale';
 import { movePath } from './move';
@@ -14,13 +14,13 @@ import { movePath } from './move';
  * @returns 返回一个调整大小后的新图形对象。
  */
 export function resizePath(
-  originalPath: RectangleData | EllipseData | ImageData | PolygonData | FrameData,
+  originalPath: RectangleData | EllipseData | ImageData | PolygonData | FrameData | TextData,
   handle: ResizeHandlePosition,
   currentPos: Point,
   initialPos: Point,
   keepAspectRatio: boolean,
   rotationCenter?: Point,
-): RectangleData | EllipseData | ImageData | PolygonData | FrameData {
+): RectangleData | EllipseData | ImageData | PolygonData | FrameData | TextData {
   const ZERO_EPSILON = 1e-6;
   const { rotation } = originalPath;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -345,7 +345,7 @@ type ResizeDragState = {
   type: 'resize';
   pathId: string;
   handle: ResizeHandlePosition;
-  originalPath: RectangleData | EllipseData | ImageData | PolygonData | FrameData;
+  originalPath: RectangleData | EllipseData | ImageData | PolygonData | FrameData | TextData;
   initialPointerPos: Point;
 };
 


### PR DESCRIPTION
## Summary
- allow ResizeDragState and the resizePath helper to operate on TextData
- treat text paths as simple shapes so resize drags go through the rotation-aware flow

## Testing
- npx tsc --noEmit *(fails: existing type errors throughout the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e34cb439ac8323b1d6eaba316f8555