### PR TITLE
chore: switch whiteboard file extension to .wb

### DIFF
--- a/src/hooks/actions/useExportActions.ts
+++ b/src/hooks/actions/useExportActions.ts
@@ -234,7 +234,7 @@ export const useExportActions = ({
         }
 
         const blob = new Blob([svgString], { type: 'image/svg+xml' });
-        const fileName = activeFileName ? activeFileName.replace(/\.whiteboard$/, '.svg') : 'whiteboard.svg';
+        const fileName = activeFileName ? activeFileName.replace(/\.(?:whiteboard|wb)$/i, '.svg') : 'whiteboard.svg';
         await fileSave(blob, {
           fileName,
           extensions: ['.svg'],
@@ -250,7 +250,7 @@ export const useExportActions = ({
       return;
     }
     const blob = new Blob([svgString], { type: 'image/svg+xml' });
-    const fileName = activeFileName ? activeFileName.replace(/\.whiteboard$/, '.svg') : 'whiteboard.svg';
+    const fileName = activeFileName ? activeFileName.replace(/\.(?:whiteboard|wb)$/i, '.svg') : 'whiteboard.svg';
     await fileSave(blob, {
         fileName: fileName,
         extensions: ['.svg'],
@@ -295,7 +295,7 @@ export const useExportActions = ({
           alert('Could not generate PNG for export.');
           return;
         }
-        const fileName = activeFileName ? activeFileName.replace(/\.whiteboard$/, '.png') : 'whiteboard.png';
+        const fileName = activeFileName ? activeFileName.replace(/\.(?:whiteboard|wb)$/i, '.png') : 'whiteboard.png';
         const scaleSuffix = pngExportOptions.scale !== 1 ? `@${pngExportOptions.scale}x` : '';
         await fileSave(blob, {
           fileName: fileName.replace(/(\.png)$/, `${scaleSuffix}$1`),
@@ -314,7 +314,7 @@ export const useExportActions = ({
         alert("Could not generate PNG for export.");
         return;
     }
-    const fileName = activeFileName ? activeFileName.replace(/\.whiteboard$/, '.png') : 'whiteboard.png';
+    const fileName = activeFileName ? activeFileName.replace(/\.(?:whiteboard|wb)$/i, '.png') : 'whiteboard.png';
     const scaleSuffix = pngExportOptions.scale !== 1 ? `@${pngExportOptions.scale}x` : '';
     await fileSave(blob, {
         fileName: fileName.replace(/(\.png)$/, `${scaleSuffix}$1`),
@@ -368,7 +368,7 @@ export const useExportActions = ({
         }
       }
       const zipBlob = await zip.generateAsync({ type: 'blob' });
-      const fileName = activeFileName ? activeFileName.replace(/\.whiteboard$/, '.zip') : 'animation.zip';
+      const fileName = activeFileName ? activeFileName.replace(/\.(?:whiteboard|wb)$/i, '.zip') : 'animation.zip';
       await fileSave(zipBlob, { fileName, extensions: ['.zip'], id: 'whiteboardExportAnimation' });
     } else { // spritesheet
       const frameBbox = clipFrame ? getPathBoundingBox(clipFrame, false) : globalBbox;
@@ -410,7 +410,7 @@ export const useExportActions = ({
       
       canvas.toBlob(async (blob) => {
         if (blob) {
-          const fileName = activeFileName ? activeFileName.replace(/\.whiteboard$/, '_spritesheet.png') : 'spritesheet.png';
+          const fileName = activeFileName ? activeFileName.replace(/\.(?:whiteboard|wb)$/i, '_spritesheet.png') : 'spritesheet.png';
           await fileSave(blob, { fileName, extensions: ['.png'], id: 'whiteboardExportAnimation' });
         }
       }, 'image/png');

--- a/src/hooks/actions/useFileActions.ts
+++ b/src/hooks/actions/useFileActions.ts
@@ -72,8 +72,8 @@ export const useFileActions = ({
         // 移除了 'id' 属性，以确保在所有浏览器中都能可靠地触发原生保存对话框，
         // 而不是依赖可能导致问题的浏览器特定行为。
         const fileHandle = await fileSave(blob, {
-            fileName: activeFileName || 'untitled.whiteboard',
-            extensions: ['.whiteboard'],
+            fileName: activeFileName || 'untitled.wb',
+            extensions: ['.wb'],
         });
 
         if (fileHandle) {
@@ -198,7 +198,7 @@ export const useFileActions = ({
     try {
         const file = await fileOpen({
             mimeTypes: ['application/vnd.whiteboard+json', 'application/json'],
-            extensions: ['.whiteboard'],
+            extensions: ['.wb'],
             id: 'whiteboardOpen',
         }) as FileWithHandle;
         if (!file) return;

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -1810,7 +1810,7 @@ export const useAppStore = () => {
 
       const files: BoardFileEntry[] = [];
       for await (const [name, entry] of targetHandle.entries()) {
-        if (entry.kind !== 'file' || !name.toLowerCase().endsWith('.whiteboard')) {
+        if (entry.kind !== 'file' || !name.toLowerCase().endsWith('.wb')) {
           continue;
         }
         const fileHandle = entry as FileSystemFileHandle;


### PR DESCRIPTION
## Summary
- update file handling to save and open documents using the new .wb extension
- adjust export routines to transform .wb filenames when generating assets
- filter directory listings for .wb files to align with the new extension

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4f044b7dc8323b9c6a82db6ec1227