### PR TITLE
fix: improve frame selection hit testing

### DIFF
--- a/src/lib/hit-testing.ts
+++ b/src/lib/hit-testing.ts
@@ -133,10 +133,11 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
             }
 
             const isFillVisible = path.tool === 'text' ? true : hasVisibleFill(path);
+            const treatInteriorAsHit = isFillVisible || path.tool === 'frame';
 
             // Check for hit on the fill area first.
             const isInside = testPoint.x >= x && testPoint.x <= x + width && testPoint.y >= y && testPoint.y <= y + height;
-            if (isInside && isFillVisible) return true;
+            if (isInside && treatInteriorAsHit) return true;
 
             // If not inside, or if fill is transparent, check for hit on the stroke, which is important for transparent shapes.
             const p1 = { x, y };
@@ -150,7 +151,11 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
                 distSqToSegment(testPoint, p4, p1) < thresholdSq
             );
 
-            return path.tool === 'text' ? isInside || borderHit : borderHit;
+            if (borderHit) {
+                return true;
+            }
+
+            return false;
         }
         case 'polygon': {
             const { x, y, width, height, sides, rotation } = path as PolygonData;

--- a/tests/lib/hit-testing.test.ts
+++ b/tests/lib/hit-testing.test.ts
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('paper', () => ({}));
 import { findDeepestHitPath, isPathIntersectingLasso, isPathIntersectingMarquee, isPointHittingPath, isPointInPolygon } from '@/lib/hit-testing';
-import type { AnyPath, RectangleData, EllipseData, BrushPathData, Point, GroupData } from '@/types';
+import type { AnyPath, RectangleData, EllipseData, BrushPathData, Point, GroupData, FrameData } from '@/types';
 
 const baseShape = {
   id: 'shape-base',
@@ -87,6 +87,21 @@ describe('命中检测函数测试', () => {
 
       // 点远离画笔路径，不应命中
       expect(isPointHittingPath({ x: 50, y: 20 }, brush, 1)).toBe(false);
+    });
+
+    it('透明填充的画框在内部点击仍可命中', () => {
+      const frame = {
+        ...baseShape,
+        tool: 'frame',
+        x: 0,
+        y: 0,
+        width: 120,
+        height: 90,
+        fill: 'transparent',
+      } as unknown as FrameData;
+
+      expect(isPointHittingPath({ x: 60, y: 45 }, frame, 1)).toBe(true);
+      expect(isPointHittingPath({ x: 200, y: 200 }, frame, 1)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- treat frame interiors as selectable even when their fill is transparent so that clicks inside still select the frame
- cover the new hit testing behavior with a dedicated unit test

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e37b784d04832393e08102db10a3fb