### PR TITLE
Cache and reuse text layout during editing; adjust textarea height handling

### DIFF
--- a/src/hooks/useAppStore.ts
+++ b/src/hooks/useAppStore.ts
@@ -228,6 +228,7 @@ interface TextEditingState {
   draft: string;
   isNew: boolean;
   original: TextEditingSnapshot | null;
+  latestLayout: Pick<TextEditingSnapshot, 'width' | 'height' | 'lineHeight'> | null;
 }
 
 interface AppState {
@@ -1460,7 +1461,15 @@ export const useAppStore = () => {
 
     setAppState(prev => ({
       ...prev,
-      textEditing: { pathId, draft, isNew: options?.isNew ?? false, original },
+      textEditing: {
+        pathId,
+        draft,
+        isNew: options?.isNew ?? false,
+        original,
+        latestLayout: original
+          ? { width: original.width, height: original.height, lineHeight: original.lineHeight }
+          : null,
+      },
     }));
   }, [paths, setAppState]);
 
@@ -1578,18 +1587,38 @@ export const useAppStore = () => {
   const textEditing = appState.textEditing;
 
   const updateTextEditing = useCallback((draft: string) => {
-    setAppState(prev => {
-      if (!prev.textEditing || prev.textEditing.draft === draft) {
-        return prev;
-      }
-      return { ...prev, textEditing: { ...prev.textEditing, draft } };
-    });
-
     if (!textEditing) {
       return;
     }
 
+    const textPath = paths.find((path): path is TextData => path.id === textEditing.pathId && path.tool === 'text');
     const normalized = draft.replace(/\r/g, '');
+    const layout = textPath
+      ? layoutText(
+        normalized,
+        textPath.fontSize,
+        textPath.fontFamily,
+        resolveLineHeight(textPath.fontSize, textPath.lineHeight),
+        textPath.fontWeight,
+        textEditing.isNew ? undefined : Math.max(textPath.width, 0),
+      )
+      : null;
+
+    setAppState(prev => {
+      if (!prev.textEditing || (prev.textEditing.draft === draft && layout === null)) {
+        return prev;
+      }
+      return {
+        ...prev,
+        textEditing: {
+          ...prev.textEditing,
+          draft,
+          latestLayout: layout
+            ? { width: layout.width, height: layout.height, lineHeight: layout.lineHeight }
+            : prev.textEditing.latestLayout,
+        },
+      };
+    });
 
     setPaths(currentPaths => {
       const index = currentPaths.findIndex(path => path.id === textEditing.pathId);
@@ -1603,20 +1632,22 @@ export const useAppStore = () => {
       }
 
       const textPath = target as TextData;
-      const baseLineHeight = resolveLineHeight(textPath.fontSize, textPath.lineHeight);
-      const widthConstraint = textEditing.isNew ? undefined : Math.max(textPath.width, 0);
-      const layout = layoutText(
-        normalized,
-        textPath.fontSize,
-        textPath.fontFamily,
-        baseLineHeight,
-        textPath.fontWeight,
-        widthConstraint,
-      );
+      const computedLayout = layout ?? (() => {
+        const baseLineHeight = resolveLineHeight(textPath.fontSize, textPath.lineHeight);
+        const widthConstraint = textEditing.isNew ? undefined : Math.max(textPath.width, 0);
+        return layoutText(
+          normalized,
+          textPath.fontSize,
+          textPath.fontFamily,
+          baseLineHeight,
+          textPath.fontWeight,
+          widthConstraint,
+        );
+      })();
 
-      const nextWidth = textEditing.isNew ? layout.width : textPath.width;
-      const nextHeight = layout.height;
-      const nextLineHeight = layout.lineHeight;
+      const nextWidth = textEditing.isNew ? computedLayout.width : textPath.width;
+      const nextHeight = computedLayout.height;
+      const nextLineHeight = computedLayout.lineHeight;
 
       if (
         textPath.width === nextWidth &&
@@ -1637,7 +1668,7 @@ export const useAppStore = () => {
       nextPaths[index] = updated;
       return nextPaths;
     });
-  }, [setAppState, textEditing, setPaths]);
+  }, [setAppState, textEditing, setPaths, paths]);
 
   const commitTextEditing = useCallback(() => {
     if (!textEditing) {
@@ -1665,16 +1696,18 @@ export const useAppStore = () => {
         return currentPaths.filter(path => path.id !== pathId);
       }
 
-      const baseLineHeight = resolveLineHeight(textPath.fontSize, textPath.lineHeight);
-      const widthConstraint = isNew ? undefined : Math.max(textPath.width, 0);
-      const layout = layoutText(
-        normalized,
-        textPath.fontSize,
-        textPath.fontFamily,
-        baseLineHeight,
-        textPath.fontWeight,
-        widthConstraint,
-      );
+      const layout = textEditing.latestLayout ?? (() => {
+        const baseLineHeight = resolveLineHeight(textPath.fontSize, textPath.lineHeight);
+        const widthConstraint = isNew ? undefined : Math.max(textPath.width, 0);
+        return layoutText(
+          normalized,
+          textPath.fontSize,
+          textPath.fontFamily,
+          baseLineHeight,
+          textPath.fontWeight,
+          widthConstraint,
+        );
+      })();
       const updated: TextData = {
         ...textPath,
         text: normalized,

--- a/src/hooks/useTextEditing.ts
+++ b/src/hooks/useTextEditing.ts
@@ -48,7 +48,7 @@ export function useTextEditing({
   }, [path.id]);
 
   const width = Math.max(!isNew && path.width > 0 ? path.width : layout.width, layout.width, 1);
-  const height = Math.max(path.height, layout.height, 1);
+  const height = Math.max(layout.height, 1);
 
   const transform = useMemo(() => {
     const viewMatrix = { a: viewTransform.scale, b: 0, c: 0, d: viewTransform.scale, e: viewTransform.translateX, f: viewTransform.translateY };


### PR DESCRIPTION
### Motivation

- Reduce redundant text layout calculations while editing and prevent layout flicker when typing.  
- Ensure final committed text uses the same layout that was used while editing to avoid visual jumps.

### Description

- Add `latestLayout` to `TextEditingState` and initialize it in `beginTextEditing` from the current path snapshot.  
- Update `updateTextEditing` to compute a `layout` for the current draft, store it in `latestLayout`, and reuse it when updating the in-memory `paths`.  
- Change `commitTextEditing` to prefer `textEditing.latestLayout` when applying the final layout to the `TextData` path.  
- Adjust `useTextEditing` textarea sizing to compute `height` from the live `layout` only (`Math.max(layout.height, 1)`) to avoid unexpected shrinkage based on `path.height`.  
- Fix hook dependencies by including `paths` where necessary to ensure layouts are computed from the current path state.

### Testing

- Ran unit test suite with `yarn test`, and all tests passed.  
- Ran linter with `yarn lint`, and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faaaadf0dc83239f71c9be396c5742)