### PR TITLE
feat(text): add text tool editing lifecycle and canvas overlay handling

### DIFF
--- a/src/components/layout/CanvasOverlays.tsx
+++ b/src/components/layout/CanvasOverlays.tsx
@@ -2,7 +2,7 @@
  * 本文件定义了画布的覆盖层组件。
  * 它包含了所有绝对定位在画布上方的UI元素，如工具栏、菜单和对话框。
  */
-import React, { useMemo, useCallback, useEffect, useRef } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '@/context/AppContext';
 import PanelButton from '@/components/PanelButton';
@@ -18,13 +18,7 @@ import { CropToolbar } from '../CropToolbar';
 import type { AnyPath, MaterialData, TextData } from '@/types';
 import { ICONS } from '@/constants';
 import { getPathsBoundingBox, getPathBoundingBox } from '@/lib/drawing';
-import { layoutText, resolveLineHeight } from '@/lib/text';
-import {
-    createTranslationMatrix,
-    getShapeTransformMatrix,
-    matrixToCssString,
-    multiplyMatrices,
-} from '@/lib/drawing/transform/matrix';
+import { useTextEditing } from '@/hooks/useTextEditing';
 
 // Helper to define context menu actions
 const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform);
@@ -156,6 +150,7 @@ export const CanvasOverlays: React.FC = () => {
                 viewTransform={camera}
                 onChange={updateTextEditing}
                 onCommit={commitTextEditing}
+                onCancel={cancelTextEditing}
                 onCanvasWheel={handleCanvasWheel}
             />
         );
@@ -321,6 +316,7 @@ interface TextEditorOverlayProps {
     viewTransform: { scale: number; translateX: number; translateY: number };
     onChange: (value: string) => void;
     onCommit: () => void;
+    onCancel: () => void;
     onCanvasWheel: (event: WheelEvent) => void;
 }
 
