### PR TITLE
Extract cursor and onion-skin logic into dedicated modules and add unit tests

### DIFF
--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -10,7 +10,7 @@ import { Whiteboard } from './Whiteboard';
 import { LayersProvider, type LayersContextValue } from '../lib/layers-context';
 import { ICONS, CONTROL_BUTTON_CLASS } from '../constants';
 import PanelButton from '@/components/PanelButton';
-import type { MaterialData, AnyPath, GroupData } from '../types';
+import type { MaterialData } from '../types';
 import { useTranslation } from 'react-i18next';
 
 // Import new layout components
@@ -18,26 +18,8 @@ import { MainMenuPanel } from './layout/MainMenuPanel';
 import { SideToolbarPanel } from './layout/SideToolbarPanel';
 import { CanvasOverlays } from './layout/CanvasOverlays';
 import { TimelinePanel } from './TimelinePanel';
-
-const clonePathForOnionSkin = (path: AnyPath, prefix: string, opacityFactor: number): AnyPath => {
-    const baseOpacity = path.opacity ?? 1;
-    const cloned = {
-        ...path,
-        id: `${prefix}${path.id}`,
-        opacity: baseOpacity * opacityFactor,
-        isLocked: true,
-    } as AnyPath;
-
-    if (path.tool === 'group') {
-        const group = path as GroupData;
-        return {
-            ...(cloned as GroupData),
-            children: group.children.map(child => clonePathForOnionSkin(child, prefix, opacityFactor)),
-        };
-    }
-
-    return cloned;
-};
+import { selectOnionSkinPaths } from '@/features/timeline/selectors';
+import { resolveCanvasCursor } from '@/features/canvas/cursorPolicy';
 
 export const MainLayout: React.FC = () => {
     const store = useAppContext();
@@ -94,38 +76,14 @@ export const MainLayout: React.FC = () => {
 
     const layersValue = useMemo<LayersContextValue>(() => store.activePathState, [store.activePathState]);
 
-    const onionSkinPaths = useMemo(() => {
-        if (!isOnionSkinEnabled || frames.length <= 1) {
-            return [];
-        }
-
-        const skinPaths: AnyPath[] = [];
-        const maxOpacity = onionSkinOpacity;
-
-        // Previous frames
-        for (let i = 1; i <= onionSkinPrevFrames; i++) {
-            const frameIndex = currentFrameIndex - i;
-            if (frameIndex < 0) break;
-            const opacity = maxOpacity * ((onionSkinPrevFrames - i + 1) / (onionSkinPrevFrames + 1));
-            const framePaths = frames[frameIndex].paths
-                .filter(p => p.isVisible !== false)
-                .map(p => clonePathForOnionSkin(p, `onion-prev-${i}-`, opacity));
-            skinPaths.push(...framePaths);
-        }
-
-        // Next frames
-        for (let i = 1; i <= onionSkinNextFrames; i++) {
-            const frameIndex = currentFrameIndex + i;
-            if (frameIndex >= frames.length) break;
-            const opacity = maxOpacity * ((onionSkinNextFrames - i + 1) / (onionSkinNextFrames + 1));
-            const framePaths = frames[frameIndex].paths
-                .filter(p => p.isVisible !== false)
-                .map(p => clonePathForOnionSkin(p, `onion-next-${i}-`, opacity));
-            skinPaths.push(...framePaths);
-        }
-
-        return skinPaths;
-    }, [isOnionSkinEnabled, frames, currentFrameIndex, onionSkinPrevFrames, onionSkinNextFrames, onionSkinOpacity]);
+    const onionSkinPaths = useMemo(() => selectOnionSkinPaths({
+        isOnionSkinEnabled,
+        frames,
+        currentFrameIndex,
+        onionSkinPrevFrames,
+        onionSkinNextFrames,
+        onionSkinOpacity,
+    }), [isOnionSkinEnabled, frames, currentFrameIndex, onionSkinPrevFrames, onionSkinNextFrames, onionSkinOpacity]);
 
     /**
      * 创建一个处理画布右键菜单的函数。
@@ -150,21 +108,16 @@ export const MainLayout: React.FC = () => {
     /**
      * 根据当前状态决定光标样式。
      */
-    const getCursor = useCallback(() => {
-        if (isPanning) return 'grabbing';
-        if (selectionInteraction.dragState?.type === 'move' || selectionInteraction.dragState?.type === 'rotate') return 'grabbing';
-        if (selectionInteraction.dragState?.type === 'crop') return (selectionInteraction.dragState as any).cursor || 'crosshair';
-        if (croppingState && cropTool === 'magic-wand') return 'crosshair';
-        switch (tool) {
-            case 'selection':
-                if (selectionMode === 'lasso') return 'crosshair';
-                if (selectionMode === 'move') return selectionInteraction.isHoveringMovable ? 'grab' : 'default';
-                if (selectionMode === 'edit') return selectionInteraction.isHoveringEditable ? 'pointer' : 'default';
-                return 'default';
-            case 'brush': case 'pen': case 'rectangle': case 'polygon': case 'ellipse': case 'line': case 'arc': return 'crosshair';
-            default: return 'default';
-        }
-    }, [isPanning, tool, selectionMode, selectionInteraction.dragState, selectionInteraction.isHoveringMovable, selectionInteraction.isHoveringEditable, croppingState, cropTool]);
+    const getCursor = useCallback(() => resolveCanvasCursor({
+        isPanning,
+        tool,
+        selectionMode,
+        dragState: selectionInteraction.dragState,
+        isHoveringMovable: selectionInteraction.isHoveringMovable,
+        isHoveringEditable: selectionInteraction.isHoveringEditable,
+        hasCroppingState: Boolean(croppingState),
+        cropTool,
+    }), [isPanning, tool, selectionMode, selectionInteraction.dragState, selectionInteraction.isHoveringMovable, selectionInteraction.isHoveringEditable, croppingState, cropTool]);
 
     /**
      * 处理画布上的拖放事件，用于素材和文件导入。

--- a/src/features/canvas/cursorPolicy.ts
+++ b/src/features/canvas/cursorPolicy.ts
@@ -1,0 +1,51 @@
+import type { SelectionMode, Tool } from '@/types';
+
+export type CursorDragState = {
+  type: string;
+  cursor?: string;
+} | null;
+
+export type CursorPolicyInput = {
+  isPanning: boolean;
+  tool: Tool;
+  selectionMode: SelectionMode;
+  dragState: CursorDragState;
+  isHoveringMovable: boolean;
+  isHoveringEditable: boolean;
+  hasCroppingState: boolean;
+  cropTool: 'crop' | 'magic-wand' | 'adjust';
+};
+
+export const resolveCanvasCursor = ({
+  isPanning,
+  tool,
+  selectionMode,
+  dragState,
+  isHoveringMovable,
+  isHoveringEditable,
+  hasCroppingState,
+  cropTool,
+}: CursorPolicyInput): string => {
+  if (isPanning) return 'grabbing';
+  if (dragState?.type === 'move' || dragState?.type === 'rotate') return 'grabbing';
+  if (dragState?.type === 'crop') return dragState.cursor || 'crosshair';
+  if (hasCroppingState && cropTool === 'magic-wand') return 'crosshair';
+
+  switch (tool) {
+    case 'selection':
+      if (selectionMode === 'lasso') return 'crosshair';
+      if (selectionMode === 'move') return isHoveringMovable ? 'grab' : 'default';
+      if (selectionMode === 'edit') return isHoveringEditable ? 'pointer' : 'default';
+      return 'default';
+    case 'brush':
+    case 'pen':
+    case 'rectangle':
+    case 'polygon':
+    case 'ellipse':
+    case 'line':
+    case 'arc':
+      return 'crosshair';
+    default:
+      return 'default';
+  }
+};

--- a/src/features/timeline/selectors.ts
+++ b/src/features/timeline/selectors.ts
@@ -1,0 +1,68 @@
+import type { AnyPath, GroupData } from '@/types';
+
+export type OnionSkinOptions = {
+  isOnionSkinEnabled: boolean;
+  frames: Array<{ paths: AnyPath[] }>;
+  currentFrameIndex: number;
+  onionSkinPrevFrames: number;
+  onionSkinNextFrames: number;
+  onionSkinOpacity: number;
+};
+
+const clonePathForOnionSkin = (path: AnyPath, prefix: string, opacityFactor: number): AnyPath => {
+  const baseOpacity = path.opacity ?? 1;
+  const cloned = {
+    ...path,
+    id: `${prefix}${path.id}`,
+    opacity: baseOpacity * opacityFactor,
+    isLocked: true,
+  } as AnyPath;
+
+  if (path.tool === 'group') {
+    const group = path as GroupData;
+    return {
+      ...(cloned as GroupData),
+      children: group.children.map(child => clonePathForOnionSkin(child, prefix, opacityFactor)),
+    };
+  }
+
+  return cloned;
+};
+
+export const selectOnionSkinPaths = ({
+  isOnionSkinEnabled,
+  frames,
+  currentFrameIndex,
+  onionSkinPrevFrames,
+  onionSkinNextFrames,
+  onionSkinOpacity,
+}: OnionSkinOptions): AnyPath[] => {
+  if (!isOnionSkinEnabled || frames.length <= 1) {
+    return [];
+  }
+
+  const skinPaths: AnyPath[] = [];
+  const maxOpacity = onionSkinOpacity;
+
+  for (let i = 1; i <= onionSkinPrevFrames; i++) {
+    const frameIndex = currentFrameIndex - i;
+    if (frameIndex < 0) break;
+    const opacity = maxOpacity * ((onionSkinPrevFrames - i + 1) / (onionSkinPrevFrames + 1));
+    const framePaths = frames[frameIndex].paths
+      .filter(p => p.isVisible !== false)
+      .map(p => clonePathForOnionSkin(p, `onion-prev-${i}-`, opacity));
+    skinPaths.push(...framePaths);
+  }
+
+  for (let i = 1; i <= onionSkinNextFrames; i++) {
+    const frameIndex = currentFrameIndex + i;
+    if (frameIndex >= frames.length) break;
+    const opacity = maxOpacity * ((onionSkinNextFrames - i + 1) / (onionSkinNextFrames + 1));
+    const framePaths = frames[frameIndex].paths
+      .filter(p => p.isVisible !== false)
+      .map(p => clonePathForOnionSkin(p, `onion-next-${i}-`, opacity));
+    skinPaths.push(...framePaths);
+  }
+
+  return skinPaths;
+};

--- a/tests/features/canvas/cursorPolicy.test.ts
+++ b/tests/features/canvas/cursorPolicy.test.ts
@@ -1,0 +1,40 @@
+/**
+ * 覆盖画布光标策略的可观察行为：优先级判定与不同工具模式下的返回值。
+ */
+import { describe, expect, it } from 'vitest';
+import type { SelectionMode, Tool } from '@/types';
+import { resolveCanvasCursor } from '@/features/canvas/cursorPolicy';
+
+const baseInput = {
+  isPanning: false,
+  tool: 'selection' as Tool,
+  selectionMode: 'move' as SelectionMode,
+  dragState: null,
+  isHoveringMovable: false,
+  isHoveringEditable: false,
+  hasCroppingState: false,
+  cropTool: 'crop' as const,
+};
+
+describe('resolveCanvasCursor', () => {
+  it('prioritizes panning and drag states', () => {
+    expect(resolveCanvasCursor({ ...baseInput, isPanning: true })).toBe('grabbing');
+    expect(resolveCanvasCursor({ ...baseInput, dragState: { type: 'move' } })).toBe('grabbing');
+    expect(resolveCanvasCursor({ ...baseInput, dragState: { type: 'crop', cursor: 'nwse-resize' } })).toBe('nwse-resize');
+  });
+
+  it('returns crosshair in magic-wand crop mode', () => {
+    expect(resolveCanvasCursor({ ...baseInput, hasCroppingState: true, cropTool: 'magic-wand' })).toBe('crosshair');
+  });
+
+  it('handles selection sub-modes', () => {
+    expect(resolveCanvasCursor({ ...baseInput, selectionMode: 'lasso' })).toBe('crosshair');
+    expect(resolveCanvasCursor({ ...baseInput, selectionMode: 'move', isHoveringMovable: true })).toBe('grab');
+    expect(resolveCanvasCursor({ ...baseInput, selectionMode: 'edit', isHoveringEditable: true })).toBe('pointer');
+  });
+
+  it('returns crosshair for drawing tools', () => {
+    expect(resolveCanvasCursor({ ...baseInput, tool: 'brush' })).toBe('crosshair');
+    expect(resolveCanvasCursor({ ...baseInput, tool: 'arc' })).toBe('crosshair');
+  });
+});

--- a/tests/features/timeline/selectors.test.ts
+++ b/tests/features/timeline/selectors.test.ts
@@ -1,0 +1,74 @@
+/**
+ * 覆盖洋葱皮路径选择器的可观察行为：前后帧聚合、可见性过滤、组递归克隆与透明度。
+ */
+import { describe, expect, it } from 'vitest';
+import type { AnyPath } from '@/types';
+import { selectOnionSkinPaths } from '@/features/timeline/selectors';
+
+const makePath = (id: string, tool: string, extra: Record<string, unknown> = {}): AnyPath => ({
+  id,
+  tool,
+  opacity: 1,
+  isVisible: true,
+  ...extra,
+} as unknown as AnyPath);
+
+describe('selectOnionSkinPaths', () => {
+  it('returns empty when onion skin is disabled', () => {
+    const result = selectOnionSkinPaths({
+      isOnionSkinEnabled: false,
+      frames: [{ paths: [makePath('p1', 'rectangle')] }],
+      currentFrameIndex: 0,
+      onionSkinPrevFrames: 1,
+      onionSkinNextFrames: 1,
+      onionSkinOpacity: 0.5,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it('collects prev/next visible paths and applies prefixed ids', () => {
+    const frames = [
+      { paths: [makePath('prev', 'rectangle')] },
+      { paths: [makePath('current', 'rectangle')] },
+      { paths: [makePath('next', 'ellipse'), makePath('hidden', 'ellipse', { isVisible: false })] },
+    ];
+
+    const result = selectOnionSkinPaths({
+      isOnionSkinEnabled: true,
+      frames,
+      currentFrameIndex: 1,
+      onionSkinPrevFrames: 1,
+      onionSkinNextFrames: 1,
+      onionSkinOpacity: 0.6,
+    });
+
+    expect(result.map(p => p.id)).toEqual(['onion-prev-1-prev', 'onion-next-1-next']);
+    expect(result.every(p => p.isLocked === true)).toBe(true);
+  });
+
+  it('clones group children recursively and keeps opacity gradient', () => {
+    const group = makePath('group1', 'group', {
+      children: [makePath('child1', 'rectangle')],
+    });
+    const frames = [
+      { paths: [group] },
+      { paths: [makePath('current', 'rectangle')] },
+    ];
+
+    const result = selectOnionSkinPaths({
+      isOnionSkinEnabled: true,
+      frames,
+      currentFrameIndex: 1,
+      onionSkinPrevFrames: 1,
+      onionSkinNextFrames: 0,
+      onionSkinOpacity: 0.8,
+    });
+
+    const clonedGroup = result[0] as unknown as { id: string; opacity: number; children: Array<{ id: string; opacity: number }> };
+    expect(clonedGroup.id).toBe('onion-prev-1-group1');
+    expect(clonedGroup.opacity).toBeCloseTo(0.4);
+    expect(clonedGroup.children[0].id).toBe('onion-prev-1-child1');
+    expect(clonedGroup.children[0].opacity).toBeCloseTo(0.4);
+  });
+});


### PR DESCRIPTION
### Motivation
- Decouple canvas cursor resolution and onion-skin path selection from the main layout to improve separation of concerns and testability.
- Simplify `MainLayout` by removing inline cloning and cursor logic so core rendering is clearer and easier to maintain.

### Description
- Added a new cursor policy module at `src/features/canvas/cursorPolicy.ts` that exports `resolveCanvasCursor` to centralize cursor decision logic.
- Added a timeline selector at `src/features/timeline/selectors.ts` that exports `selectOnionSkinPaths` to encapsulate onion-skin path cloning and opacity calculations.
- Updated `src/components/MainLayout.tsx` to use `selectOnionSkinPaths` and `resolveCanvasCursor`, removed the inline `clonePathForOnionSkin` and cursor switch logic, and adjusted imports accordingly.
- Added unit tests for both modules: `tests/features/canvas/cursorPolicy.test.ts` and `tests/features/timeline/selectors.test.ts` covering priority rules, selection modes, drawing tools, prev/next frame aggregation, visibility filtering, group cloning, and opacity gradients.

### Testing
- Ran the unit tests with `vitest` for the new modules, including `tests/features/canvas/cursorPolicy.test.ts` and `tests/features/timeline/selectors.test.ts`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2ebb8d7148323bdd3b4b41d8ca930)