### PR TITLE
feat(types): add TextElement into unified element union

### DIFF
--- a/src/lib/document.ts
+++ b/src/lib/document.ts
@@ -1,3 +1,5 @@
+import type { AnyPath, TextElement, WhiteboardData } from '@/types';
+
 /**
  * Create a stable signature representing the current whiteboard document.
  *
@@ -8,4 +10,44 @@
  */
 export const createDocumentSignature = (revision: number, backgroundColor: string, fps: number): string => {
   return `${revision}:${backgroundColor}:${fps}`;
+};
+
+const normalizeTextElement = (path: AnyPath): AnyPath => {
+  if (path.tool !== 'text') {
+    return path;
+  }
+
+  const textPath = path as TextElement;
+  return {
+    ...textPath,
+    type: 'text',
+    lineHeight: textPath.lineHeight ?? 1.2,
+    letterSpacing: textPath.letterSpacing ?? 0,
+    align: textPath.align ?? textPath.textAlign ?? 'left',
+  };
+};
+
+export const normalizeDocumentForRead = (doc: WhiteboardData): WhiteboardData => {
+  if (Array.isArray(doc.frames)) {
+    return {
+      ...doc,
+      frames: doc.frames.map((frame) => ({
+        ...frame,
+        paths: frame.paths.map((path) => normalizeTextElement(path)),
+      })),
+    };
+  }
+
+  if (Array.isArray(doc.paths)) {
+    return {
+      ...doc,
+      paths: doc.paths.map((path) => normalizeTextElement(path)),
+    };
+  }
+
+  return doc;
+};
+
+export const normalizeDocumentForWrite = (doc: WhiteboardData): WhiteboardData => {
+  return normalizeDocumentForRead(doc);
 };

--- a/src/lib/export.ts
+++ b/src/lib/export.ts
@@ -7,3 +7,4 @@
 export { renderPathNode } from './export/core/render';
 export { pathsToSvgString } from './export/svg/export';
 export { pathsToPngBlob } from './export/png/export';
+export { normalizeDocumentForRead, normalizeDocumentForWrite } from './document';

--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -4,7 +4,7 @@
  * 从而允许用户将外部 SVG 文件导入到白板中。
  */
 import paper from 'paper';
-import type { AnyPath, VectorPathData, Anchor, Point, RectangleData, EllipseData } from '../types';
+import type { AnyPath, VectorPathData, Anchor, Point, RectangleData, EllipseData, TextElement } from '../types';
 import { DEFAULT_ROUGHNESS, DEFAULT_BOWING, DEFAULT_FILL_WEIGHT, DEFAULT_HACHURE_ANGLE, DEFAULT_HACHURE_GAP, DEFAULT_CURVE_TIGHTNESS, DEFAULT_CURVE_STEP_COUNT } from '../constants';
 
 /**
@@ -139,6 +139,26 @@ export function importSvg(svgString: string): AnyPath[] {
                 width: item.bounds.width,
                 height: item.bounds.height,
             } as EllipseData;
+        } else if (item instanceof paper.PointText) {
+            const style = item.style;
+            newPath = {
+                ...getSharedSvgProps(item),
+                type: 'text',
+                tool: 'text',
+                x: item.bounds.x,
+                y: item.bounds.y,
+                width: item.bounds.width,
+                height: item.bounds.height,
+                text: item.content ?? '',
+                fontSize: Number(style.fontSize ?? 16),
+                fontFamily: String(style.fontFamily ?? 'sans-serif'),
+                fontWeight: Number(style.fontWeight ?? 400),
+                lineHeight: 1.2,
+                letterSpacing: 0,
+                align: style.justification as 'left' | 'center' | 'right' | undefined,
+                textAlign: style.justification as 'left' | 'center' | 'right' | undefined,
+                fill: paperColorToCss(style.fillColor ?? item.fillColor),
+            } as TextElement;
         } else {
             let path = item;
             let tempPath = null;

--- a/src/lib/importExcalidraw.ts
+++ b/src/lib/importExcalidraw.ts
@@ -141,7 +141,7 @@ export async function importExcalidraw(json: string): Promise<AnyPath[]> {
         align: resolvedAlign,
         textAlign: resolvedAlign,
         fill: el.strokeColor ?? '#000000',
-        color: 'transparent',
+        color: el.strokeColor ?? '#000000',
         strokeWidth: 0,
       } as TextElement);
     }

--- a/src/lib/importExcalidraw.ts
+++ b/src/lib/importExcalidraw.ts
@@ -2,7 +2,7 @@
  * Imports Excalidraw JSON and converts it into internal AnyPath objects.
  */
 
