### PR TITLE
fix(text): keep font size stable while resizing text bounds

### DIFF
--- a/src/lib/drawing/transform/resize.ts
+++ b/src/lib/drawing/transform/resize.ts
@@ -2,6 +2,7 @@ import type { Point, RectangleData, EllipseData, ImageData, PolygonData, FrameDa
 import { rotatePoint } from '../geom';
 import { scalePath } from './scale';
 import { movePath } from './move';
+import { layoutText, resolveLineHeight } from '@/lib/text';
 
 /**
  * 调整图形的大小。
@@ -122,6 +123,45 @@ export function resizePath(
 
   const scaleX = appliesToX ? rawScaleX : 1;
   const scaleY = appliesToY ? rawScaleY : 1;
+
+  if (originalPath.tool === 'text') {
+    const nextLeft = affectsX ? Math.min(anchor.x, localCurrentPos.x) : oldX;
+    const nextRight = affectsX ? Math.max(anchor.x, localCurrentPos.x) : oldX + oldWidth;
+    const nextTop = affectsY ? Math.min(anchor.y, localCurrentPos.y) : oldY;
+    const nextBottom = affectsY ? Math.max(anchor.y, localCurrentPos.y) : oldY + oldHeight;
+    const baseLineHeight = resolveLineHeight(originalPath.fontSize, originalPath.lineHeight);
+    const nextWidth = Math.max(nextRight - nextLeft, 1);
+    const layout = layoutText(
+      originalPath.text,
+      originalPath.fontSize,
+      originalPath.fontFamily,
+      baseLineHeight,
+      originalPath.fontWeight,
+      nextWidth,
+    );
+
+    let textResult: TextData = {
+      ...originalPath,
+      x: nextLeft,
+      y: nextTop,
+      width: layout.width,
+      height: affectsY ? Math.max(nextBottom - nextTop, 1) : layout.height,
+      lineHeight: layout.lineHeight,
+    };
+
+    if (rotation) {
+      const newCenter = { x: textResult.x + textResult.width / 2, y: textResult.y + textResult.height / 2 };
+      const rotationPivot = rotationCenter ?? newCenter;
+      const anchorGlobalNew = rotatePoint(anchor, rotationPivot, rotation);
+      const translation = {
+        x: anchorGlobal.x - anchorGlobalNew.x,
+        y: anchorGlobal.y - anchorGlobalNew.y,
+      };
+      textResult = movePath(textResult, translation.x, translation.y);
+    }
+
+    return textResult;
+  }
 
   let result = scalePath(originalPath, anchor, scaleX, scaleY);
 


### PR DESCRIPTION
### Motivation
- Resizing a text element should reflow its content inside a new bounding box instead of geometrically scaling the glyphs, so the visible `fontSize` remains constant when the user drags resize handles.

### Description
- Special-case text elements in `src/lib/drawing/transform/resize.ts` to avoid calling the generic geometric `scalePath` for `text` shapes. 
- Import `layoutText` and `resolveLineHeight` and recompute text layout for the new width while preserving `fontSize`, `fontFamily`, and `fontWeight`, and update `width`, `height`, `x`, `y`, and `lineHeight` accordingly. 
- Preserve existing rotation compensation by applying the same anchor translation logic and `movePath` after layout when the text is rotated. 
- All non-text shapes continue to use the existing `scalePath` flow unchanged.

### Testing
- Ran `npm run build` (Vite production build) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9ebc31d48323a4868639e2c9bb8a)