### PR TITLE
style: align files panel buttons with shared styles

### DIFF
--- a/src/components/files-panel/FilesPanel.tsx
+++ b/src/components/files-panel/FilesPanel.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
 import { ICONS } from '@/constants';
+import PanelButton from '@/components/PanelButton';
+import { PANEL_CLASSES } from '@/components/panelStyles';
 import type { BoardFileEntry } from '@/types';
 
 export const FilesPanel: React.FC = () => {
@@ -69,23 +71,25 @@ export const FilesPanel: React.FC = () => {
     <div className="flex h-full flex-col text-sm text-[var(--text-primary)]">
       <div className="flex items-center justify-end gap-2 border-b border-[var(--ui-separator)] pb-3">
         {directoryHandle ? (
-          <button
+          <PanelButton
             type="button"
             onClick={handleRefresh}
             disabled={isDirectoryLoading}
-            className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+            variant="unstyled"
+            className={`${PANEL_CLASSES.inputWrapper} h-8 px-3 text-xs font-medium text-[var(--text-primary)] justify-center disabled:cursor-not-allowed disabled:opacity-50`}
           >
             {t('filesPanel.refresh')}
-          </button>
+          </PanelButton>
         ) : null}
-        <button
+        <PanelButton
           type="button"
           onClick={handleSelectFolder}
           disabled={isDirectoryLoading}
-          className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+          variant="unstyled"
+          className={`${PANEL_CLASSES.inputWrapper} h-8 px-3 text-xs font-medium text-[var(--text-primary)] justify-center disabled:cursor-not-allowed disabled:opacity-50`}
         >
           {directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
-        </button>
+        </PanelButton>
       </div>
 
       {errorMessage ? (


### PR DESCRIPTION
## Summary
- restyle the Files panel action buttons to use the shared panel button component
- ensure the refresh and folder selection actions match other controls visually

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68e4eb28570c8323a42b13bba36c5c0f