### PR TITLE
fix: hide file panel status indicators

### DIFF
--- a/src/components/files-panel/FilesPanel.tsx
+++ b/src/components/files-panel/FilesPanel.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
-import { ICONS } from '@/constants';
 import type { BoardFileEntry } from '@/types';
 
 export const FilesPanel: React.FC = () => {
@@ -133,13 +132,6 @@ export const FilesPanel: React.FC = () => {
                           : t('filesPanel.unknownDate')}
                       </span>
                     </span>
-                    {isActive ? (
-                      <span className="ml-2 rounded-full bg-[var(--accent-primary)]/10 px-2 py-0.5 text-[11px] font-medium text-[var(--accent-primary)]">
-                        {t('filesPanel.activeBadge')}
-                      </span>
-                    ) : (
-                      <span className="ml-3 text-[var(--text-secondary)]">{ICONS.OPEN}</span>
-                    )}
                   </button>
                 </li>
               );


### PR DESCRIPTION
## Summary
- remove the trailing icon from file entries in the files panel
- stop rendering the active badge so entries only show their name and timestamp

## Testing
- npm run build

## Screenshots
![Files panel without extra status icons](browser:/invocations/vlcptqpy/artifacts/artifacts/files-panel.png)


------
https://chatgpt.com/codex/tasks/task_e_68e4eb4e6104832396f1b84b35528f80