### PR TITLE
fix: standardize side toolbar slider width

### DIFF
--- a/src/components/side-toolbar/shared.tsx
+++ b/src/components/side-toolbar/shared.tsx
@@ -45,9 +45,14 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
   };
 
   return (
-    <div className="grid grid-cols-[auto,1fr] items-center gap-x-4 min-h-[2rem]">
-      <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] whitespace-nowrap flex items-center leading-none`} htmlFor={label}>{label}</label>
-      <div className="w-full flex flex-col justify-center">
+    <div className="flex items-center gap-4 min-h-[2rem]">
+      <label
+        className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex items-center leading-none w-40 shrink-0 text-left whitespace-normal`}
+        htmlFor={label}
+      >
+        {label}
+      </label>
+      <div className="w-full flex flex-col justify-center flex-1">
         <input
           type="range"
           id={label}

--- a/src/components/side-toolbar/shared.tsx
+++ b/src/components/side-toolbar/shared.tsx
@@ -44,10 +44,13 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
     window.addEventListener('pointerup', handlePointerUp);
   };
 
+  const sliderProgress = max === min ? 0 : ((value - min) / (max - min)) * 100;
+  const clampedProgress = Math.min(100, Math.max(0, sliderProgress));
+
   return (
-    <div className="flex items-center gap-4 min-h-[2rem]">
+    <div className="flex items-center gap-4 min-h-[2rem] w-full">
       <label
-        className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex items-center leading-none w-40 shrink-0 text-left whitespace-normal`}
+        className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex items-center leading-tight w-32 shrink-0 text-left whitespace-normal`}
         htmlFor={label}
       >
         {label}
@@ -63,6 +66,7 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
           onChange={(e) => setValue(Number(e.target.value))}
           onPointerDown={handlePointerDown}
           className="w-full h-6 themed-slider"
+          style={{ '--slider-progress': `${clampedProgress}%` } as React.CSSProperties}
         />
         {displayValue && <span className="text-xs text-[var(--text-secondary)] block text-center mt-1 leading-none">{displayValue}</span>}
       </div>

--- a/src/components/side-toolbar/shared.tsx
+++ b/src/components/side-toolbar/shared.tsx
@@ -48,14 +48,14 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
   const clampedProgress = Math.min(100, Math.max(0, sliderProgress));
 
   return (
-    <div className="flex items-center gap-4 min-h-[2rem] w-full">
+    <div className="grid w-full grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-2 min-h-[2.25rem]">
       <label
-        className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex items-center leading-tight w-32 shrink-0 text-left whitespace-normal`}
+        className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex items-center leading-tight text-left whitespace-normal`}
         htmlFor={label}
       >
         {label}
       </label>
-      <div className="w-full flex flex-col justify-center flex-1">
+      <div className="flex flex-col justify-center min-w-0">
         <input
           type="range"
           id={label}

