### PR TITLE
feat: use icons for files panel actions

### DIFF
--- a/src/components/files-panel/FilesPanel.tsx
+++ b/src/components/files-panel/FilesPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from 'react';
+import { FilePlus, FolderOpen, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
 import type { BoardFileEntry } from '@/types';
@@ -82,17 +83,23 @@ export const FilesPanel: React.FC = () => {
               type="button"
               onClick={handleCreateFile}
               disabled={isDirectoryLoading}
-              className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label={t('filesPanel.createFile')}
+              title={t('filesPanel.createFile')}
+              className="flex items-center justify-center rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {t('filesPanel.createFile')}
+              <FilePlus aria-hidden="true" className="h-4 w-4" />
+              <span className="sr-only">{t('filesPanel.createFile')}</span>
             </button>
             <button
               type="button"
               onClick={handleRefresh}
               disabled={isDirectoryLoading}
-              className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label={t('filesPanel.refresh')}
+              title={t('filesPanel.refresh')}
+              className="flex items-center justify-center rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              {t('filesPanel.refresh')}
+              <RefreshCw aria-hidden="true" className="h-4 w-4" />
+              <span className="sr-only">{t('filesPanel.refresh')}</span>
             </button>
           </>
         ) : null}
@@ -100,9 +107,14 @@ export const FilesPanel: React.FC = () => {
           type="button"
           onClick={handleSelectFolder}
           disabled={isDirectoryLoading}
-          className="rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+          aria-label={directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
+          title={directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
+          className="flex items-center justify-center rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
+          <FolderOpen aria-hidden="true" className="h-4 w-4" />
+          <span className="sr-only">
+            {directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
+          </span>
         </button>
       </div>
 

--- a/src/components/files-panel/FilesPanel.tsx
+++ b/src/components/files-panel/FilesPanel.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { FilePlus, FolderOpen, RefreshCw } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
+import PanelButton from '@/components/PanelButton';
 import type { BoardFileEntry } from '@/types';
 
 export const FilesPanel: React.FC = () => {
@@ -79,43 +80,46 @@ export const FilesPanel: React.FC = () => {
       <div className="flex items-center justify-end gap-2 border-b border-[var(--ui-separator)] pb-3">
         {directoryHandle ? (
           <>
-            <button
+            <PanelButton
               type="button"
               onClick={handleCreateFile}
               disabled={isDirectoryLoading}
               aria-label={t('filesPanel.createFile')}
               title={t('filesPanel.createFile')}
-              className="flex items-center justify-center rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+              variant="unstyled"
+              className="flex h-[34px] w-[34px] items-center justify-center rounded-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--ui-element-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               <FilePlus aria-hidden="true" className="h-4 w-4" />
               <span className="sr-only">{t('filesPanel.createFile')}</span>
-            </button>
-            <button
+            </PanelButton>
+            <PanelButton
               type="button"
               onClick={handleRefresh}
               disabled={isDirectoryLoading}
               aria-label={t('filesPanel.refresh')}
               title={t('filesPanel.refresh')}
-              className="flex items-center justify-center rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+              variant="unstyled"
+              className="flex h-[34px] w-[34px] items-center justify-center rounded-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--ui-element-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
             >
               <RefreshCw aria-hidden="true" className="h-4 w-4" />
               <span className="sr-only">{t('filesPanel.refresh')}</span>
-            </button>
+            </PanelButton>
           </>
         ) : null}
-        <button
+        <PanelButton
           type="button"
           onClick={handleSelectFolder}
           disabled={isDirectoryLoading}
           aria-label={directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
           title={directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
-          className="flex items-center justify-center rounded-md border border-[var(--ui-panel-border)] bg-[var(--ui-element-bg)] px-2 py-1 text-xs font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--ui-hover-bg)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+          variant="unstyled"
+          className="flex h-[34px] w-[34px] items-center justify-center rounded-lg text-[var(--text-secondary)] transition-colors hover:bg-[var(--ui-element-bg-hover)] disabled:cursor-not-allowed disabled:opacity-50"
         >
           <FolderOpen aria-hidden="true" className="h-4 w-4" />
           <span className="sr-only">
             {directoryHandle ? t('filesPanel.changeFolder') : t('filesPanel.selectFolder')}
           </span>
-        </button>
+        </PanelButton>
       </div>
 
       {errorMessage ? (


### PR DESCRIPTION
## Summary
- replace the files panel action buttons' text labels with lucide icons for a cleaner toolbar
- add aria-label, title, and visually hidden text to keep the icon buttons accessible to assistive tech

## Testing
- npm run build

## UI Changes
![Files panel icons](browser:/invocations/qyesjliv/artifacts/artifacts/files-panel-icons.png)

------
https://chatgpt.com/codex/tasks/task_e_68e6061c51888323b69092b378e1b432