-import type { AnyPath, RectangleData, EllipseData, VectorPathData, Anchor, ImageData } from '@/types';
+import type { AnyPath, RectangleData, EllipseData, VectorPathData, Anchor, ImageData, TextElement } from '@/types';
 import {
   DEFAULT_ROUGHNESS,
   DEFAULT_BOWING,
@@ -122,6 +122,28 @@ export async function importExcalidraw(json: string): Promise<AnyPath[]> {
           strokeWidth: 0,
         } as ImageData);
       }
+    } else if (el.type === 'text') {
+      const resolvedAlign = el.textAlign ?? 'left';
+      paths.push({
+        ...sharedProps(el),
+        type: 'text',
+        tool: 'text',
+        x: el.x,
+        y: el.y,
+        width: el.width,
+        height: el.height,
+        text: el.text ?? '',
+        fontSize: el.fontSize ?? 20,
+        fontFamily: typeof el.fontFamily === 'string' ? el.fontFamily : 'Virgil, sans-serif',
+        fontWeight: 400,
+        lineHeight: 1.2,
+        letterSpacing: 0,
+        align: resolvedAlign,
+        textAlign: resolvedAlign,
+        fill: el.strokeColor ?? '#000000',
+        color: 'transparent',
+        strokeWidth: 0,
+      } as TextElement);
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -240,7 +240,8 @@ export interface EllipseData extends ShapeBase {
   skewY?: number;
 }
 
-export interface TextData extends ShapeBase {
+export interface TextElement extends ShapeBase {
+  type: 'text';
   tool: 'text';
   x: number;
   y: number;
@@ -251,8 +252,14 @@ export interface TextData extends ShapeBase {
   fontSize: number;
   fontWeight?: number;
   lineHeight: number;
-  textAlign: 'left' | 'center' | 'right';
+  letterSpacing: number;
+  textAlign?: 'left' | 'center' | 'right';
+  align?: 'left' | 'center' | 'right';
+  verticalAlign?: 'top' | 'middle' | 'bottom';
+  background?: string;
 }
+
+export type TextData = TextElement;
 
 export interface BinaryFileMetadata {
   id: string;
@@ -294,7 +301,7 @@ export interface GroupData extends ShapeBase {
 }
 
 // 任何已存储并已转换为锚点的路径的通用类型。
-export type AnyPath = VectorPathData | RectangleData | EllipseData | ImageData | BrushPathData | PolygonData | ArcData | GroupData | FrameData | TextData;
+export type AnyPath = VectorPathData | RectangleData | EllipseData | ImageData | BrushPathData | PolygonData | ArcData | GroupData | FrameData | TextElement;
 
 export interface Frame {
   id: string;


### PR DESCRIPTION
### Motivation
- Introduce a first-class text element that participates in the same path/frame pipelines as other shapes to avoid parallel state and enable consistent selectors/reducers/exports. 
- Ensure imported documents and external formats map into the unified model and that saved documents are normalized for backward compatibility.

### Description
- Add `TextElement` to `src/types.ts` with `type: 'text'`, geometry (`x`, `y`, `width`, `height`, `rotation` via `ShapeBase`), text/layout fields (`text`, `fontSize`, `fontFamily`, `fontWeight`, `lineHeight`, `letterSpacing`), styling (`fill`, `opacity`), and optional `align`, `verticalAlign`, and `background`, and include it in the `AnyPath` union. 
- Keep `TextData` as a type alias to preserve compatibility with existing call sites. 
- Update SVG import (`src/lib/import.ts`) to convert `paper.PointText` into unified `TextElement` objects. 
- Update Excalidraw importer (`src/lib/importExcalidraw.ts`) to emit `TextElement` for `el.type === 'text'`. 
- Add document normalization helpers in `src/lib/document.ts` (`normalizeDocumentForRead` / `normalizeDocumentForWrite`) to fill missing text defaults (`type`, `lineHeight`, `letterSpacing`, `align`) when reading/writing documents. 
- Re-export the document normalizers from `src/lib/export.ts` for use in export/import flows.

### Testing
- Ran the production build with `npm run build`, which completed successfully (Vite build passed and dist artifacts were produced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30eb645108323888e2a08ecd494f9)