--- a/src/index.css
+++ b/src/index.css
@@ -241,8 +241,8 @@ input[type='range'].themed-slider {
   cursor: pointer;
   width: 100%;
   --slider-track-height: 0.375rem;
-  --slider-track-bg: rgba(var(--oc-gray-6-rgb), 0.35);
-  --slider-track-fill: rgba(var(--oc-blue-6-rgb), 0.75);
+  --slider-track-bg: rgba(var(--oc-gray-7-rgb), 0.7);
+  --slider-track-fill: var(--oc-blue-8);
   --slider-progress: 50%;
 }
 input[type='range'].themed-slider::-webkit-slider-runnable-track {

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,7 @@
   --dark-bg: #1a1b1e;
   --oc-gray-6-rgb: 134, 142, 150; /* Added for grid lines */
   --oc-gray-7-rgb: 73, 80, 87;
+  --oc-gray-8-rgb: 52, 58, 64;
 
   /* Base & Text */
   --bg-color: var(--dark-bg);
@@ -241,15 +242,16 @@ input[type='range'].themed-slider {
   cursor: pointer;
   width: 100%;
   --slider-track-height: 0.375rem;
-  --slider-track-bg: rgba(var(--oc-gray-7-rgb), 0.7);
-  --slider-track-fill: var(--oc-blue-8);
+  --slider-track-bg: rgba(var(--oc-gray-8-rgb), 0.85);
+  --slider-track-fill-start: #0f2443;
+  --slider-track-fill-end: #1e5cae;
   --slider-progress: 50%;
 }
 input[type='range'].themed-slider::-webkit-slider-runnable-track {
   background: linear-gradient(
     to right,
-    var(--slider-track-fill) 0%,
-    var(--slider-track-fill) var(--slider-progress),
+    var(--slider-track-fill-start) 0%,
+    var(--slider-track-fill-end) var(--slider-progress),
     var(--slider-track-bg) var(--slider-progress),
     var(--slider-track-bg) 100%
   );
@@ -273,7 +275,11 @@ input[type='range'].themed-slider::-moz-range-track {
   border-radius: 9999px;
 }
 input[type='range'].themed-slider::-moz-range-progress {
-  background: var(--slider-track-fill);
+  background: linear-gradient(
+    to right,
+    var(--slider-track-fill-start),
+    var(--slider-track-fill-end)
+  );
   height: var(--slider-track-height);
   border-radius: 9999px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -240,33 +240,50 @@ input[type='range'].themed-slider {
   background: transparent;
   cursor: pointer;
   width: 100%;
+  --slider-track-height: 0.375rem;
+  --slider-track-bg: rgba(var(--oc-gray-6-rgb), 0.35);
+  --slider-track-fill: rgba(var(--oc-blue-6-rgb), 0.75);
+  --slider-progress: 50%;
 }
 input[type='range'].themed-slider::-webkit-slider-runnable-track {
-  background: var(--ui-element-bg);
-  height: 0.25rem;
-  border-radius: 0.25rem;
+  background: linear-gradient(
+    to right,
+    var(--slider-track-fill) 0%,
+    var(--slider-track-fill) var(--slider-progress),
+    var(--slider-track-bg) var(--slider-progress),
+    var(--slider-track-bg) 100%
+  );
+  height: var(--slider-track-height);
+  border-radius: 9999px;
 }
 input[type='range'].themed-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  margin-top: -0.375rem;
-  background-color: var(--text-primary);
-  height: 1rem;
-  width: 1rem;
+  margin-top: calc((var(--slider-track-height) - 1rem) / 2);
+  background-color: var(--accent-primary);
+  height: 1.1rem;
+  width: 1.1rem;
   border-radius: 9999px;
-  border: 2px solid var(--accent-primary);
+  border: 2px solid rgba(var(--oc-blue-6-rgb), 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
 }
 input[type='range'].themed-slider::-moz-range-track {
-  background: var(--ui-element-bg);
-  height: 0.25rem;
-  border-radius: 0.25rem;
+  background: var(--slider-track-bg);
+  height: var(--slider-track-height);
+  border-radius: 9999px;
+}
+input[type='range'].themed-slider::-moz-range-progress {
+  background: var(--slider-track-fill);
+  height: var(--slider-track-height);
+  border-radius: 9999px;
 }
 input[type='range'].themed-slider::-moz-range-thumb {
-  background-color: var(--text-primary);
-  height: 1rem;
-  width: 1rem;
+  background-color: var(--accent-primary);
+  height: 1.1rem;
+  width: 1.1rem;
   border-radius: 9999px;
-  border: 2px solid var(--accent-primary);
+  border: 2px solid rgba(var(--oc-blue-6-rgb), 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
 }
 
 @keyframes marching-ants {


### PR DESCRIPTION
## Summary
- ensure side toolbar slider labels use a fixed width so the slider track remains consistent
- allow longer labels to wrap while keeping the slider and label aligned side-by-side

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e5033526208323a1048627d2d146f5