@@ -331,238 +327,38 @@ const TextEditingOverlay: React.FC<TextEditorOverlayProps> = ({
     viewTransform,
     onChange,
     onCommit,
+    onCancel,
     onCanvasWheel,
 }) => {
-    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-    const normalizedDraft = draft.replace(/\r/g, '');
-    const baseLineHeight = useMemo(
-        () => resolveLineHeight(path.fontSize, path.lineHeight),
-        [path.fontSize, path.lineHeight],
-    );
-    const widthConstraint = useMemo(
-        () => (!isNew && path.width > 0 ? path.width : undefined),
-        [isNew, path.width],
-    );
-    const layout = useMemo(
-        () => layoutText(
-            normalizedDraft,
-            path.fontSize,
-            path.fontFamily,
-            baseLineHeight,
-            path.fontWeight,
-            widthConstraint,
-        ),
-        [normalizedDraft, path.fontSize, path.fontFamily, baseLineHeight, path.fontWeight, widthConstraint],
-    );
-
-    useEffect(() => {
-        const element = textareaRef.current;
-        if (!element) {
-            return;
-        }
-        const rafId = requestAnimationFrame(() => {
-            element.focus();
-            element.select();
-        });
-        return () => cancelAnimationFrame(rafId);
-    }, [path.id]);
-
-    useEffect(() => {
-        const handleKey = (event: KeyboardEvent) => {
-            if (event.key === 'Escape') {
-                event.preventDefault();
-                onCommit();
-                return;
-            }
-
-            const isCommitKey = (event.key === 'Enter' || event.key === 's') && (event.metaKey || event.ctrlKey);
-            if (!isCommitKey) {
-                return;
-            }
-
-            const target = event.target as HTMLElement | null;
-            if (target && target.tagName === 'TEXTAREA') {
-                return;
-            }
-
-            event.preventDefault();
-            onCommit();
-        };
-
-        window.addEventListener('keydown', handleKey);
-        return () => window.removeEventListener('keydown', handleKey);
-    }, [onCommit]);
-
-    const draftWidth = !isNew && path.width > 0 ? path.width : layout.width;
-    const width = Math.max(draftWidth, layout.width, 1);
-    const height = Math.max(path.height, layout.height, 1);
-    const leadingTop = layout.leading.top;
-    const leadingBottom = layout.leading.bottom;
-    const glyphHeight = layout.metrics.height;
-    const cssHalfLeading = Math.max(layout.lineHeight - glyphHeight, 0) / 2;
-    const paddingTop = Math.max(leadingTop - cssHalfLeading, 0);
-    const paddingBottom = Math.max(leadingBottom - cssHalfLeading, 0);
-
-    const textareaInlineStyle = useMemo<React.CSSProperties>(() => {
-        const style: React.CSSProperties = {
-            boxSizing: 'border-box',
-            color: path.color,
-            fontSize: `${path.fontSize}px`,
-            lineHeight: `${layout.lineHeight}px`,
-            fontFamily: path.fontFamily,
-            fontWeight: path.fontWeight ?? 400,
-            textAlign: path.textAlign as React.CSSProperties['textAlign'],
-            caretColor: path.color,
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-word',
-        };
-
-        const formatPx = (value: number) => `${Math.round(value * 1000) / 1000}px`;
-
-        if (paddingTop > 0.0001) {
-            style.paddingTop = formatPx(paddingTop);
-        }
-
-        if (paddingBottom > 0.0001) {
-            style.paddingBottom = formatPx(paddingBottom);
-        }
-
-        return style;
-    }, [
-        path.color,
-        path.fontFamily,
-        path.fontSize,
-        path.fontWeight,
-        path.textAlign,
-        layout.lineHeight,
-        paddingTop,
-        paddingBottom,
-    ]);
-
-    const transform = useMemo(() => {
-        const viewMatrix = {
-            a: viewTransform.scale,
-            b: 0,
-            c: 0,
-            d: viewTransform.scale,
-            e: viewTransform.translateX,
-            f: viewTransform.translateY,
-        };
-        const translation = createTranslationMatrix(path.x, path.y);
-        const shapeMatrix = getShapeTransformMatrix({ ...path, x: 0, y: 0 });
-        const localMatrix = multiplyMatrices(translation, shapeMatrix);
-        const combined = multiplyMatrices(viewMatrix, localMatrix);
-        return matrixToCssString(combined);
-    }, [
-        viewTransform.scale,
-        viewTransform.translateX,
-        viewTransform.translateY,
-        path.x,
-        path.y,
-        path.width,
-        path.height,
-        path.rotation,
-        path.scaleX,
-        path.scaleY,
-        path.skewX,
-        path.skewY,
-    ]);
-
-    const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        onChange(event.target.value);
-    };
-
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if ((event.key === 'Enter' || event.key === 's') && (event.metaKey || event.ctrlKey)) {
-            event.preventDefault();
-            onCommit();
-            return;
-        }
-        if (event.key === 'Escape') {
-            event.preventDefault();
-            onCommit();
-        }
-    };
+    const { textareaRef, style, onKeyDown, onWheel, onBlur } = useTextEditing({
+        path,
+        draft,
+        isNew,
+        viewTransform,
+        onChange,
+        onCommit,
+        onCancel,
+        onCanvasWheel,
+    });
 
     const handlePointerDown = (event: React.PointerEvent<HTMLTextAreaElement>) => {
         event.stopPropagation();
     };
 
