### PR TITLE
Fix text editor overlay height mismatch

### DIFF
--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -391,7 +391,7 @@ const TextEditingOverlay: React.FC<TextEditorOverlayProps> = ({
 
     const draftWidth = !isNew && path.width > 0 ? path.width : layout.width;
     const width = Math.max(draftWidth, layout.width, 1);
-    const height = Math.max(path.height, layout.height, 1);
+    const height = Math.max(layout.height, 1);
     const leadingTop = layout.leading.top;
     const leadingBottom = layout.leading.bottom;
     const glyphHeight = layout.metrics.height;


### PR DESCRIPTION
## Summary
- ensure the text editing overlay uses the current layout height so it matches the rendered preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e375263c34832399e9ad78b413bfd1