### PR TITLE
Update main menu header to show folder name

### DIFF
--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -13,6 +13,7 @@ import { FloatingAnimationExporter } from './FloatingAnimationExporter';
 import LanguageSelector from './LanguageSelector';
 import { useTranslation } from 'react-i18next';
 import { FilesPanel } from './files-panel/FilesPanel';
+import { useAppContext } from '@/context/AppContext';
 
 // --- 主菜单组件 ---
 
@@ -32,7 +33,6 @@ interface MainMenuProps {
   frameCount: number;
   backgroundColor: string;
   setBackgroundColor: (color: string) => void;
-  activeFileName: string | null;
   hasUnsavedChanges: boolean;
   isDocumentUncreated: boolean;
   onResetPreferences: () => void;
@@ -55,7 +55,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
     onSave, onSaveAs, onOpen, onImport, onClear, canClear, onClearAllData, canClearAllData,
     onExportSvg, onExportPng, onExportAnimation, canExport, frameCount,
     backgroundColor, setBackgroundColor,
-    activeFileName, hasUnsavedChanges, isDocumentUncreated,
+    hasUnsavedChanges, isDocumentUncreated,
     onResetPreferences,
     zoomLevel,
     selectionInfo, elementCount, canvasWidth, canvasHeight,
@@ -64,6 +64,8 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
   } = props;
 
   const { t } = useTranslation();
