### PR TITLE
fix: adjust pointer hit detection order

### DIFF
--- a/src/hooks/selection-logic/pointerDown.ts
+++ b/src/hooks/selection-logic/pointerDown.ts
@@ -301,7 +301,19 @@ export const handlePointerDownLogic = (props: HandlePointerDownProps) => {
         } return;
     }
     
-    let clickedPath: AnyPath | null = selectionMode === 'edit' ? findDeepestHitPath(point, paths, vt.scale) : paths.slice().reverse().find((p: AnyPath) => !p.isLocked && isPointHittingPath(point, p, vt.scale)) || null;
+    let clickedPath: AnyPath | null = null;
+    if (selectionMode === 'edit') {
+        clickedPath = findDeepestHitPath(point, paths, vt.scale);
+    } else {
+        for (let i = paths.length - 1; i >= 0; i--) {
+            const path = paths[i];
+            if (path.isLocked) continue;
+            if (isPointHittingPath(point, path, vt.scale)) {
+                clickedPath = path;
+                break;
+            }
+        }
+    }
 
     if (clickedPath) {
         const now = Date.now();


### PR DESCRIPTION
## Summary
- iterate pointer-down hit detection in reverse order to return as soon as the topmost unlocked path is hit
- keep edit mode using deepest-path hit testing so nested group elements remain selectable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e37ce75c188323a92f6065ea88deb7