### PR TITLE
fix: allow zoom gestures while editing text

### DIFF
--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -124,6 +124,7 @@ export const CanvasOverlays: React.FC = () => {
         commitTextEditing,
         cancelTextEditing,
         viewTransform: camera,
+        handleWheel: handleCanvasWheel,
     } = store;
 
     const canGroup = useMemo(() => selectedPathIds.length > 1, [selectedPathIds]);
@@ -155,6 +156,7 @@ export const CanvasOverlays: React.FC = () => {
                 viewTransform={camera}
                 onChange={updateTextEditing}
                 onCommit={commitTextEditing}
+                onCanvasWheel={handleCanvasWheel}
             />
         );
     }, [textEditing, activeTextPath, camera, updateTextEditing, commitTextEditing]);
@@ -319,6 +321,7 @@ interface TextEditorOverlayProps {
     viewTransform: { scale: number; translateX: number; translateY: number };
     onChange: (value: string) => void;
     onCommit: () => void;
+    onCanvasWheel: (event: WheelEvent) => void;
 }
 
 const TextEditingOverlay: React.FC<TextEditorOverlayProps> = ({
@@ -328,6 +331,7 @@ const TextEditingOverlay: React.FC<TextEditorOverlayProps> = ({
     viewTransform,
     onChange,
     onCommit,
+    onCanvasWheel,
 }) => {
     const textareaRef = useRef<HTMLTextAreaElement | null>(null);
     const normalizedDraft = draft.replace(/\r/g, '');
@@ -484,14 +488,53 @@ const TextEditingOverlay: React.FC<TextEditorOverlayProps> = ({
         event.stopPropagation();
     };
 
-    const handleWheel = (event: React.WheelEvent<HTMLTextAreaElement>) => {
+    const handleWheel = useCallback((event: React.WheelEvent<HTMLTextAreaElement>) => {
         const isZoomGesture = event.ctrlKey || event.metaKey;
-        if (isZoomGesture) {
-            // Allow the wheel event to bubble so the canvas view can handle zooming.
+        if (!isZoomGesture) {
+            event.stopPropagation();
             return;
         }
+
+        event.preventDefault();
         event.stopPropagation();
-    };
+
+        const canvasSvg = document.querySelector<SVGSVGElement>('[data-whiteboard-canvas="true"]');
+        const canvasContainer = canvasSvg?.parentElement as HTMLDivElement | null;
+
+        if (!canvasContainer) {
+            return;
+        }
+
+        const {
+            deltaX,
+            deltaY,
+            deltaMode,
+            clientX,
+            clientY,
+            metaKey,
+            shiftKey,
+            altKey,
+        } = event.nativeEvent;
+
+        const forwardedEvent = {
+            deltaX,
+            deltaY,
+            deltaMode,
+            clientX,
+            clientY,
+            ctrlKey: event.ctrlKey || event.metaKey,
+            metaKey,
+            shiftKey,
+            altKey,
+            type: event.nativeEvent.type,
+            currentTarget: canvasContainer,
+            target: canvasSvg ?? canvasContainer,
+            preventDefault: () => event.preventDefault(),
+            stopPropagation: () => event.stopPropagation(),
+        } as unknown as WheelEvent;
+
+        onCanvasWheel(forwardedEvent);
+    }, [onCanvasWheel]);
 
     return (
         <div className="absolute inset-0 z-40 pointer-events-none">

--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -485,6 +485,11 @@ const TextEditingOverlay: React.FC<TextEditorOverlayProps> = ({
     };
 
     const handleWheel = (event: React.WheelEvent<HTMLTextAreaElement>) => {
+        const isZoomGesture = event.ctrlKey || event.metaKey;
+        if (isZoomGesture) {
+            // Allow the wheel event to bubble so the canvas view can handle zooming.
+            return;
+        }
         event.stopPropagation();
     };
 


### PR DESCRIPTION
## Summary
- allow ctrl/meta wheel gestures on the text editor overlay to bubble so the canvas can zoom while editing text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e37bfd09f883239903d7b20629b3a6