### PR TITLE
fix: adjust measurement label placement

### DIFF
--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -232,13 +232,9 @@ const ShapeControls: React.FC<{
 
     let rotationHandleLabel: React.ReactNode = null;
     if (showMeasurements && typeof path.rotation === 'number') {
-        const handleVec = { x: rotationHandlePos.x - topCenter.x, y: rotationHandlePos.y - topCenter.y };
-        const handleLength = Math.hypot(handleVec.x, handleVec.y);
-        const handleUnit = handleLength > 0.0001 ? { x: handleVec.x / handleLength, y: handleVec.y / handleLength } : { x: 0, y: -1 };
-
         const labelCenter = {
-            x: rotationHandlePos.x + handleUnit.x * handleLabelOffsetWorld,
-            y: rotationHandlePos.y + handleUnit.y * handleLabelOffsetWorld,
+            x: rotationHandlePos.x + handleLabelOffsetWorld,
+            y: rotationHandlePos.y,
         };
 
         const handleRotationSubmit = (newRotation: number) => {
@@ -297,19 +293,10 @@ const ShapeControls: React.FC<{
                     const handlePos = transformPoint(unrotatedHandlePos);
                     const rotatedCornerPos = transformPoint(cornerPos);
 
-                    const handleDirection = {
-                        x: handlePos.x - rotatedCornerPos.x,
-                        y: handlePos.y - rotatedCornerPos.y,
-                    };
-                    const handleLength = Math.hypot(handleDirection.x, handleDirection.y);
-                    const handleUnit = handleLength > 0.0001
-                        ? { x: handleDirection.x / handleLength, y: handleDirection.y / handleLength }
-                        : { x: 0, y: -1 };
-
                     const cornerRadiusValue = 'borderRadius' in path ? Math.max(0, path.borderRadius ?? 0) : 0;
                     const cornerLabelCenter = {
-                        x: handlePos.x + handleUnit.x * handleLabelOffsetWorld,
-                        y: handlePos.y + handleUnit.y * handleLabelOffsetWorld,
+                        x: handlePos.x - handleLabelOffsetWorld,
+                        y: handlePos.y,
                     };
 
                     return (
@@ -1070,13 +1057,9 @@ const MultiSelectionControls: React.FC<{
 
     let rotationHandleLabel: React.ReactNode = null;
     if (showMeasurements && typeof rotationValue === 'number') {
-        const handleVec = { x: rotationHandlePos.x - topCenter.x, y: rotationHandlePos.y - topCenter.y };
-        const handleLength = Math.hypot(handleVec.x, handleVec.y);
-        const handleUnit = handleLength > 0.0001 ? { x: handleVec.x / handleLength, y: handleVec.y / handleLength } : { x: 0, y: -1 };
-
         const labelCenter = {
-            x: rotationHandlePos.x + handleUnit.x * handleLabelOffsetWorld,
-            y: rotationHandlePos.y + handleUnit.y * handleLabelOffsetWorld,
+            x: rotationHandlePos.x + handleLabelOffsetWorld,
+            y: rotationHandlePos.y,
         };
 
         const labelOrientation = normalizeLabelOrientation(rotationValue);

--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -225,16 +225,20 @@ const ShapeControls: React.FC<{
     const topCenter = transformPoint(topCenterUnrotated);
     const rotationHandlePos = transformPoint(rotationHandlePosUnrotated);
 
-    const labelHeight = LABEL_FONT_SIZE + LABEL_PADDING_Y * 2;
-    const handleLabelOffsetWorld = (HANDLE_LABEL_OFFSET_PX + labelHeight / 2) / scale;
-
     const labelOrientation = normalizeLabelOrientation(path.rotation ?? 0);
+    const orientationVector = {
+        x: Math.cos(labelOrientation),
+        y: Math.sin(labelOrientation),
+    };
 
     let rotationHandleLabel: React.ReactNode = null;
     if (showMeasurements && typeof path.rotation === 'number') {
+        const rotationLabelText = formatRotationValue(path.rotation ?? 0);
+        const { width: rotationLabelWidthPx } = getLabelDimensionsPx(rotationLabelText);
+        const rotationLabelOffsetWorld = (HANDLE_LABEL_OFFSET_PX + rotationLabelWidthPx / 2) / scale;
         const labelCenter = {
-            x: rotationHandlePos.x + handleLabelOffsetWorld,
-            y: rotationHandlePos.y,
+            x: rotationHandlePos.x + orientationVector.x * rotationLabelOffsetWorld,
+            y: rotationHandlePos.y + orientationVector.y * rotationLabelOffsetWorld,
         };
 
         const handleRotationSubmit = (newRotation: number) => {
@@ -294,9 +298,12 @@ const ShapeControls: React.FC<{
                     const rotatedCornerPos = transformPoint(cornerPos);
 
                     const cornerRadiusValue = 'borderRadius' in path ? Math.max(0, path.borderRadius ?? 0) : 0;
+                    const cornerLabelText = `R ${formatDimensionValue(Math.max(0, cornerRadiusValue))}`;
+                    const { width: cornerLabelWidthPx } = getLabelDimensionsPx(cornerLabelText);
+                    const cornerLabelOffsetWorld = (HANDLE_LABEL_OFFSET_PX + cornerLabelWidthPx / 2) / scale;
                     const cornerLabelCenter = {
-                        x: handlePos.x - handleLabelOffsetWorld,
-                        y: handlePos.y,
+                        x: handlePos.x - orientationVector.x * cornerLabelOffsetWorld,
+                        y: handlePos.y - orientationVector.y * cornerLabelOffsetWorld,
                     };
 
                     return (
@@ -573,6 +580,11 @@ const LABEL_PADDING_X = 10;
 const LABEL_PADDING_Y = 4;
 const LABEL_OFFSET_PX = 12;
 const HANDLE_LABEL_OFFSET_PX = 8;
+
+const getLabelDimensionsPx = (text: string) => ({
+  width: measureTextWidth(text, LABEL_FONT) + LABEL_PADDING_X * 2,
+  height: LABEL_FONT_SIZE + LABEL_PADDING_Y * 2,
+});
 
 type DimensionGuide = {
   width: number;
@@ -1052,17 +1064,20 @@ const MultiSelectionControls: React.FC<{
     const rotationHandlePos = { x: topCenter.x, y: topCenter.y - rotationHandleOffset };
     const firstPathId = paths[0]?.id;
 
-    const labelHeight = LABEL_FONT_SIZE + LABEL_PADDING_Y * 2;
-    const handleLabelOffsetWorld = (HANDLE_LABEL_OFFSET_PX + labelHeight / 2) / scale;
-
     let rotationHandleLabel: React.ReactNode = null;
     if (showMeasurements && typeof rotationValue === 'number') {
-        const labelCenter = {
-            x: rotationHandlePos.x + handleLabelOffsetWorld,
-            y: rotationHandlePos.y,
-        };
-
+        const rotationLabelText = formatRotationValue(rotationValue);
+        const { width: rotationLabelWidthPx } = getLabelDimensionsPx(rotationLabelText);
         const labelOrientation = normalizeLabelOrientation(rotationValue);
+        const orientationVector = {
+            x: Math.cos(labelOrientation),
+            y: Math.sin(labelOrientation),
+        };
+        const rotationLabelOffsetWorld = (HANDLE_LABEL_OFFSET_PX + rotationLabelWidthPx / 2) / scale;
+        const labelCenter = {
+            x: rotationHandlePos.x + orientationVector.x * rotationLabelOffsetWorld,
+            y: rotationHandlePos.y + orientationVector.y * rotationLabelOffsetWorld,
+        };
 
         const handleRotationSubmit = (newRotation: number) => {
             if (onRotationCommit) {

--- a/src/components/whiteboard/ControlsRenderer.tsx
+++ b/src/components/whiteboard/ControlsRenderer.tsx
@@ -226,10 +226,7 @@ const ShapeControls: React.FC<{
     const rotationHandlePos = transformPoint(rotationHandlePosUnrotated);
 
     const labelOrientation = normalizeLabelOrientation(path.rotation ?? 0);
-    const orientationVector = {
-        x: Math.cos(labelOrientation),
-        y: Math.sin(labelOrientation),
-    };
+    const orientationVector = getStableHandleOffsetVector(labelOrientation);
 
     let rotationHandleLabel: React.ReactNode = null;
     if (showMeasurements && typeof path.rotation === 'number') {
@@ -660,6 +657,11 @@ const normalizeLabelOrientation = (radians: number) => {
   return normalized > 0 ? normalized - Math.PI : normalized + Math.PI;
 };
 
+const getStableHandleOffsetVector = (orientationRadians: number) => ({
+  x: Math.cos(orientationRadians),
+  y: Math.abs(Math.sin(orientationRadians)),
+});
+
 const formatRotationInputValue = (radians: number) => {
   const normalizedDegrees = (normalizeRotationRadians(radians) * 180) / Math.PI;
   if (Math.abs(normalizedDegrees) < 0.01) {
@@ -1069,10 +1071,7 @@ const MultiSelectionControls: React.FC<{
         const rotationLabelText = formatRotationValue(rotationValue);
         const { width: rotationLabelWidthPx } = getLabelDimensionsPx(rotationLabelText);
         const labelOrientation = normalizeLabelOrientation(rotationValue);
-        const orientationVector = {
-            x: Math.cos(labelOrientation),
-            y: Math.sin(labelOrientation),
-        };
+        const orientationVector = getStableHandleOffsetVector(labelOrientation);
         const rotationLabelOffsetWorld = (HANDLE_LABEL_OFFSET_PX + rotationLabelWidthPx / 2) / scale;
         const labelCenter = {
             x: rotationHandlePos.x + orientationVector.x * rotationLabelOffsetWorld,


### PR DESCRIPTION
## Summary
- move the rotation measurement label to the right side of the angle handle
- position the corner radius measurement label to the left of its handle to avoid overlap

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e60df619008323874727e5daa29ddd