### PR TITLE
fix(crop): persist HSV adjustments as savable change

### DIFF
--- a/src/hooks/actions/useObjectActions.ts
+++ b/src/hooks/actions/useObjectActions.ts
@@ -377,12 +377,14 @@ export const useObjectActions = ({
   }, [paths, selectedPathIds]);
 
   const applyCommittedImageFile = useCallback((pathId: string, fileId: string) => {
+    pathState.beginCoalescing();
     pathState.setPaths(prev => prev.map(p => {
       if (p.id !== pathId || p.tool !== 'image') {
         return p;
       }
       return { ...p, fileId, src: undefined };
     }));
+    pathState.endCoalescing();
 
     setCroppingState(prev => {
       if (!prev || prev.pathId !== pathId) {


### PR DESCRIPTION
### Motivation
- HSV adjustments applied in crop/adjust mode were not being recorded as a proper document change, causing color edits to not be picked up by the save/dirty tracking and preventing users from saving.

### Description
- Wrap the image file update in `applyCommittedImageFile` with `pathState.beginCoalescing()` / `pathState.endCoalescing()` so the `setPaths` change is recorded as a coalesced history entry and becomes a savable document change (`src/hooks/actions/useObjectActions.ts`).

### Testing
- Ran `npm run build` and the project built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc35d0fde48323bab079940ece5a6e)