-    const handleWheel = useCallback((event: React.WheelEvent<HTMLTextAreaElement>) => {
-        const isZoomGesture = event.ctrlKey || event.metaKey;
-        if (!isZoomGesture) {
-            event.stopPropagation();
-            return;
-        }
-
-        event.preventDefault();
-        event.stopPropagation();
-
-        const canvasSvg = document.querySelector<SVGSVGElement>('[data-whiteboard-canvas="true"]');
-        const canvasContainer = canvasSvg?.parentElement as HTMLDivElement | null;
-
-        if (!canvasContainer) {
-            return;
-        }
-
-        const {
-            deltaX,
-            deltaY,
-            deltaMode,
-            clientX,
-            clientY,
-            metaKey,
-            shiftKey,
-            altKey,
-        } = event.nativeEvent;
-
-        const forwardedEvent = {
-            deltaX,
-            deltaY,
-            deltaMode,
-            clientX,
-            clientY,
-            ctrlKey: event.ctrlKey || event.metaKey,
-            metaKey,
-            shiftKey,
-            altKey,
-            type: event.nativeEvent.type,
-            currentTarget: canvasContainer,
-            target: canvasSvg ?? canvasContainer,
-            preventDefault: () => event.preventDefault(),
-            stopPropagation: () => event.stopPropagation(),
-        } as unknown as WheelEvent;
-
-        onCanvasWheel(forwardedEvent);
-    }, [onCanvasWheel]);
-
     return (
         <div className="absolute inset-0 z-40 pointer-events-none">
-            <div
-                className="pointer-events-auto"
-                style={{
-                    position: 'absolute',
-                    left: 0,
-                    top: 0,
-                    width,
-                    height,
-                    transformOrigin: 'top left',
-                    transformBox: 'border-box',
-                    transform,
-                }}
-            >
-                <textarea
-                    ref={textareaRef}
-                    value={draft}
-                    onChange={handleChange}
-                    onKeyDown={handleKeyDown}
-                    onPointerDown={handlePointerDown}
-                    onWheel={handleWheel}
-                    spellCheck={false}
-                    className="h-full w-full resize-none overflow-hidden border-none bg-transparent p-0 focus:outline-none"
-                    style={textareaInlineStyle}
-                />
-            </div>
+            <textarea
+                ref={textareaRef}
+                value={draft}
+                onChange={(event) => onChange(event.target.value)}
+                onKeyDown={onKeyDown}
+                onPointerDown={handlePointerDown}
+                onWheel={onWheel}
+                onBlur={onBlur}
+                spellCheck={false}
+                className="pointer-events-auto resize-none overflow-hidden border-none bg-transparent p-0 focus:outline-none"
+                style={style}
+            />
         </div>
     );
 };

