### PR TITLE
fix: deepen side toolbar slider gradient

### DIFF
--- a/src/components/side-toolbar/shared.tsx
+++ b/src/components/side-toolbar/shared.tsx
@@ -44,10 +44,18 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
     window.addEventListener('pointerup', handlePointerUp);
   };
 
+  const sliderProgress = max === min ? 0 : ((value - min) / (max - min)) * 100;
+  const clampedProgress = Math.min(100, Math.max(0, sliderProgress));
+
   return (
-    <div className="grid grid-cols-[auto,1fr] items-center gap-x-4 min-h-[2rem]">
-      <label className={`${PANEL_CLASSES.label} text-[var(--text-primary)] whitespace-nowrap flex items-center leading-none`} htmlFor={label}>{label}</label>
-      <div className="w-full flex flex-col justify-center">
+    <div className="grid w-full grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-2 min-h-[2.25rem]">
+      <label
+        className={`${PANEL_CLASSES.label} text-[var(--text-primary)] flex items-center leading-tight text-left whitespace-normal`}
+        htmlFor={label}
+      >
+        {label}
+      </label>
+      <div className="flex flex-col justify-center min-w-0">
         <input
           type="range"
           id={label}
@@ -58,6 +66,7 @@ export const Slider: React.FC<SliderProps> = React.memo(({ label, value, setValu
           onChange={(e) => setValue(Number(e.target.value))}
           onPointerDown={handlePointerDown}
           className="w-full h-6 themed-slider"
+          style={{ '--slider-progress': `${clampedProgress}%` } as React.CSSProperties}
         />
         {displayValue && <span className="text-xs text-[var(--text-secondary)] block text-center mt-1 leading-none">{displayValue}</span>}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,7 @@
   --dark-bg: #1a1b1e;
   --oc-gray-6-rgb: 134, 142, 150; /* Added for grid lines */
   --oc-gray-7-rgb: 73, 80, 87;
+  --oc-gray-8-rgb: 52, 58, 64;
 
   /* Base & Text */
   --bg-color: var(--dark-bg);
@@ -240,33 +241,55 @@ input[type='range'].themed-slider {
   background: transparent;
   cursor: pointer;
   width: 100%;
+  --slider-track-height: 0.375rem;
+  --slider-track-bg: rgba(var(--oc-gray-8-rgb), 0.85);
+  --slider-track-fill-start: #0f2443;
+  --slider-track-fill-end: #1e5cae;
+  --slider-progress: 50%;
 }
 input[type='range'].themed-slider::-webkit-slider-runnable-track {
-  background: var(--ui-element-bg);
-  height: 0.25rem;
-  border-radius: 0.25rem;
+  background: linear-gradient(
+    to right,
+    var(--slider-track-fill-start) 0%,
+    var(--slider-track-fill-end) var(--slider-progress),
+    var(--slider-track-bg) var(--slider-progress),
+    var(--slider-track-bg) 100%
+  );
+  height: var(--slider-track-height);
+  border-radius: 9999px;
 }
 input[type='range'].themed-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
-  margin-top: -0.375rem;
-  background-color: var(--text-primary);
-  height: 1rem;
-  width: 1rem;
+  margin-top: calc((var(--slider-track-height) - 1rem) / 2);
+  background-color: var(--accent-primary);
+  height: 1.1rem;
+  width: 1.1rem;
   border-radius: 9999px;
-  border: 2px solid var(--accent-primary);
+  border: 2px solid rgba(var(--oc-blue-6-rgb), 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
 }
 input[type='range'].themed-slider::-moz-range-track {
-  background: var(--ui-element-bg);
-  height: 0.25rem;
-  border-radius: 0.25rem;
+  background: var(--slider-track-bg);
+  height: var(--slider-track-height);
+  border-radius: 9999px;
+}
+input[type='range'].themed-slider::-moz-range-progress {
+  background: linear-gradient(
+    to right,
+    var(--slider-track-fill-start),
+    var(--slider-track-fill-end)
+  );
+  height: var(--slider-track-height);
+  border-radius: 9999px;
 }
 input[type='range'].themed-slider::-moz-range-thumb {
-  background-color: var(--text-primary);
-  height: 1rem;
-  width: 1rem;
+  background-color: var(--accent-primary);
+  height: 1.1rem;
+  width: 1.1rem;
   border-radius: 9999px;
-  border: 2px solid var(--accent-primary);
+  border: 2px solid rgba(var(--oc-blue-6-rgb), 0.5);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.25);
 }
 
 @keyframes marching-ants {


### PR DESCRIPTION
## Summary
- expand the slider row into a grid layout so labels stay aligned while the track stretches further across the panel
- deepen the slider track background and apply a darker gradient progress fill for higher contrast

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5033526208323a1048627d2d146f5