### PR TITLE
Magic-wand: add sliders, centralize mask resolution, and handle Delete during crop

### DIFF
--- a/src/components/CropToolbar.tsx
+++ b/src/components/CropToolbar.tsx
@@ -485,6 +485,16 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
                       className={`${PANEL_CLASSES.input} hide-spinners text-right`}
                     />
                   </div>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    step={1}
+                    value={cropMagicWandOptions.featherRadius}
+                    onChange={handleFeatherRadiusChange}
+                    aria-label={t('featherRadius')}
+                    className="w-24 accent-[var(--accent-primary)]"
+                  />
                 </label>
 
                 {cropSelectionMode === 'brush' && (
@@ -530,6 +540,16 @@ export const CropToolbar: React.FC<CropToolbarProps> = ({
                           className={`${PANEL_CLASSES.input} hide-spinners text-right`}
                         />
                       </div>
+                      <input
+                        type="range"
+                        min={1}
+                        max={120}
+                        step={1}
+                        value={cropMagicWandOptions.threshold}
+                        onChange={handleThresholdChange}
+                        aria-label={t('threshold')}
+                        className="w-24 accent-[var(--accent-primary)]"
+                      />
                     </label>
 
                     <PanelButton

--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -173,6 +173,26 @@ const areMasksEqual = (a: MagicWandMask | null, b: MagicWandMask | null): boolea
   return true;
 };
 
+const resolveNextSelectionMask = (
+  currentMask: MagicWandMask | null,
+  incomingMask: MagicWandMask | null,
+  operation: 'add' | 'subtract' | 'replace'
+): MagicWandMask | null => {
+  if (!incomingMask) {
+    return operation === 'replace' ? null : currentMask;
+  }
+
+  if (operation === 'replace') {
+    return incomingMask;
+  }
+
+  if (!currentMask) {
+    return operation === 'add' ? incomingMask : null;
+  }
+
+  return combineMasks(currentMask, incomingMask, operation);
+};
+
 // --- State Type Definitions ---
 
 interface UiState {
@@ -617,17 +637,9 @@ export const useAppStore = () => {
       return;
     }
 
-    let nextMask: MagicWandMask | null = null;
-    if (operation === 'replace') {
-      nextMask = result.mask;
-    } else if (!cropMagicWandMaskRef.current) {
-      if (operation === 'add') {
-        nextMask = result.mask;
-      } else {
-        return;
-      }
-    } else {
-      nextMask = combineMasks(cropMagicWandMaskRef.current, result.mask, operation);
+    const nextMask = resolveNextSelectionMask(cropMagicWandMaskRef.current, result.mask, operation);
+    if (!nextMask && operation !== 'replace') {
+      return;
     }
 
     updateMagicWandSelection(nextMask);
@@ -663,17 +675,9 @@ export const useAppStore = () => {
       return;
     }
 
-    let nextMask: MagicWandMask | null = null;
-    if (operation === 'replace') {
-      nextMask = mask;
-    } else if (!cropMagicWandMaskRef.current) {
-      if (operation === 'add') {
-        nextMask = mask;
-      } else {
-        return;
-      }
-    } else {
-      nextMask = combineMasks(cropMagicWandMaskRef.current, mask, operation);
+    const nextMask = resolveNextSelectionMask(cropMagicWandMaskRef.current, mask, operation);
+    if (!nextMask && operation !== 'replace') {
+      return;
     }
 
     updateMagicWandSelection(nextMask);
@@ -711,17 +715,9 @@ export const useAppStore = () => {
       return;
     }
 
-    let nextMask: MagicWandMask | null = null;
-    if (operation === 'replace') {
-      nextMask = mask;
-    } else if (!cropMagicWandMaskRef.current) {
-      if (operation === 'add') {
-        nextMask = mask;
-      } else {
-        return;
-      }
-    } else {
-      nextMask = combineMasks(cropMagicWandMaskRef.current, mask, operation);
+    const nextMask = resolveNextSelectionMask(cropMagicWandMaskRef.current, mask, operation);
+    if (!nextMask && operation !== 'replace') {
+      return;
     }
 
     updateMagicWandSelection(nextMask);

--- a/src/hooks/useGlobalEventHandlers.ts
+++ b/src/hooks/useGlobalEventHandlers.ts
@@ -44,6 +44,7 @@ const useGlobalEventHandlers = () => {
     groupIsolationPath, handleExitGroup, activePathState,
     croppingState, currentCropRect, setCurrentCropRect, pushCropHistory,
     cancelCrop,
+    cutMagicWandSelection, cropTool, cropSelectionContours,
     textEditing,
     commitTextEditing,
     cancelTextEditing,
@@ -371,7 +372,11 @@ const useGlobalEventHandlers = () => {
           break;
         case 'backspace':
         case 'delete':
-          handleDeleteSelected();
+          if (croppingState && cropTool === 'magic-wand' && (cropSelectionContours?.length ?? 0) > 0) {
+            cutMagicWandSelection();
+          } else {
+            handleDeleteSelected();
+          }
           break;
       }
     });
@@ -603,6 +608,7 @@ const useGlobalEventHandlers = () => {
     handleUndo,
     handleRedo,
     handleDeleteSelected,
+    cutMagicWandSelection,
     drawingShape,
     cancelDrawingShape,
     handleCut,
@@ -624,6 +630,8 @@ const useGlobalEventHandlers = () => {
     groupIsolationPath,
     handleExitGroup,
     croppingState,
+    cropTool,
+    cropSelectionContours,
     cancelCrop,
     activePaths,
     textEditing,


### PR DESCRIPTION
### Motivation
- Improve the magic-wand cropping UX by exposing continuous controls for `featherRadius` and `threshold` alongside existing numeric inputs. 
- Reduce code duplication and clarify mask merge behavior by centralizing logic for resolving the next selection mask. 
- Make keyboard `Delete` behavior context-aware so that deleting while cropping with the magic-wand cuts the current selection instead of acting on canvas selection.

### Description
- Added range sliders to `CropToolbar` for `featherRadius` and `threshold` with `aria-label` and styling (`className="w-24 accent-[var(--accent-primary)]"`).
- Introduced `resolveNextSelectionMask` in `useAppStore.ts` to encapsulate combining or replacing masks and replaced duplicated branching in `performMagicWandSelection`, `applyManualSelection`, and `applyBrushSelection` with calls to the new helper. 
- Updated `useGlobalEventHandlers.ts` to call `cutMagicWandSelection()` when `Delete` is pressed while `croppingState` is active, `cropTool === 'magic-wand'`, and there are `cropSelectionContours`, otherwise falling back to `handleDeleteSelected()`; also added the required dependencies to the hook.

### Testing
- Ran the TypeScript type check and project build (`yarn build` / `npm run build`) and the test suite (`yarn test` / `npm test`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f301dd5af48323af442b1ee0e8f78c)