--- a/src/hooks/useDrawing.ts
+++ b/src/hooks/useDrawing.ts
@@ -246,7 +246,7 @@ export const useDrawing = ({
           ? viewTransform.viewTransform.scale
           : 1;
         const hitPath = findDeepestHitPath(point, paths, scale);
-        if (hitPath && hitPath.tool === 'text' && !hitPath.isLocked) {
+        if (e.detail >= 2 && hitPath && hitPath.tool === 'text' && !hitPath.isLocked) {
           if (e.currentTarget.hasPointerCapture(e.pointerId)) {
             e.currentTarget.releasePointerCapture(e.pointerId);
           }

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -1,0 +1,108 @@
+import { useMemo, useEffect, useRef, useCallback } from 'react';
+import type React from 'react';
+import type { TextData } from '@/types';
+import { layoutText, resolveLineHeight } from '@/lib/text';
+import {
+  createTranslationMatrix,
+  getShapeTransformMatrix,
+  matrixToCssString,
+  multiplyMatrices,
+} from '@/lib/drawing/transform/matrix';
+
+interface UseTextEditingOptions {
+  path: TextData;
+  draft: string;
+  isNew: boolean;
+  viewTransform: { scale: number; translateX: number; translateY: number };
+  onChange: (value: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+  onCanvasWheel: (event: WheelEvent) => void;
+}
+
+export function useTextEditing({
+  path,
+  draft,
+  isNew,
+  viewTransform,
+  onChange,
+  onCommit,
+  onCancel,
+  onCanvasWheel,
+}: UseTextEditingOptions) {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const normalizedDraft = draft.replace(/\r/g, '');
+  const baseLineHeight = useMemo(() => resolveLineHeight(path.fontSize, path.lineHeight), [path.fontSize, path.lineHeight]);
+  const widthConstraint = useMemo(() => (!isNew && path.width > 0 ? path.width : undefined), [isNew, path.width]);
+
+  const layout = useMemo(() => layoutText(normalizedDraft, path.fontSize, path.fontFamily, baseLineHeight, path.fontWeight, widthConstraint), [normalizedDraft, path.fontSize, path.fontFamily, baseLineHeight, path.fontWeight, widthConstraint]);
+
+  useEffect(() => {
+    const element = textareaRef.current;
+    if (!element) return;
+    const rafId = requestAnimationFrame(() => {
+      element.focus();
+      element.select();
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [path.id]);
+
+  const width = Math.max(!isNew && path.width > 0 ? path.width : layout.width, layout.width, 1);
+  const height = Math.max(path.height, layout.height, 1);
+
+  const transform = useMemo(() => {
+    const viewMatrix = { a: viewTransform.scale, b: 0, c: 0, d: viewTransform.scale, e: viewTransform.translateX, f: viewTransform.translateY };
+    const translation = createTranslationMatrix(path.x, path.y);
+    const shapeMatrix = getShapeTransformMatrix({ ...path, x: 0, y: 0 });
+    const localMatrix = multiplyMatrices(translation, shapeMatrix);
+    return matrixToCssString(multiplyMatrices(viewMatrix, localMatrix));
+  }, [viewTransform.scale, viewTransform.translateX, viewTransform.translateY, path]);
+
+  const onKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      onCommit();
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onCancel();
+    }
+  }, [onCommit, onCancel]);
+
+  const onWheel = useCallback((event: React.WheelEvent<HTMLTextAreaElement>) => {
+    if (!(event.ctrlKey || event.metaKey)) {
+      event.stopPropagation();
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const canvasSvg = document.querySelector<SVGSVGElement>('[data-whiteboard-canvas="true"]');
+    const canvasContainer = canvasSvg?.parentElement as HTMLDivElement | null;
+    if (!canvasContainer) return;
+    onCanvasWheel({ ...event.nativeEvent, ctrlKey: event.ctrlKey || event.metaKey, currentTarget: canvasContainer, target: canvasSvg ?? canvasContainer } as unknown as WheelEvent);
+  }, [onCanvasWheel]);
+
+  const style = useMemo<React.CSSProperties>(() => ({
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width,
+    height,
+    transformOrigin: 'top left',
+    transformBox: 'border-box',
+    transform,
+    boxSizing: 'border-box',
+    color: path.color,
+    fontSize: `${path.fontSize}px`,
+    lineHeight: `${layout.lineHeight}px`,
+    fontFamily: path.fontFamily,
+    fontWeight: path.fontWeight ?? 400,
+    textAlign: path.textAlign as React.CSSProperties['textAlign'],
+    caretColor: path.color,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  }), [width, height, transform, path.color, path.fontSize, path.fontFamily, path.fontWeight, path.textAlign, layout.lineHeight]);
+
+  return { textareaRef, style, onKeyDown, onWheel, onBlur: onCommit, onChange };
+}


### PR DESCRIPTION
### Motivation
- Provide a proper in-canvas text editing experience with an overlay input that follows canvas transforms and lifecycle rules.
- Ensure the text tool interaction matches expected flow: single-click to create and enter edit, Enter/Esc/blur semantics, and double-click to edit existing text.
- Keep pointer/drawing logic isolated so text editing does not interfere with brush/selection interactions.

### Description
- Add `src/hooks/useTextEditing.ts` to centralize overlay positioning, focus lifecycle, keyboard handling (`Enter` commit, `Esc` cancel), blur-to-commit, and wheel forwarding while editing.
- Replace the large inline text overlay logic in `src/components/layout/CanvasOverlays.tsx` with the new `useTextEditing` hook and wire explicit `onCancel` handling into the overlay.
- Update `src/hooks/useDrawing.ts` text pointer handling so a single click always creates a new temporary text element and a double-click on an existing text element enters edit mode.
- Keep text layout/measurement and commit/cancel semantics in the existing app store code, reusing them from the overlay lifecycle.

### Testing
- Ran `npm run build`, which completed successfully and produced the production bundle without errors.
- Verified the project builds cleanly after the changes (Vite build output completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f31ab565c483239811b811ad517080)