### PR TITLE
fix: require edge clicks for frame selection

### DIFF
--- a/src/lib/hit-testing.ts
+++ b/src/lib/hit-testing.ts
@@ -133,7 +133,7 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
             }
 
             const isFillVisible = path.tool === 'text' ? true : hasVisibleFill(path);
-            const treatInteriorAsHit = isFillVisible || path.tool === 'frame';
+            const treatInteriorAsHit = path.tool === 'frame' ? false : isFillVisible;
 
             // Check for hit on the fill area first.
             const isInside = testPoint.x >= x && testPoint.x <= x + width && testPoint.y >= y && testPoint.y <= y + height;


### PR DESCRIPTION
## Summary
- ensure hit testing treats frames as edge-only selections so clicking the interior no longer selects them

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e38919310483239742904ff1b4468e