### PR TITLE
Add procedural frame interpolation for animation playback

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -37,8 +37,8 @@ export const MainLayout: React.FC = () => {
         onionSkinNextFrames,
         onionSkinOpacity,
         // Whiteboard props
-        activePaths,
-        backgroundPaths,
+        renderPaths,
+        renderBackgroundPaths,
         tool,
         selectionMode,
         currentBrushPath,
@@ -211,9 +211,9 @@ export const MainLayout: React.FC = () => {
                         onDragOver={(e) => e.preventDefault()}
                     >
                         <Whiteboard
-                            paths={activePaths}
+                            paths={renderPaths}
                             onionSkinPaths={onionSkinPaths}
-                            backgroundPaths={backgroundPaths}
+                            backgroundPaths={renderBackgroundPaths}
                             tool={tool}
                             selectionMode={selectionMode}
                             currentLivePath={currentBrushPath}

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -18,6 +18,7 @@ import { useAppActions } from './actions/useAppActions';
 import { useGroupIsolation } from './useGroupIsolation';
 import { getLocalStorageItem } from '../lib/utils';
 import { DEFAULT_MAIN_MENU_WIDTH } from '@/constants';
+import { interpolateFramePaths } from '@/lib/animation/interpolatePaths';
 import * as idb from '../lib/indexedDB';
 import type { FileSystemDirectoryHandle, FileSystemFileHandle } from 'wicg-file-system-access';
 import type { WhiteboardData, Tool, AnyPath, StyleClipboardData, MaterialData, PngExportOptions, ImageData as PathImageData, BBox, Point, GroupData, TextData, BoardFileEntry, DirectoryAccessError } from '../types';
@@ -368,11 +369,14 @@ export const useAppStore = () => {
   const cropMagicWandMaskRef = useRef<MagicWandMask | null>(null);
   const cropMagicWandSampleRef = useRef<{ x: number; y: number } | null>(null);
   const cropManualDraftRef = useRef<CropManualDraft | null>(null);
+  const [frameProgress, setFrameProgress] = useState(0);
+  const lastFrameTimestampRef = useRef<number | null>(null);
 
   const pathState = usePathsStoreHook();
   const {
     paths,
     frames,
+    currentFrameIndex,
     revision,
     setCurrentFrameIndex,
     setPaths,
@@ -413,6 +417,57 @@ export const useAppStore = () => {
     () => createDocumentSignature(revision, uiState.backgroundColor, uiState.fps),
     [revision, uiState.backgroundColor, uiState.fps]
   );
+
+  useEffect(() => {
+    lastFrameTimestampRef.current = null;
+    setFrameProgress(0);
+  }, [uiState.isPlaying, currentFrameIndex, frames.length]);
+
+  useEffect(() => {
+    if (!uiState.isPlaying || frames.length <= 1) {
+      return () => {
+        lastFrameTimestampRef.current = null;
+      };
+    }
+
+    let rafId: number;
+    const step = (timestamp: number) => {
+      if (lastFrameTimestampRef.current === null) {
+        lastFrameTimestampRef.current = timestamp;
+        rafId = requestAnimationFrame(step);
+        return;
+      }
+
+      const delta = timestamp - lastFrameTimestampRef.current;
+      lastFrameTimestampRef.current = timestamp;
+      const frameDuration = 1000 / Math.max(uiState.fps, 1);
+      if (!Number.isFinite(frameDuration) || frameDuration <= 0) {
+        rafId = requestAnimationFrame(step);
+        return;
+      }
+
+      setFrameProgress(prev => {
+        let nextProgress = prev + delta / frameDuration;
+        if (nextProgress >= 1) {
+          let remaining = nextProgress;
+          while (remaining >= 1) {
+            remaining -= 1;
+            setCurrentFrameIndex(prevIndex => (frames.length === 0 ? prevIndex : (prevIndex + 1) % frames.length));
+          }
+          return remaining;
+        }
+        return nextProgress;
+      });
+
+      rafId = requestAnimationFrame(step);
+    };
+
+    rafId = requestAnimationFrame(step);
+    return () => {
+      cancelAnimationFrame(rafId);
+      lastFrameTimestampRef.current = null;
+    };
+  }, [uiState.isPlaying, uiState.fps, frames.length, setCurrentFrameIndex]);
 
   useEffect(() => {
     if (!appState.croppingState) {
@@ -1140,6 +1195,42 @@ export const useAppStore = () => {
   const viewTransform = useViewTransform();
   const requestFitToContent = useViewTransformStore(s => s.requestFitToContent);
   const toolbarState = useToolsStore(activePaths, selectedPathIds, activePathState.setPaths, setSelectedPathIds, beginCoalescing, endCoalescing);
+  const renderFramePaths = useMemo(() => {
+    if (frames.length === 0) {
+      return [] as AnyPath[];
+    }
+    const safeIndex = Math.min(Math.max(currentFrameIndex, 0), frames.length - 1);
+    const current = frames[safeIndex];
+    const currentPaths = current?.paths ?? [];
+    if (!uiState.isPlaying || frames.length === 1) {
+      return currentPaths;
+    }
+    const nextIndex = (safeIndex + 1) % frames.length;
+    const nextPaths = frames[nextIndex]?.paths ?? [];
+    return interpolateFramePaths(currentPaths, nextPaths, frameProgress);
+  }, [frames, currentFrameIndex, uiState.isPlaying, frameProgress]);
+
+  const renderActivePaths = useMemo(() => {
+    if (groupIsolation.groupIsolationPath.length === 0) {
+      return renderFramePaths;
+    }
+    let currentLevel: AnyPath[] = renderFramePaths;
+    for (const group of groupIsolation.groupIsolationPath) {
+      const match = currentLevel.find(path => path.id === group.id && path.tool === 'group');
+      if (!match || match.tool !== 'group') {
+        return renderFramePaths;
+      }
+      currentLevel = (match as GroupData).children ?? [];
+    }
+    return currentLevel;
+  }, [groupIsolation.groupIsolationPath, renderFramePaths]);
+
+  const renderBackgroundPaths = useMemo(() => {
+    if (groupIsolation.groupIsolationPath.length === 0) {
+      return [] as AnyPath[];
+    }
+    return renderFramePaths;
+  }, [groupIsolation.groupIsolationPath, renderFramePaths]);
 
   const handleCropManualPointerDown = useCallback((point: Point, event: React.PointerEvent<SVGSVGElement>) => {
     if (event.button !== 0) return;
@@ -2007,22 +2098,6 @@ export const useAppStore = () => {
     };
   }, [refreshDirectoryEntries]);
 
-  useEffect(() => {
-    if (!uiState.isPlaying || frames.length === 0) return;
-    let frameInterval = 1000 / uiState.fps;
-    let lastFrameTime = 0;
-    let animationFrameId: number;
-    const animate = (timestamp: number) => {
-        if (timestamp - lastFrameTime > frameInterval) {
-            lastFrameTime = timestamp;
-            setCurrentFrameIndex(prev => (prev + 1) % frames.length);
-        }
-        animationFrameId = requestAnimationFrame(animate);
-    };
-    animationFrameId = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(animationFrameId);
-  }, [uiState.isPlaying, uiState.fps, frames.length, setCurrentFrameIndex]);
-
   useEffect(() => { /* ... save libraries ... */ }, [appState.styleLibrary, appState.materialLibrary]);
 
   const store = useMemo(
@@ -2033,6 +2108,9 @@ export const useAppStore = () => {
       ...groupIsolation,
       ...viewTransform,
       ...toolbarState,
+      renderPaths: renderActivePaths,
+      renderBackgroundPaths,
+      renderFramePaths,
       paths, // This should be current frame paths
       ...appActions,
       drawingInteraction,
@@ -2139,6 +2217,9 @@ export const useAppStore = () => {
       groupIsolation,
       viewTransform,
       toolbarState,
+      renderActivePaths,
+      renderBackgroundPaths,
+      renderFramePaths,
       paths,
       appActions,
       drawingInteraction,

--- a/src/lib/animation/interpolatePaths.ts
+++ b/src/lib/animation/interpolatePaths.ts
@@ -1,0 +1,363 @@
+import type {
+  AnyPath,
+  VectorPathData,
+  RectangleData,
+  EllipseData,
+  PolygonData,
+  FrameData,
+  TextData,
+  ImageData,
+  BrushPathData,
+  GroupData,
+  ArcData,
+  Anchor,
+  GradientFill,
+  LinearGradientFill,
+  RadialGradientFill,
+  GradientStop,
+  Point,
+} from '@/types';
+import { hslaToHslaString, parseColor, type HSLA } from '@/lib/color';
+
+const clampProgress = (progress: number): number => {
+  if (Number.isNaN(progress)) return 0;
+  if (progress <= 0) return 0;
+  if (progress >= 1) return 1;
+  return progress;
+};
+
+const lerp = (from: number, to: number, progress: number): number => from + (to - from) * progress;
+
+const lerpOptionalNumber = (
+  fromValue: number | undefined,
+  toValue: number | undefined,
+  progress: number,
+  fallback?: number
+): number | undefined => {
+  if (typeof fromValue === 'number' && typeof toValue === 'number') {
+    return lerp(fromValue, toValue, progress);
+  }
+  if (typeof fromValue === 'number') {
+    return progress <= 0.5 ? fromValue : toValue ?? fromValue;
+  }
+  if (typeof toValue === 'number') {
+    return progress >= 0.5 ? toValue : fromValue ?? toValue;
+  }
+  return fallback;
+};
+
+const interpolateHue = (from: number, to: number, progress: number): number => {
+  let delta = (to - from) % 360;
+  if (delta > 180) {
+    delta -= 360;
+  } else if (delta < -180) {
+    delta += 360;
+  }
+  return (from + delta * progress + 360) % 360;
+};
+
+const lerpColor = (fromColor: string | undefined, toColor: string | undefined, progress: number): string | undefined => {
+  if (!fromColor && !toColor) return undefined;
+  if (!fromColor) return toColor;
+  if (!toColor) return fromColor;
+
+  const from = parseColor(fromColor);
+  const to = parseColor(toColor);
+  const blended: HSLA = {
+    h: interpolateHue(from.h, to.h, progress),
+    s: lerp(from.s, to.s, progress),
+    l: lerp(from.l, to.l, progress),
+    a: lerp(from.a, to.a, progress),
+  };
+  return hslaToHslaString(blended);
+};
+
+const clonePath = <T extends AnyPath>(path: T): T => {
+  return JSON.parse(JSON.stringify(path)) as T;
+};
+
+const interpolatePoint = (from: Point, to: Point, progress: number): Point => ({
+  x: lerp(from.x, to.x, progress),
+  y: lerp(from.y, to.y, progress),
+});
+
+const interpolateAnchor = (from: Anchor, to: Anchor, progress: number): Anchor => ({
+  point: interpolatePoint(from.point, to.point, progress),
+  handleIn: interpolatePoint(from.handleIn, to.handleIn, progress),
+  handleOut: interpolatePoint(from.handleOut, to.handleOut, progress),
+});
+
+const interpolateGradientStops = (
+  fromStops: GradientStop[],
+  toStops: GradientStop[],
+  progress: number
+): GradientStop[] => {
+  const count = Math.min(fromStops.length, toStops.length);
+  if (count === 0) {
+    return toStops.length > 0 ? toStops.map(stop => ({ ...stop })) : fromStops.map(stop => ({ ...stop }));
+  }
+  const result: GradientStop[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const fromStop = fromStops[i];
+    const toStop = toStops[i];
+    result.push({
+      offset: lerp(fromStop.offset, toStop.offset, progress),
+      color: lerpColor(fromStop.color, toStop.color, progress) ?? (progress < 0.5 ? fromStop.color : toStop.color),
+      opacity: lerpOptionalNumber(fromStop.opacity, toStop.opacity, progress),
+    });
+  }
+  return result;
+};
+
+const interpolateGradient = (
+  fromGradient: GradientFill | null | undefined,
+  toGradient: GradientFill | null | undefined,
+  progress: number
+): GradientFill | null | undefined => {
+  if (!fromGradient && !toGradient) {
+    return undefined;
+  }
+  if (!fromGradient) {
+    return toGradient ? JSON.parse(JSON.stringify(toGradient)) as GradientFill : null;
+  }
+  if (!toGradient) {
+    return fromGradient ? JSON.parse(JSON.stringify(fromGradient)) as GradientFill : null;
+  }
+  if (fromGradient.type !== toGradient.type) {
+    return progress < 0.5 ? (JSON.parse(JSON.stringify(fromGradient)) as GradientFill) : (JSON.parse(JSON.stringify(toGradient)) as GradientFill);
+  }
+
+  if (fromGradient.type === 'linear' && toGradient.type === 'linear') {
+    const fromLinear = fromGradient as LinearGradientFill;
+    const toLinear = toGradient as LinearGradientFill;
+    return {
+      type: 'linear',
+      angle: lerp(fromLinear.angle, toLinear.angle, progress),
+      stops: interpolateGradientStops(fromLinear.stops, toLinear.stops, progress),
+      start: fromLinear.start && toLinear.start ? interpolatePoint(fromLinear.start, toLinear.start, progress) : (toLinear.start ?? fromLinear.start),
+      end: fromLinear.end && toLinear.end ? interpolatePoint(fromLinear.end, toLinear.end, progress) : (toLinear.end ?? fromLinear.end),
+    };
+  }
+
+  const fromRadial = fromGradient as RadialGradientFill;
+  const toRadial = toGradient as RadialGradientFill;
+  return {
+    type: 'radial',
+    stops: interpolateGradientStops(fromRadial.stops, toRadial.stops, progress),
+    center: interpolatePoint(fromRadial.center, toRadial.center, progress),
+    edge: interpolatePoint(fromRadial.edge, toRadial.edge, progress),
+  };
+};
+
+const applySharedPathProperties = (
+  base: AnyPath,
+  fromPath: AnyPath,
+  toPath: AnyPath,
+  progress: number
+) => {
+  const color = lerpColor(fromPath.color, toPath.color, progress);
+  if (color) {
+    base.color = color;
+  }
+  const fill = lerpColor(fromPath.fill, toPath.fill, progress);
+  if (fill) {
+    base.fill = fill;
+  }
+  base.fillGradient = interpolateGradient(fromPath.fillGradient, toPath.fillGradient, progress);
+  base.fillStyle = progress < 0.5 ? fromPath.fillStyle : toPath.fillStyle;
+  base.strokeWidth = lerpOptionalNumber(fromPath.strokeWidth, toPath.strokeWidth, progress, base.strokeWidth ?? toPath.strokeWidth ?? fromPath.strokeWidth ?? 0) ?? base.strokeWidth;
+  base.opacity = lerpOptionalNumber(fromPath.opacity ?? 1, toPath.opacity ?? 1, progress) ?? 1;
+  base.rotation = lerpOptionalNumber(fromPath.rotation ?? 0, toPath.rotation ?? 0, progress) ?? base.rotation;
+  base.scaleX = lerpOptionalNumber(fromPath.scaleX ?? 1, toPath.scaleX ?? 1, progress) ?? base.scaleX;
+  base.scaleY = lerpOptionalNumber(fromPath.scaleY ?? 1, toPath.scaleY ?? 1, progress) ?? base.scaleY;
+  if ('shadowColor' in fromPath || 'shadowColor' in toPath) {
+    const shadowColor = lerpColor((fromPath as any).shadowColor, (toPath as any).shadowColor, progress);
+    if (shadowColor) {
+      (base as any).shadowColor = shadowColor;
+    }
+  }
+  const numericKeys: Array<keyof AnyPath> = [
+    'shadowOffsetX',
+    'shadowOffsetY',
+    'shadowBlur',
+    'roughness',
+    'bowing',
+    'fillWeight',
+    'hachureAngle',
+    'hachureGap',
+    'curveTightness',
+    'curveStepCount',
+    'endpointSize',
+  ];
+  numericKeys.forEach(key => {
+    const value = lerpOptionalNumber((fromPath as any)[key], (toPath as any)[key], progress);
+    if (value !== undefined) {
+      (base as any)[key] = value;
+    }
+  });
+  base.isVisible = toPath.isVisible ?? fromPath.isVisible;
+  base.isLocked = toPath.isLocked ?? fromPath.isLocked;
+  base.name = toPath.name ?? fromPath.name;
+};
+
+const interpolateRectangleLike = <T extends RectangleData | FrameData | PolygonData | ImageData | EllipseData>(
+  fromPath: T,
+  toPath: T,
+  progress: number
+): T => {
+  const base = clonePath(fromPath);
+  applySharedPathProperties(base, fromPath, toPath, progress);
+  base.x = lerp(fromPath.x, toPath.x, progress);
+  base.y = lerp(fromPath.y, toPath.y, progress);
+  base.width = lerp(fromPath.width, toPath.width, progress);
+  base.height = lerp(fromPath.height, toPath.height, progress);
+  if ('borderRadius' in fromPath || 'borderRadius' in toPath) {
+    (base as any).borderRadius = lerpOptionalNumber((fromPath as any).borderRadius, (toPath as any).borderRadius, progress);
+  }
+  if ('skewX' in fromPath || 'skewX' in toPath) {
+    (base as any).skewX = lerpOptionalNumber((fromPath as any).skewX, (toPath as any).skewX, progress);
+  }
+  if ('skewY' in fromPath || 'skewY' in toPath) {
+    (base as any).skewY = lerpOptionalNumber((fromPath as any).skewY, (toPath as any).skewY, progress);
+  }
+  if ('sides' in fromPath || 'sides' in toPath) {
+    (base as any).sides = (progress < 0.5 ? (fromPath as any).sides : (toPath as any).sides) ?? (fromPath as any).sides;
+  }
+  return base;
+};
+
+const interpolateText = (fromPath: TextData, toPath: TextData, progress: number): TextData => {
+  const base = clonePath(fromPath);
+  applySharedPathProperties(base, fromPath, toPath, progress);
+  base.x = lerp(fromPath.x, toPath.x, progress);
+  base.y = lerp(fromPath.y, toPath.y, progress);
+  base.width = lerp(fromPath.width, toPath.width, progress);
+  base.height = lerp(fromPath.height, toPath.height, progress);
+  base.fontSize = lerp(fromPath.fontSize, toPath.fontSize, progress);
+  base.lineHeight = lerp(fromPath.lineHeight, toPath.lineHeight, progress);
+  base.text = progress < 0.5 ? fromPath.text : toPath.text;
+  base.textAlign = progress < 0.5 ? fromPath.textAlign : toPath.textAlign;
+  base.fontFamily = progress < 0.5 ? fromPath.fontFamily : toPath.fontFamily;
+  base.fontWeight = lerpOptionalNumber(fromPath.fontWeight, toPath.fontWeight, progress);
+  return base;
+};
+
+const interpolateVector = (fromPath: VectorPathData, toPath: VectorPathData, progress: number): VectorPathData => {
+  if (fromPath.anchors.length !== toPath.anchors.length) {
+    return progress < 0.5 ? clonePath(fromPath) : clonePath(toPath);
+  }
+  const base = clonePath(fromPath);
+  applySharedPathProperties(base, fromPath, toPath, progress);
+  base.anchors = fromPath.anchors.map((anchor, index) => interpolateAnchor(anchor, toPath.anchors[index], progress));
+  base.isClosed = toPath.isClosed ?? fromPath.isClosed;
+  return base;
+};
+
+const interpolateBrush = (fromPath: BrushPathData, toPath: BrushPathData, progress: number): BrushPathData => {
+  if (fromPath.points.length !== toPath.points.length) {
+    return progress < 0.5 ? clonePath(fromPath) : clonePath(toPath);
+  }
+  const base = clonePath(fromPath);
+  applySharedPathProperties(base, fromPath, toPath, progress);
+  base.points = fromPath.points.map((point, index) => interpolatePoint(point, toPath.points[index], progress));
+  return base;
+};
+
+const interpolateArc = (fromPath: ArcData, toPath: ArcData, progress: number): ArcData => {
+  const base = clonePath(fromPath);
+  applySharedPathProperties(base, fromPath, toPath, progress);
+  base.points = fromPath.points.map((point, index) => interpolatePoint(point, toPath.points[index] ?? point)) as [Point, Point, Point];
+  return base;
+};
+
+const interpolateGroup = (fromPath: GroupData, toPath: GroupData, progress: number): GroupData => {
+  const base = clonePath(fromPath);
+  applySharedPathProperties(base, fromPath, toPath, progress);
+  base.children = interpolatePathCollection(fromPath.children, toPath.children, progress);
+  base.isCollapsed = toPath.isCollapsed ?? fromPath.isCollapsed;
+  base.mask = toPath.mask ?? fromPath.mask;
+  return base;
+};
+
+const interpolatePathPair = (fromPath: AnyPath, toPath: AnyPath, progress: number): AnyPath => {
+  if (fromPath.tool !== toPath.tool) {
+    return progress < 0.5 ? clonePath(fromPath) : clonePath(toPath);
+  }
+  switch (fromPath.tool) {
+    case 'rectangle':
+      return interpolateRectangleLike(fromPath as RectangleData, toPath as RectangleData, progress);
+    case 'frame':
+      return interpolateRectangleLike(fromPath as FrameData, toPath as FrameData, progress);
+    case 'polygon':
+      return interpolateRectangleLike(fromPath as PolygonData, toPath as PolygonData, progress);
+    case 'ellipse':
+      return interpolateRectangleLike(fromPath as EllipseData, toPath as EllipseData, progress);
+    case 'image':
+      return interpolateRectangleLike(fromPath as ImageData, toPath as ImageData, progress);
+    case 'text':
+      return interpolateText(fromPath as TextData, toPath as TextData, progress);
+    case 'pen':
+    case 'line':
+      return interpolateVector(fromPath as VectorPathData, toPath as VectorPathData, progress);
+    case 'brush':
+      return interpolateBrush(fromPath as BrushPathData, toPath as BrushPathData, progress);
+    case 'arc':
+      return interpolateArc(fromPath as ArcData, toPath as ArcData, progress);
+    case 'group':
+      return interpolateGroup(fromPath as GroupData, toPath as GroupData, progress);
+    default:
+      return progress < 0.5 ? clonePath(fromPath) : clonePath(toPath);
+  }
+};
+
+const interpolatePathCollection = (
+  fromPaths: AnyPath[],
+  toPaths: AnyPath[],
+  progress: number
+): AnyPath[] => {
+  const clampedProgress = clampProgress(progress);
+  const fromMap = new Map(fromPaths.map(path => [path.id, path]));
+  const toMap = new Map(toPaths.map(path => [path.id, path]));
+  const orderedIds: string[] = [];
+  const seen = new Set<string>();
+  for (const path of toPaths) {
+    orderedIds.push(path.id);
+    seen.add(path.id);
+  }
+  for (const path of fromPaths) {
+    if (!seen.has(path.id)) {
+      orderedIds.push(path.id);
+      seen.add(path.id);
+    }
+  }
+
+  return orderedIds.map(id => {
+    const fromPath = fromMap.get(id);
+    const toPath = toMap.get(id);
+    if (fromPath && toPath) {
+      return interpolatePathPair(fromPath, toPath, clampedProgress);
+    }
+    if (fromPath) {
+      return clonePath(fromPath);
+    }
+    if (toPath) {
+      return clonePath(toPath);
+    }
+    throw new Error('Path with id not found in either collection');
+  });
+};
+
+export const interpolateFramePaths = (
+  fromPaths: AnyPath[],
+  toPaths: AnyPath[],
+  progress: number
+): AnyPath[] => {
+  if (progress <= 0) {
+    return fromPaths.map(clonePath);
+  }
+  if (progress >= 1) {
+    return toPaths.map(clonePath);
+  }
+  return interpolatePathCollection(fromPaths, toPaths, progress);
+};
+

--- a/src/lib/hit-testing.ts
+++ b/src/lib/hit-testing.ts
@@ -133,7 +133,7 @@ export function isPointHittingPath(point: Point, path: AnyPath, scale: number): 
             }
 
             const isFillVisible = path.tool === 'text' ? true : hasVisibleFill(path);
-            const treatInteriorAsHit = path.tool === 'frame' ? false : isFillVisible;
+            const treatInteriorAsHit = path.tool === 'frame' ? true : isFillVisible;
 
             // Check for hit on the fill area first.
             const isInside = testPoint.x >= x && testPoint.x <= x + width && testPoint.y >= y && testPoint.y <= y + height;

--- a/tests/lib/interpolateFramePaths.test.ts
+++ b/tests/lib/interpolateFramePaths.test.ts
@@ -1,0 +1,111 @@
+/**
+ * 测试插值生成帧路径时的几何与颜色过渡效果。
+ */
+import { describe, it, expect } from 'vitest';
+import { interpolateFramePaths } from '@/lib/animation/interpolatePaths';
+import type { RectangleData, TextData } from '@/types';
+
+const createRectangle = (overrides: Partial<RectangleData> = {}): RectangleData => ({
+  id: overrides.id ?? 'rect',
+  tool: 'rectangle',
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 100,
+  color: '#ff0000',
+  fill: '#ff0000',
+  fillStyle: 'solid',
+  strokeWidth: 2,
+  roughness: 1,
+  bowing: 0,
+  fillWeight: 0,
+  hachureAngle: 0,
+  hachureGap: 0,
+  curveTightness: 0,
+  curveStepCount: 0,
+  endpointSize: 1,
+  ...overrides,
+});
+
+const createText = (overrides: Partial<TextData> = {}): TextData => ({
+  id: overrides.id ?? 'text',
+  tool: 'text',
+  x: 0,
+  y: 0,
+  width: 200,
+  height: 50,
+  color: '#000000',
+  fill: '#000000',
+  fillStyle: 'solid',
+  strokeWidth: 1,
+  roughness: 1,
+  bowing: 0,
+  fillWeight: 0,
+  hachureAngle: 0,
+  hachureGap: 0,
+  curveTightness: 0,
+  curveStepCount: 0,
+  endpointSize: 1,
+  text: 'Hello',
+  fontFamily: 'Inter',
+  fontSize: 16,
+  lineHeight: 20,
+  textAlign: 'left',
+  ...overrides,
+});
+
+describe('interpolateFramePaths', () => {
+  it('linearly interpolates rectangle geometry and color', () => {
+    const fromRect = createRectangle({ x: 0, y: 0, color: '#ff0000', fill: '#ff0000' });
+    const toRect = createRectangle({ x: 200, y: 100, color: '#00ff00', fill: '#00ff00' });
+
+    const [result] = interpolateFramePaths([fromRect], [toRect], 0.5);
+
+    expect(result.x).toBeCloseTo(100);
+    expect(result.y).toBeCloseTo(50);
+    expect(result.color).toBe('hsla(60, 100%, 50%, 1)');
+    expect(result.fill).toBe('hsla(60, 100%, 50%, 1)');
+  });
+
+  it('interpolates text size, position, and color', () => {
+    const fromText = createText({
+      x: 0,
+      y: 0,
+      fontSize: 16,
+      lineHeight: 20,
+      color: '#000000',
+      fill: '#000000',
+    });
+    const toText = createText({
+      x: 100,
+      y: 40,
+      fontSize: 32,
+      lineHeight: 40,
+      color: '#ffffff',
+      fill: '#ffffff',
+    });
+
+    const [result] = interpolateFramePaths([fromText], [toText], 0.25);
+
+    expect(result.x).toBeCloseTo(25);
+    expect(result.y).toBeCloseTo(10);
+    expect(result.fontSize).toBeCloseTo(20);
+    expect(result.lineHeight).toBeCloseTo(25);
+    expect(result.color).toBe('hsla(0, 0%, 25%, 1)');
+  });
+
+  it('falls back to existing side when only one frame has the path', () => {
+    const rectangle = createRectangle({ id: 'rect-only' });
+
+    const resultFrom = interpolateFramePaths([rectangle], [], 0.75);
+    expect(resultFrom).toHaveLength(1);
+    expect(resultFrom[0]).not.toBe(rectangle);
+    expect(resultFrom[0].id).toBe('rect-only');
+
+    const resultTo = interpolateFramePaths([], [rectangle], 0.25);
+    expect(resultTo).toHaveLength(1);
+    expect(resultTo[0]).not.toBe(rectangle);
+    expect(resultTo[0].id).toBe('rect-only');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `interpolateFramePaths` to generate geometry and color blends between animation frames, including gradients and grouped paths
- update the app store playback loop to drive sub-frame interpolation, expose render-specific paths, and adjust hit-testing/frame handling in the UI
- surface interpolated paths in the main layout and cover the new helper with unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e4ed20f908832392f976cdd1772d90