+  const { directoryHandle } = useAppContext();
+  const menuTitle = directoryHandle?.name ?? t('appTitle');
 
   type MenuAction = {
     label?: string;
@@ -125,12 +127,9 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
       <div className="flex items-center gap-2 mb-4">
         <div className="h-10 w-10 p-2 rounded-lg flex items-center justify-center bg-[var(--accent-bg)] text-[var(--accent-primary)] ring-1 ring-inset ring-[var(--accent-primary-muted)]"><Paintbrush className="h-6 w-6" /></div>
         <div>
-          <h1 className="text-base font-bold text-[var(--text-primary)]">{t('appTitle')}</h1>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)] min-w-0">
-            <span className="truncate" title={activeFileName ?? t('untitled')}>
-              {activeFileName ?? t('untitled')}
-            </span>
-          </div>
+          <h1 className="text-base font-bold text-[var(--text-primary)]" title={menuTitle}>
+            {menuTitle}
+          </h1>
         </div>
       </div>
       

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -125,11 +125,11 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
   return (
     <nav className="w-full h-full bg-[var(--ui-panel-bg)] border-r border-[var(--ui-panel-border)] flex flex-col p-3 z-30">
       <div className="flex items-center gap-2 mb-4">
-        <div className="h-10 w-10 p-2 rounded-lg flex items-center justify-center bg-[var(--accent-bg)] text-[var(--accent-primary)] ring-1 ring-inset ring-[var(--accent-primary-muted)]"><Paintbrush className="h-6 w-6" /></div>
-        <div>
-          <h1 className="text-base font-bold text-[var(--text-primary)]" title={menuTitle}>
-            {menuTitle}
-          </h1>
+        <div
+          className="h-10 w-10 p-2 rounded-lg flex items-center justify-center bg-[var(--accent-bg)] text-[var(--accent-primary)] ring-1 ring-inset ring-[var(--accent-primary-muted)]"
+          aria-label={menuTitle}
+        >
+          <Paintbrush className="h-6 w-6" />
         </div>
       </div>
       

--- a/src/components/MainMenu.tsx
+++ b/src/components/MainMenu.tsx
@@ -33,6 +33,7 @@ interface MainMenuProps {
   frameCount: number;
   backgroundColor: string;
   setBackgroundColor: (color: string) => void;
+  activeFileName: string | null;
   hasUnsavedChanges: boolean;
   isDocumentUncreated: boolean;
   onResetPreferences: () => void;
@@ -55,6 +56,7 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
     onSave, onSaveAs, onOpen, onImport, onClear, canClear, onClearAllData, canClearAllData,
     onExportSvg, onExportPng, onExportAnimation, canExport, frameCount,
     backgroundColor, setBackgroundColor,
+    activeFileName,
     hasUnsavedChanges, isDocumentUncreated,
     onResetPreferences,
     zoomLevel,
@@ -131,8 +133,16 @@ export const MainMenu: React.FC<MainMenuProps> = (props) => {
         >
           <Paintbrush className="h-6 w-6" />
         </div>
+        <div className="min-w-0">
+          <h1 className="text-base font-bold text-[var(--text-primary)]">{menuTitle}</h1>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-secondary)] min-w-0">
+            <span className="truncate" title={activeFileName ?? t('untitled')}>
+              {activeFileName ?? t('untitled')}
+            </span>
+          </div>
+        </div>
       </div>
-      
+
       <Tab.Group as="div" className="flex flex-col flex-grow min-h-0">
         <Tab.List className="flex-shrink-0 flex space-x-1 rounded-lg bg-[var(--ui-element-bg)] p-1 mb-3">
           {tabs.map(tab => (

--- a/src/components/files-panel/FilesPanel.tsx
+++ b/src/components/files-panel/FilesPanel.tsx
@@ -73,11 +73,6 @@ export const FilesPanel: React.FC = () => {
             <h2 className="truncate text-sm font-semibold text-[var(--text-primary)]">
               {directoryHandle ? directoryHandle.name : t('filesPanel.noFolderSelected')}
             </h2>
-            <p className="text-xs text-[var(--text-secondary)]">
-              {directoryHandle
-                ? t('filesPanel.currentFolder', { name: directoryHandle.name })
-                : t('filesPanel.noFolderDescription')}
-            </p>
           </div>
           <div className="flex flex-shrink-0 items-center gap-2">
             {directoryHandle ? (
@@ -100,9 +95,6 @@ export const FilesPanel: React.FC = () => {
             </button>
           </div>
         </div>
-        {directoryHandle ? (
-          <p className="text-xs text-[var(--text-secondary)]">{t('filesPanel.hint')}</p>
-        ) : null}
       </div>
 
       {errorMessage ? (

--- a/src/components/files-panel/FilesPanel.tsx
+++ b/src/components/files-panel/FilesPanel.tsx
@@ -67,34 +67,25 @@ export const FilesPanel: React.FC = () => {
 
   return (
     <div className="flex h-full flex-col text-sm text-[var(--text-primary)]">
-      <div className="flex flex-col gap-2 border-b border-[var(--ui-separator)] pb-3">
-        <div className="flex items-center justify-between gap-2">
-          <div className="min-w-0">
-            <h2 className="truncate text-sm font-semibold text-[var(--text-primary)]">
-              {directoryHandle ? directoryHandle.name : t('filesPanel.noFolderSelected')}
-            </h2>
-          </div>
-          <div className="flex flex-shrink-0 items-center gap-2">
-            {directoryHandle ? (
-              <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={isDirectoryLoading}
-                className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {t('filesPanel.refresh')}
-              </button>
-            ) : null}
-            <button
-              type="button"
-              onClick={handleSelectFolder}
-              disabled={isDirectoryLoading}
-              className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
-            </button>
-          </div>
-        </div>
+      <div className="flex items-center justify-end gap-2 border-b border-[var(--ui-separator)] pb-3">
+        {directoryHandle ? (
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isDirectoryLoading}
+            className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t('filesPanel.refresh')}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={handleSelectFolder}
+          disabled={isDirectoryLoading}
+          className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
+        </button>
       </div>
 
       {errorMessage ? (

--- a/src/components/layout/MainMenuPanel.tsx
+++ b/src/components/layout/MainMenuPanel.tsx
@@ -32,6 +32,7 @@ export const MainMenuPanel: React.FC = () => {
         selectedPathIds,
         backgroundColor,
         setBackgroundColor,
+        activeFileName,
         hasUnsavedChanges,
         lastSavedDocumentSignature,
         viewTransform,
@@ -160,6 +161,7 @@ export const MainMenuPanel: React.FC = () => {
                     frameCount={frames.length}
                     backgroundColor={backgroundColor}
                     setBackgroundColor={setBackgroundColor}
+                    activeFileName={activeFileName}
                     hasUnsavedChanges={hasUnsavedChanges}
                     isDocumentUncreated={isDocumentUncreated}
                     onResetPreferences={handleResetPreferences}

--- a/src/components/layout/MainMenuPanel.tsx
+++ b/src/components/layout/MainMenuPanel.tsx
@@ -32,7 +32,6 @@ export const MainMenuPanel: React.FC = () => {
         selectedPathIds,
         backgroundColor,
         setBackgroundColor,
-        activeFileName,
         hasUnsavedChanges,
         lastSavedDocumentSignature,
         viewTransform,
@@ -161,7 +160,6 @@ export const MainMenuPanel: React.FC = () => {
                     frameCount={frames.length}
                     backgroundColor={backgroundColor}
                     setBackgroundColor={setBackgroundColor}
-                    activeFileName={activeFileName}
                     hasUnsavedChanges={hasUnsavedChanges}
                     isDocumentUncreated={isDocumentUncreated}
                     onResetPreferences={handleResetPreferences}


### PR DESCRIPTION
## Summary
- show the selected directory name at the top of the main menu instead of the generic title
- remove redundant folder description and hint text from the files panel header for a cleaner layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3b544a2f883239420075af58f44cc